### PR TITLE
static musl builds

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
 [*.{cpp,h,sh,md,cfg,sample}]
 indent_style = tab
 indent_size = 4
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -1,9 +1,11 @@
 name: Continuous Build Linux
-
+  
 on:
+  workflow_dispatch:
   push:
     branches:
-      - main
+      - master
+      - musl-build
     tags-ignore:
       - '*.*'
     paths:
@@ -12,111 +14,101 @@ on:
       - '!src/freebsd/**'
       - 'include/**'
       - 'Makefile'
+      - '.github/workflows/continuous-build.yml'
 
 jobs:
-  build:
+  static-build:
+    continue-on-error: true
+    strategy:
+      matrix:
+        toolchain:
+          - aarch64-linux-musl
+          - aarch64_be-linux-musl
+          - arm-linux-musleabi
+          - arm-linux-musleabihf
+          - armeb-linux-musleabi
+          - armeb-linux-musleabihf
+          - armel-linux-musleabi
+          - armel-linux-musleabihf
+          - armv5l-linux-musleabi
+          - armv5l-linux-musleabihf
+          - armv6-linux-musleabi
+          - armv6-linux-musleabihf
+          - armv7l-linux-musleabihf
+          - armv7m-linux-musleabi
+          - armv7r-linux-musleabihf
+          - i486-linux-musl
+          - i686-linux-musl
+          - m68k-linux-musl
+          - microblaze-linux-musl
+          - microblazeel-linux-musl
+          - mips-linux-musl
+          - mips-linux-musln32sf
+          - mips-linux-muslsf
+          - mips64-linux-musl
+          - mips64-linux-musln32
+          - mips64-linux-musln32sf
+          - mips64el-linux-musl
+          - mips64el-linux-musln32
+          - mips64el-linux-musln32sf
+          - mipsel-linux-musl
+          - mipsel-linux-musln32
+          - mipsel-linux-musln32sf
+          - mipsel-linux-muslsf
+          - or1k-linux-musl
+          - powerpc-linux-musl
+          - powerpc-linux-muslsf
+          - powerpc64-linux-musl
+          - powerpc64le-linux-musl
+          - powerpcle-linux-musl
+          - powerpcle-linux-muslsf
+          - riscv32-linux-musl
+          - riscv64-linux-musl
+          - s390x-linux-musl
+          - sh2-linux-musl
+          - sh2-linux-muslfdpic
+          - sh2eb-linux-musl
+          - sh2eb-linux-muslfdpic
+          - sh4-linux-musl
+          - sh4eb-linux-musl
+          - x86_64-linux-musl
+          - x86_64-linux-muslx32
 
     runs-on: ubuntu-latest
-    container: ubuntu:21.04
+    container: muslcc/x86_64:${{ matrix.toolchain }}
 
     steps:
-      - uses: actions/checkout@v2
       - name: Install build tools
+        run: apk add --no-cache coreutils git make tar zstd
+
+      - name: Checkout source
+        uses: actions/checkout@v2
+      
+      - name: Fix - Stopping at filesystem boundary
+        run: git init # [fix Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).]
+
+      - name: Build
         run: |
