### PR TITLE
Fix documentation of --utf-force in README and --help.

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ log_level = "DEBUG"
 #### Command line options
 
 ```text
-usage: btop [-h] [-v] [-/+t] [--utf-foce] [--debug]
+usage: btop [-h] [-v] [-/+t] [--utf-force] [--debug]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -485,7 +485,7 @@ optional arguments:
   -t, --tty_on          force (ON) tty mode, max 16 colors and tty friendly graph symbols
   +t, --tty_off         force (OFF) tty mode
   -p --preset <id>      start with preset, integer value between 0-9
-  --utf-foce            force start even if no UTF-8 locale was detected
+  --utf-force           force start even if no UTF-8 locale was detected
   --debug               start in DEBUG mode: shows microsecond timer for information collect
                         and screen draw functions and sets loglevel to DEBUG
 ```

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -92,7 +92,7 @@ void argumentParser(const int& argc, char **argv) {
 	for(int i = 1; i < argc; i++) {
 		const string argument = argv[i];
 		if (is_in(argument, "-h", "--help")) {
-			cout 	<< "usage: btop [-h] [-v] [-/+t] [--utf-foce] [--debug]\n\n"
+			cout 	<< "usage: btop [-h] [-v] [-/+t] [--utf-force] [--debug]\n\n"
 					<< "optional arguments:\n"
 					<< "  -h, --help            show this help message and exit\n"
 					<< "  -v, --version         show version info and exit\n"
@@ -100,7 +100,7 @@ void argumentParser(const int& argc, char **argv) {
 					<< "  -t, --tty_on          force (ON) tty mode, max 16 colors and tty friendly graph symbols\n"
 					<< "  +t, --tty_off         force (OFF) tty mode\n"
 					<< "  -p --preset <id>      start with preset, integer value between 0-9\n"
-					<< "  --utf-foce            force start even if no UTF-8 locale was detected\n"
+					<< "  --utf-force           force start even if no UTF-8 locale was detected\n"
 					<< "  --debug               start in DEBUG mode: shows microsecond timer for information collect\n"
 					<< "                        and screen draw functions and sets loglevel to DEBUG\n"
 					<< endl;


### PR DESCRIPTION
This seems like a simple enough issue that I figured I could submit a patch instead of just reporting it.

Just in case I did run `make` and verify that the new binary runs properly and outputs correct `--help` output as well (great job on making it single Makefile without needing CMake or anything else btw).

Fixes #1.