### PR TITLE
Improved battery detection

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -480,15 +480,20 @@ namespace Cpu {
 					//? Only consider online power supplies of type Battery or UPS
 					//? see kernel docs for details on the file structure and contents
 					//? https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-power
-					if (not d.is_directory()
-						or not fs::exists(d.path() / "type") 
-						or not fs::exists(d.path() / "present")
-						or stoi(readfile(d.path() / "present")) != 1)
+					try {
+						if (not d.is_directory()
+							or not fs::exists(d.path() / "type") 
+							or not fs::exists(d.path() / "present")
+							or stoi(readfile(d.path() / "present")) != 1)
+							continue;
+						string type = readfile(d.path() / "type");
+						if (type == "Battery" or type == "UPS") {
+							bat_dir = d.path();
+							break;
+						}
+					} catch (...) {
+						//? skip power supplies not conforming to the kernel standard
 						continue;
-					string type = readfile(d.path() / "type");
-					if (type == "Battery" or type == "UPS") {
-						bat_dir = d.path();
-						break;
 					}
 				}
 			}

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -477,7 +477,16 @@ namespace Cpu {
 		if (bat_dir.empty() and has_battery) {
 			if (fs::exists("/sys/class/power_supply")) {
 				for (const auto& d : fs::directory_iterator("/sys/class/power_supply")) {
-					if (const string dir_name = d.path().filename(); d.is_directory() and (dir_name.starts_with("BAT") or s_contains(str_to_lower(dir_name), "battery"))) {
+					//? Only consider online power supplies of type Battery or UPS
+					//? see kernel docs for details on the file structure and contents
+					//? https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-power
+					if (not d.is_directory()
+						or not fs::exists(d.path() / "type") 
+						or not fs::exists(d.path() / "present")
+						or stoi(readfile(d.path() / "present")) != 1)
+						continue;
+					string type = readfile(d.path() / "type");
+					if (type == "Battery" or type == "UPS") {
 						bat_dir = d.path();
 						break;
 					}


### PR DESCRIPTION
### Improvements to the battery detection:
 
- now considering all power supplies (instead of path name filtering)
- only consider power supplies that are currently present
- only consider power supplies of type Batter or UPS

_All changes made are in accordants to the definitions of `/sys/class/power_supply` from the [kernel docs](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-power)_

---

This change was made to address the battery issue part of issue #94

This issue is still draft status, since I'm still awaiting feedback by the issue reporter @bionade24 on the test build I provided.