-          apt update && \
-          apt install coreutils sed git build-essential gcc-11 g++-11 -y
-          apt install -y g++-11-aarch64-linux-gnu g++-11-i686-linux-gnu \
-          g++-11-arm-linux-gnueabi  g++-11-arm-linux-gnueabihf g++-11-riscv64-linux-gnu \
-          g++-11-sparc64-linux-gnu
-
-          mkdir -p multiarch_bin
-
-          git init # [fix Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).]
-
-      - name: Compile x86_64
-        run: |
-          make CXX=g++-11 ARCH=x86_64 STATIC=true QUIET=true
-          GIT_HASH=$(git rev-parse --short "$GITHUB_SHA")
-          mv bin/btop multiarch_bin/btop-x86_64-$GIT_HASH
-          make distclean
-
-      - name: Compile i686
-        run: |
-          make CXX=i686-linux-gnu-g++-11 ARCH=i686 STATIC=true QUIET=true
-          GIT_HASH=$(git rev-parse --short "$GITHUB_SHA")
-          mv bin/btop multiarch_bin/btop-i686-$GIT_HASH
-          make distclean
-
-      - name: Compile aarch64
-        run: |
-          make CXX=aarch64-linux-gnu-g++-11 ARCH=aarch64 STATIC=true QUIET=true
-          GIT_HASH=$(git rev-parse --short "$GITHUB_SHA")
-          mv bin/btop multiarch_bin/btop-aarch64-$GIT_HASH
-          make distclean
-
-      - name: Compile armel
-        run: |
-          make CXX=arm-linux-gnueabi-g++-11 ARCH=armel STATIC=true QUIET=true
-          GIT_HASH=$(git rev-parse --short "$GITHUB_SHA")
-          mv bin/btop multiarch_bin/btop-armel-$GIT_HASH
-          make distclean
-
-      - name: Compile armhf
-        run: |
-          make CXX=arm-linux-gnueabihf-g++-11 ARCH=armhf STATIC=true QUIET=true
-          GIT_HASH=$(git rev-parse --short "$GITHUB_SHA")
-          mv bin/btop multiarch_bin/btop-armhf-$GIT_HASH
-          make distclean
-
-      - name: Compile riscv64
-        run: |
-          make CXX=riscv64-linux-gnu-g++-11 ARCH=riscv64 STATIC=true QUIET=true
-          GIT_HASH=$(git rev-parse --short "$GITHUB_SHA")
-          mv bin/btop multiarch_bin/btop-riscv64-$GIT_HASH
-          make distclean
-
-      - name: Compile sparc64
-        run: |
-          make CXX=sparc64-linux-gnu-g++-11 ARCH=sparc64 STATIC=true QUIET=true
-          GIT_HASH=$(git rev-parse --short "$GITHUB_SHA")
-          mv bin/btop multiarch_bin/btop-sparc64-$GIT_HASH
-          make distclean
+          TOOLCHAIN=${{ matrix.toolchain }}
+          make -j $(getconf _NPROCESSORS_ONLN) ARCH=${TOOLCHAIN/-*/} STATIC=true QUIET=true
 
       - name: Make executable
