### PR TITLE
in_avail() can always be zero, it is an optimization opportunity only

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -237,15 +237,15 @@ void clean_quit(int sig) {
 		std::cerr << Global::fg_red << "ERROR: " << Global::fg_white << Global::exit_error_msg << Fx::reset << endl;
 	}
 	Logger::info("Quitting! Runtime: " + sec_to_dhms(time_s() - Global::start_time));
-
-	const auto excode = (sig != -1 ? sig : 0);
-
+	close(0);
 	//? Assume error if still not cleaned up and call quick_exit to avoid a segfault from Tools::atomic_lock destructor
 #ifndef __APPLE__
-	quick_exit(excode);
+	if (Tools::active_locks > 0) {
+		quick_exit((sig != -1 ? sig : 0));
+	}
 #endif
 
-	exit(excode);
+	if (sig != -1) exit(sig);
 }
 
 //* Handler for SIGTSTP; stops threads, restores terminal and sends SIGSTOP

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -17,6 +17,7 @@ tab-size = 4
 */
 
 #include <csignal>
+#include <clocale>
 #include <pthread.h>
 #include <thread>
 #include <numeric>
@@ -237,14 +238,14 @@ void clean_quit(int sig) {
 	}
 	Logger::info("Quitting! Runtime: " + sec_to_dhms(time_s() - Global::start_time));
 
+	const auto excode = (sig != -1 ? sig : 0);
+
 	//? Assume error if still not cleaned up and call quick_exit to avoid a segfault from Tools::atomic_lock destructor
 #ifndef __APPLE__
-	if (Tools::active_locks > 0) {
-		quick_exit((sig != -1 ? sig : 0));
-	}
+	quick_exit(excode);
 #endif
 
-	if (sig != -1) exit(sig);
+	exit(excode);
 }
 
 //* Handler for SIGTSTP; stops threads, restores terminal and sends SIGSTOP

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -241,11 +241,11 @@ void clean_quit(int sig) {
 	const auto excode = (sig != -1 ? sig : 0);
 
 	//? Assume error if still not cleaned up and call quick_exit to avoid a segfault from Tools::atomic_lock destructor
-#ifndef __APPLE__
+#ifdef __APPLE__
+	_Exit(excode);
+#else
 	quick_exit(excode);
 #endif
-
-	exit(excode);
 }
 
 //* Handler for SIGTSTP; stops threads, restores terminal and sends SIGSTOP

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -237,15 +237,15 @@ void clean_quit(int sig) {
 		std::cerr << Global::fg_red << "ERROR: " << Global::fg_white << Global::exit_error_msg << Fx::reset << endl;
 	}
 	Logger::info("Quitting! Runtime: " + sec_to_dhms(time_s() - Global::start_time));
-	close(0);
+
+	const auto excode = (sig != -1 ? sig : 0);
+
 	//? Assume error if still not cleaned up and call quick_exit to avoid a segfault from Tools::atomic_lock destructor
 #ifndef __APPLE__
-	if (Tools::active_locks > 0) {
-		quick_exit((sig != -1 ? sig : 0));
-	}
+	quick_exit(excode);
 #endif
 
-	if (sig != -1) exit(sig);
+	exit(excode);
 }
 
 //* Handler for SIGTSTP; stops threads, restores terminal and sends SIGSTOP

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -82,10 +82,14 @@ namespace Input {
 
 	struct InputThr {
 		InputThr() : thr(run, this) {
+			thr.detach();
 		}
 
 		static void run(InputThr* that) {
-			that->runImpl();
+			try {
+				that->runImpl();
+			} catch (...) {}
+			delete that;
 		}
 
 		void runImpl() {
@@ -120,7 +124,6 @@ namespace Input {
 		}
 
 		static InputThr& instance() {
-			// intentional memory leak, to simplify shutdown process
 			static InputThr* input = new InputThr();
 
 			return *input;

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -82,14 +82,10 @@ namespace Input {
 
 	struct InputThr {
 		InputThr() : thr(run, this) {
-			thr.detach();
 		}
 
 		static void run(InputThr* that) {
-			try {
-				that->runImpl();
-			} catch (...) {}
-			delete that;
+			that->runImpl();
 		}
 
 		void runImpl() {
@@ -124,6 +120,7 @@ namespace Input {
 		}
 
 		static InputThr& instance() {
+			// intentional memory leak, to simplify shutdown process
 			static InputThr* input = new InputThr();
 
 			return *input;


### PR DESCRIPTION
in_avail() can always return zero, so libc++'s streams does. 

So, one can not use such a technique to async cin poll.

One can use poll/select for zero fd, but it will not work for file inputs, like in 'btop < some_file'.

Best available option - just read input in separate thread. Also, after this commit, we will have an opportunity to remove sleep's from code, and use condition_variable timed_wait.

Also we should always try quick_exit, instead of plain exit() call, cause:

1) why bother with threads? let them die fast.
2) should not overcomplicate shutdown process

And I do not personally understand, why quick_exit disabled on Darwin... One can always use _Exit()/_exit() instead.