### PR TITLE
Sort input file list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,9 +129,9 @@ ifdef DEBUG
 	override OPTFLAGS := -O0 -g
 endif
 
-SOURCES	:= $(shell find $(SRCDIR) -maxdepth 1 -type f -name *.$(SRCEXT))
+SOURCES	:= $(sort $(shell find $(SRCDIR) -maxdepth 1 -type f -name *.$(SRCEXT)))
 
-SOURCES += $(shell find $(SRCDIR)/$(PLATFORM_DIR) -type f -name *.$(SRCEXT))
+SOURCES += $(sort $(shell find $(SRCDIR)/$(PLATFORM_DIR) -type f -name *.$(SRCEXT)))
 
 SOURCE_COUNT := $(words $(SOURCES))
 


### PR DESCRIPTION
Sort input file list
so that `btop` builds in a reproducible way
in spite of indeterministic filesystem readdir order. (linking order matters)

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).