### PR TITLE
fix CPU temp fallback on macOS

### DIFF
--- a/src/osx/smc.hpp
+++ b/src/osx/smc.hpp
@@ -26,7 +26,8 @@
 
 // key values
 #define SMC_KEY_CPU_TEMP "TC0P" // proximity temp?
-#define SMC_KEY_CPU_DIE_TEMP "TC0D" // die temp?
+#define SMC_KEY_CPU_DIODE_TEMP "TC0D" // diode temp?
+#define SMC_KEY_CPU_DIE_TEMP "TC0F" // die temp?
 #define SMC_KEY_CPU1_TEMP "TC1C"
 #define SMC_KEY_CPU2_TEMP "TC2C"  // etc
 #define SMC_KEY_FAN0_RPM_CUR "F0Ac"
@@ -86,6 +87,7 @@ namespace Cpu {
 
 	   private:
         kern_return_t SMCReadKey(UInt32Char_t key, SMCVal_t *val);
+		long long getSMCTemp(char *key);
 		kern_return_t SMCCall(int index, SMCKeyData_t *inputStructure, SMCKeyData_t *outputStructure);
 
 		io_connect_t conn;


### PR DESCRIPTION
@aristocratos You can remove the debug lines if you want. I've left the ones in get_sensors() as this is only ran once.