### PR TITLE
Add support for building using meson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ stage/
 *.app
 
 build
+builddir
 bin
 btop
 .*/

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,40 @@
+project('btop', 'cpp',
+  version : '1.0.20',
+  default_options : ['cpp_std=c++20', 'warning_level=3'])
+
+src_files = files([
+  'src/btop_config.cpp',
+  'src/btop_draw.cpp',
+  'src/btop_input.cpp',
+  'src/btop_menu.cpp',
+  'src/btop_theme.cpp',
+  'src/btop_tools.cpp',
+  'src/linux/btop_collect.cpp',
+  'src/btop.cpp'
+])
+
+add_global_arguments('-DMESON_BUILD', language : ['c', 'cpp'])
+
+config_data = configuration_data()
+config_data.set_quoted('CONFIG_BTOP_VERSION', meson.project_version())
+
+configure_file(
+  output : 'config.h',
+  configuration: config_data,
+)
+
+src_inc = include_directories(['src'])
+thirdparty_inc = include_directories(['include'])
+
+threads_dep = dependency('threads')
+
+install_data('README.md', install_dir : get_option('datadir') / 'btop')
+install_subdir('themes', install_dir : get_option('datadir') / 'btop')
+
+exe = executable(
+  'btop',
+  sources: src_files,
+  dependencies: [threads_dep],
+  include_directories: [src_inc, thirdparty_inc],
+  install : true,
+)

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -37,6 +37,10 @@ tab-size = 4
 #include <btop_draw.hpp>
 #include <btop_menu.hpp>
 
+#ifdef MESON_BUILD
+	#include "config.h"
+#endif
+
 using std::string, std::string_view, std::vector, std::atomic, std::endl, std::cout, std::min, std::flush, std::endl;
 using std::string_literals::operator""s, std::to_string;
 namespace fs = std::filesystem;
@@ -53,7 +57,11 @@ namespace Global {
 		{"#801414", "██████╔╝   ██║   ╚██████╔╝██║        ╚═╝    ╚═╝"},
 		{"#000000", "╚═════╝    ╚═╝    ╚═════╝ ╚═╝"},
 	};
+#ifdef MESON_BUILD
+	const string Version = CONFIG_BTOP_VERSION;
+#else
 	const string Version = "1.0.20";
+#endif
 
 	int coreCount;
 	string overlay;


### PR DESCRIPTION
I thought it would be a good idea to have a build system that makes porting to other platforms easier. Another good point is that the build system is a lot more understandable to someone with no shell and Makefile experience, and also a lot more standardized. Meson specifically has testing and benchmarking features (which I haven't used here) but will be helpful in the future. In addition, dependency management is much easier in meson, which will be handy when many external dependencies are added (inevitable with GPU support).

This currently only has support for linux with a basic installation (with themes and readme), and notably setsid feature missing. I found out that a change I made in src/btop.cpp breaks reading version in the Makefile, though it builds successfully and the resulting binary works as intended.

To use meson run:
```bash
cd btop # Go to the root of the project
meson builddir # set builddir as the build directory
cd builddir
ninja # to build 
ninja install # to install or can be skipped if not needed
```
I didn't change default build flags, but it may be useful to do so.