### PR TITLE
Ignore hidden directories like .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 build
 bin
 btop
+.*/


### PR DESCRIPTION
Set git to ignore linux hidden directories (.vscode, .config, ...) while still allowing hidden files (.gitignore, ...) to be tracked. 