### PR TITLE
Add support for AMD Ryzen 5000 series temp sensor

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -313,12 +313,7 @@ namespace Cpu {
 		if (not got_coretemp or core_sensors.empty()) cpu_temp_only = true;
 		if (cpu_sensor.empty() and not found_sensors.empty()) {
 			for (const auto& [name, sensor] : found_sensors) {
-				if (s_contains(str_to_lower(name), "cpu")) {
-					cpu_sensor = name;
-					break;
-				}
-				if (s_contains(str_to_lower(name), "k10temp")) {
-					Logger::warning("Using k10temp sensors for AMD.");
+				if (s_contains(str_to_lower(name), "cpu") or s_contains(str_to_lower(name), "k10temp")) {
 					cpu_sensor = name;
 					break;
 				}


### PR DESCRIPTION
Running this on a Lenovo Legion 5 with a Ryzen 5800H doesn't show reliable CPU temperatures. We do not have support for per core temp sensors here, and btop chooses a sensor at random from found sensors with `cpu_sensor = found_sensors.begin()->first;`, which happens to be amdgpu/edge in this case. However with the k10temp kernel module, you can get the Tctl temperature that more accurately represents the CPU temperature. This may be the case with all 5000 series AMD Ryzen CPUs.