### PR TITLE
README: Update openSUSE install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,18 +269,12 @@ Also needs a UTF8 locale and a font that covers:
 **Binary release (from native os repo)**
 
 * **openSUSE**
-  * **Add repo**
-  ```bash
-  sudo zypper ar --refresh obs://home:Werwolf2517 home:Werwolf2517
-  ```
-  * **Refresh metadata**
-  ```bash
-  sudo zypper ref
-  ```
-  * **Install package**
-  ```bash
-  sudo zypper in btop
-  ```
+  * **Tumbleweed:**
+    ```bash
+    sudo zypper in btop
+    ```
+  * For all other versions, see [openSUSE Software: btop](https://software.opensuse.org/package/btop)
+
 
 **Binary release on Homebrew (macOS (x86_64 & ARM64) / Linux (x86_64))**
 


### PR DESCRIPTION
The package is available in the official default repos for Tumbleweed. For Leap, the package is available in the development repository. Linking to the generic page, which has the current information - independent of distro releases and package submissions. The user's repository is obsolete/not necessary any more.