### PR TITLE
add opensuse repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,22 @@ Also needs a UTF8 locale and a font that covers:
    make help
    ```
 
+**Binary release (from native os repo)**
+
+* **openSUSE**
+  * **Add repo**
+  ```bash
+  sudo zypper ar --refresh obs://home:Werwolf2517 home:Werwolf2517 
+  ```
+  * **Refresh metadata**
+  ```bash
+  sudo zypper ref
+  ```
+  * **Install package**
+  ```bash
+  sudo zypper in btop
+  ```
+
 ## Compilation
 
    Needs GCC 10 or higher, (GCC 11 or above strongly recommended for better CPU efficiency in the compiled binary).


### PR DESCRIPTION
despite the emergence of a variety of self-sufficient packages, the best way to supply software is still the native repositories for the system.
I took the liberty of taking responsibility for maintaining the opensuse package myself.

postscript: sorry for my english