### PR TITLE
#168 - try again with TC0C smc key

### DIFF
--- a/src/osx/smc.cpp
+++ b/src/osx/smc.cpp
@@ -63,6 +63,11 @@ namespace Cpu {
 			snprintf(key, 5, "TC%1dc", core);
 		}
 		result = SMCReadKey(key, &val);
+		if (result != kIOReturnSuccess) {
+			// try again with C
+			snprintf(key, 5, "TC%1dC", core);
+			result = SMCReadKey(key, &val);
+		}
 		if (result == kIOReturnSuccess) {
 			if (strcmp(val.dataType, DATATYPE_SP78) == 0) {
 				// convert sp78 value to temperature

--- a/src/osx/smc.hpp
+++ b/src/osx/smc.hpp
@@ -25,7 +25,8 @@
 #define DATATYPE_SP78 "sp78"
 
 // key values
-#define SMC_KEY_CPU_TEMP "TC0P"
+#define SMC_KEY_CPU_TEMP "TC0P" // proximity temp?
+#define SMC_KEY_CPU_DIE_TEMP "TC0D" // die temp?
 #define SMC_KEY_CPU1_TEMP "TC1C"
 #define SMC_KEY_CPU2_TEMP "TC2C"  // etc
 #define SMC_KEY_FAN0_RPM_CUR "F0Ac"


### PR DESCRIPTION
@aristocratos The coretemp program (and also others) fallback to TC0C if TC0c does not give any reading. Implemented here. I asked the guy in #168 to test with a build with that change, but he didn't reply. I guess this is ok.

Apparently I don't have commit rights to your repo anymore so creating pull request ;-).