### PR TITLE
Removed build-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,13 +52,6 @@ parts:
     make-parameters:
       - PREFIX=/usr/local
       - STATIC=true
-#    build-packages:
-#      - coreutils 
-#      - sed 
-#      - git 
-#      - build-essential 
-#      - gcc-11 
-#      - g++-11
     
     stage-packages:
       - coreutils 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,7 +53,7 @@ parts:
       - PREFIX=/usr/local
       - STATIC=true
     
-    stage-packages:
+    build-packages:
       - coreutils 
       - sed 
       - git 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,6 +51,7 @@ parts:
     plugin: make
     make-parameters:
       - PREFIX=/usr/local
+      - STATIC=true
     build-packages:
       - coreutils 
       - sed 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,13 +52,13 @@ parts:
     make-parameters:
       - PREFIX=/usr/local
       - STATIC=true
-    build-packages:
-      - coreutils 
-      - sed 
-      - git 
-      - build-essential 
-      - gcc-11 
-      - g++-11
+#    build-packages:
+#      - coreutils 
+#      - sed 
+#      - git 
+#      - build-essential 
+#      - gcc-11 
+#      - g++-11
     
     stage-packages:
       - coreutils 


### PR DESCRIPTION
Removed `build-packages` to shrink snap size. See: https://github.com/aristocratos/btop/issues/36 