### PR TITLE
fix SISEGV on Mojave

### DIFF
--- a/src/osx/sensors.cpp
+++ b/src/osx/sensors.cpp
@@ -37,7 +37,8 @@ CFDictionaryRef matching(int page, int usage) {
 	nums[1] = CFNumberCreate(0, kCFNumberSInt32Type, &usage);
 
 	CFDictionaryRef dict = CFDictionaryCreate(0, (const void **)keys, (const void **)nums, 2, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-	CFRelease(keys);
+	CFRelease(keys[0]);
+	CFRelease(keys[1]);
 	return dict;
 }
 


### PR DESCRIPTION
My understanding of the issue:
 - CFStringRef is a pointer to __CFString.
 - CFRelease takes a pointer to a CF object.
 - We give it a pointer to a __CFString pointer.
 - This couldn't possibly go right!
 
So anyway, it's my first PR. I just changed the CFRelease call to free each CFStringRef separately. My understanding of CF is minimal so a review is welcome!