+        run: chmod +x bin/*
+
+      - name: Set up directories
         run: |
-          chmod +x multiarch_bin/*
+          mkdir .artifacts
+          mkdir .package
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: btop-x86_64
-          path: 'multiarch_bin/btop-x86_64*'
+      - name: Create binary atrifacts
+        run: |
+          TOOLCHAIN=${{ matrix.toolchain }}
+          GIT_HASH=$(git rev-parse --short "${{ github.sha }}")
+          FILENAME=btop-${TOOLCHAIN/linux-musl/}-$GIT_HASH
+          cp bin/btop .artifacts/$FILENAME
 
-      - uses: actions/upload-artifact@v2
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
         with:
-          name: btop-i686
-          path: 'multiarch_bin/btop-i686*'
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: btop-aarch64
-          path: 'multiarch_bin/btop-aarch64*'
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: btop-armel
-          path: 'multiarch_bin/btop-armel*'
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: btop-armhf
-          path: 'multiarch_bin/btop-armhf*'
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: btop-riscv64
-          path: 'multiarch_bin/btop-riscv64*'
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: btop-sparc64
-          path: 'multiarch_bin/btop-sparc64*'
+          name: btop-${{ matrix.toolchain }}
+          path: '.artifacts/**'

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -88,9 +88,7 @@ jobs:
         run: git init # [fix Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).]
 
       - name: Build
-        run: |
-          TOOLCHAIN=${{ matrix.toolchain }}
-          make -j $(getconf _NPROCESSORS_ONLN) ARCH=${TOOLCHAIN/-*/} STATIC=true QUIET=true
+        run: make STATIC=true STRIP=true QUIET=true
 
       - name: Make executable
         run: chmod +x bin/*

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - musl-build
     tags-ignore:
       - '*.*'
     paths:

--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,6 @@ ifeq ($(STRIP),true)
 	override ADDFLAGS += -s
 endif
 
-#? Make sure PLATFORM Darwin is OSX and not Darwin
-ifeq ($(PLATFORM_LC),darwin)
-	ifeq ($(shell sw_vers >/dev/null 2>&1; echo $$?),0)
-		PLATFORM := OSX
-	endif
-endif
-
 #? Compiler and Linker
 CXX ?= g++
 override CXX_VERSION := $(shell $(CXX) -dumpfullversion -dumpversion || echo 0)
@@ -62,7 +55,7 @@ ifeq ($(PLATFORM_LC),linux)
 else ifeq ($(PLATFORM_LC),freebsd)
 	PLATFORM_DIR := freebsd
 	THREADS	:= $(shell getconf NPROCESSORS_ONLN 2>/dev/null || echo 1)
-else ifeq ($(PLATFORM_LC),osx)
+else ifeq ($(PLATFORM_LC),apple)
 	PLATFORM_DIR := osx
 	THREADS	:= $(shell sysctl -n hw.ncpu || echo 1)
 else

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ARCH ?= $(shell $(CXX) -dumpmachine | cut -d "-" -f 1)
 override PLATFORM_LC := $(shell echo $(PLATFORM) | tr '[:upper:]' '[:lower:]')
 
 #? Only enable fcf-protection if on x86_64
-ifeq ($(ARCH),x86_64)
+ifneq ($(filter x86_64 i%86, $(ARCH)),)
 	override ADDFLAGS += -fcf-protection
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #* Btop++ makefile v1.2
 
-BANNER  = \n \033[38;5;196m██████\033[38;5;240m╗ \033[38;5;196m████████\033[38;5;240m╗ \033[38;5;196m██████\033[38;5;240m╗ \033[38;5;196m██████\033[38;5;240m╗\n \033[38;5;160m██\033[38;5;239m╔══\033[38;5;160m██\033[38;5;239m╗╚══\033[38;5;160m██\033[38;5;239m╔══╝\033[38;5;160m██\033[38;5;239m╔═══\033[38;5;160m██\033[38;5;239m╗\033[38;5;160m██\033[38;5;239m╔══\033[38;5;160m██\033[38;5;239m╗   \033[38;5;160m██\033[38;5;239m╗    \033[38;5;160m██\033[38;5;239m╗\n \033[38;5;124m██████\033[38;5;238m╔╝   \033[38;5;124m██\033[38;5;238m║   \033[38;5;124m██\033[38;5;238m║   \033[38;5;124m██\033[38;5;238m║\033[38;5;124m██████\033[38;5;238m╔╝ \033[38;5;124m██████\033[38;5;238m╗\033[38;5;124m██████\033[38;5;238m╗\n \033[38;5;88m██\033[38;5;237m╔══\033[38;5;88m██\033[38;5;237m╗   \033[38;5;88m██\033[38;5;237m║   \033[38;5;88m██\033[38;5;237m║   \033[38;5;88m██\033[38;5;237m║\033[38;5;88m██\033[38;5;237m╔═══╝  ╚═\033[38;5;88m██\033[38;5;237m╔═╝╚═\033[38;5;88m██\033[38;5;237m╔═╝\n \033[38;5;52m██████\033[38;5;236m╔╝   \033[38;5;52m██\033[38;5;236m║   ╚\033[38;5;52m██████\033[38;5;236m╔╝\033[38;5;52m██\033[38;5;236m║        ╚═╝    ╚═╝\n \033[38;5;235m╚═════╝    ╚═╝    ╚═════╝ ╚═╝      \033[1;3;38;5;240mMakefile v1.2\033[0m
+BANNER  = \n \033[38;5;196m██████\033[38;5;240m╗ \033[38;5;196m████████\033[38;5;240m╗ \033[38;5;196m██████\033[38;5;240m╗ \033[38;5;196m██████\033[38;5;240m╗\n \033[38;5;160m██\033[38;5;239m╔══\033[38;5;160m██\033[38;5;239m╗╚══\033[38;5;160m██\033[38;5;239m╔══╝\033[38;5;160m██\033[38;5;239m╔═══\033[38;5;160m██\033[38;5;239m╗\033[38;5;160m██\033[38;5;239m╔══\033[38;5;160m██\033[38;5;239m╗   \033[38;5;160m██\033[38;5;239m╗    \033[38;5;160m██\033[38;5;239m╗\n \033[38;5;124m██████\033[38;5;238m╔╝   \033[38;5;124m██\033[38;5;238m║   \033[38;5;124m██\033[38;5;238m║   \033[38;5;124m██\033[38;5;238m║\033[38;5;124m██████\033[38;5;238m╔╝ \033[38;5;124m██████\033[38;5;238m╗\033[38;5;124m██████\033[38;5;238m╗\n \033[38;5;88m██\033[38;5;237m╔══\033[38;5;88m██\033[38;5;237m╗   \033[38;5;88m██\033[38;5;237m║   \033[38;5;88m██\033[38;5;237m║   \033[38;5;88m██\033[38;5;237m║\033[38;5;88m██\033[38;5;237m╔═══╝  ╚═\033[38;5;88m██\033[38;5;237m╔═╝╚═\033[38;5;88m██\033[38;5;237m╔═╝\n \033[38;5;52m██████\033[38;5;236m╔╝   \033[38;5;52m██\033[38;5;236m║   ╚\033[38;5;52m██████\033[38;5;236m╔╝\033[38;5;52m██\033[38;5;236m║        ╚═╝    ╚═╝\n \033[38;5;235m╚═════╝    ╚═╝    ╚═════╝ ╚═╝      \033[1;3;38;5;240mMakefile v1.3\033[0m
 
 override BTOP_VERSION := $(shell head -n100 src/btop.cpp 2>/dev/null | grep "Version =" | cut -f2 -d"\"" || echo " unknown")
 override TIMESTAMP := $(shell date +%s 2>/dev/null || echo "0")
@@ -14,9 +14,11 @@ endif
 
 PREFIX ?= /usr/local
 
-#? NOTICE! Manually set PLATFORM and ARCH if not compiling for host system
-PLATFORM ?= $(shell uname -s || echo unknown)
-ARCH ?= $(shell uname -m || echo unknown)
+#? Detect PLATFORM and ARCH from gcc if not set
+PLATFORM ?= $(shell $(CXX) -dumpmachine | awk -F"-" '{ print (NF==4) ? $$3 : $$2 }')
+ARCH ?= $(shell $(CXX) -dumpmachine | cut -d "-" -f 1)
+
+override PLATFORM_LC := $(shell echo $(PLATFORM) | tr '[:upper:]' '[:lower:]')
 
 #? Only enable fcf-protection if on x86_64
 ifeq ($(ARCH),x86_64)
@@ -24,11 +26,15 @@ ifeq ($(ARCH),x86_64)
 endif
 
 ifeq ($(STATIC),true)
-	override ADDFLAGS += -D STATIC_BUILD -static -static-libgcc -static-libstdc++
+	override ADDFLAGS += -D STATIC_BUILD -static -static-libgcc -static-libstdc++ -Wl,--fatal-warnings
+endif
+
+ifeq ($(STRIP),true)
+	override ADDFLAGS += -s
 endif
 
 #? Make sure PLATFORM Darwin is OSX and not Darwin
-ifeq ($(PLATFORM),Darwin)
+ifeq ($(PLATFORM_LC),darwin)
 	ifeq ($(shell sw_vers >/dev/null 2>&1; echo $$?),0)
 		PLATFORM := OSX
 	endif
@@ -50,13 +56,13 @@ ifeq ($(CXX),g++)
 endif
 
 #? Pull in platform specific source files and get thread count
-ifeq ($(PLATFORM),Linux)
+ifeq ($(PLATFORM_LC),linux)
 	PLATFORM_DIR := linux
 	THREADS	:= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
-else ifeq ($(PLATFORM),FreeBSD)
+else ifeq ($(PLATFORM_LC),freebsd)
 	PLATFORM_DIR := freebsd
 	THREADS	:= $(shell getconf NPROCESSORS_ONLN 2>/dev/null || echo 1)
-else ifeq ($(PLATFORM),OSX)
+else ifeq ($(PLATFORM_LC),osx)
 	PLATFORM_DIR := osx
 	THREADS	:= $(shell sysctl -n hw.ncpu || echo 1)
 else

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Also needs a UTF8 locale and a font that covers:
 
    Append `STRIP=true` to force stripping of debug symbols (adds `-s` linker flag).
 
-   Append `ARCH=<architecture>` to manually set the target architectur.
+   Append `ARCH=<architecture>` to manually set the target architecture.
    If omitted the makefile uses the machine triple (output of `-dumpmachine` compiler parameter) to detect the target system.
 
    Use `ADDFLAGS` variable for appending flags to both compiler and linker.

--- a/README.md
+++ b/README.md
@@ -259,7 +259,10 @@ Also needs a UTF8 locale and a font that covers:
 
    Append `QUIET=true` for less verbose output.
 
-   Notice! Manually set `$ARCH` variable if cross-compiling
+   Append `STRIP=true` to force stripping of debug symbols (adds `-s` linker flag).
+
+   Append `ARCH=<architecture>` to manually set the target architectur.
+   If omitted the makefile uses the machine triple (output of `-dumpmachine` compiler parameter) to detect the target system.
 
    Use `ADDFLAGS` variable for appending flags to both compiler and linker.
 

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -27,7 +27,7 @@ tab-size = 4
 #include <ifaddrs.h>
 #include <net/if.h>
 
-#if !defined(STATIC_BUILD) || !defined(__GLIBC__)
+#if !(defined(STATIC_BUILD) && defined(__GLIBC__))
 	#include <pwd.h>
 #endif
 
@@ -1437,7 +1437,7 @@ namespace Proc {
 						new_proc.user = uid_user.at(uid);
 					}
 					else {
-					#if !defined(STATIC_BUILD) || !defined(__GLIBC__)
+					#if !(defined(STATIC_BUILD) && defined(__GLIBC__))
 						try {
 							struct passwd* udet;
 							udet = getpwuid(stoi(uid));

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -27,7 +27,7 @@ tab-size = 4
 #include <ifaddrs.h>
 #include <net/if.h>
 
-#ifndef STATIC_BUILD
+#if !defined(STATIC_BUILD) || !defined(__GLIBC__)
 	#include <pwd.h>
 #endif
 
@@ -1437,7 +1437,7 @@ namespace Proc {
 						new_proc.user = uid_user.at(uid);
 					}
 					else {
-					#ifndef STATIC_BUILD
+					#if !defined(STATIC_BUILD) || !defined(__GLIBC__)
 						try {
 							struct passwd* udet;
 							udet = getpwuid(stoi(uid));


### PR DESCRIPTION
### Description of changes

_for more details on the reasoning behind these changes see #84_

- added yaml definitions to `.editorconfig` for comfortable workflow editing
- changed static build behavior  to restrict `getpwuid` usage only in static builds with glibc so that static musl build have full functionality
- changed the continuous build workflow to create static musl binaries
- updated Makefile
  - added cf-protection for i*86 builds
  - added platform and arch detection from CXX machine tuple
  - add `PLATFORM_LC`, a lowercase version of `PLATFORM`, for case insensitive comparison
  - added bool flag `STRIP` to force `-s` linker flag
  - turned linker warnings into errors in case of `STATIC` to fail in case of glibc static linking issues
  - bumped version to 1.3
- updated README.md to reflect Makefile changes