### PR TITLE
Reverting back to previous build settings

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,8 +13,12 @@ confinement: strict
 compression: lzo
 
 architectures:
-  - build-on: [amd64, armhf, arm64, ppc64el, s390x]
-    run-on: [amd64, armhf, arm64, ppc64el, s390x]
+  - build-on: amd64
+  - build-on: arm64
+  - build-on: armhf
+  - build-on: ppc64el
+  - build-on: armhf
+  - build-on: s390x
 
 package-repositories:
  - type: apt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,10 +14,7 @@ compression: lzo
 
 architectures:
   - build-on: amd64
-  - build-on: arm64
-  - build-on: armhf
-  - build-on: ppc64el
-  - build-on: s390x
+    run-on: [amd64, armhf, arm64, ppc64el, s390x]
 
 package-repositories:
  - type: apt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ confinement: strict
 compression: lzo
 
 architectures:
-  - build-on: amd64
+  - build-on: [amd64, armhf, arm64, ppc64el, s390x]
     run-on: [amd64, armhf, arm64, ppc64el, s390x]
 
 package-repositories:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,7 +17,6 @@ architectures:
   - build-on: arm64
   - build-on: armhf
   - build-on: ppc64el
-  - build-on: armhf
   - build-on: s390x
 
 package-repositories:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,6 @@ apps:
       - hardware-observe
       - network
       - network-observe
-    #  - physical-memory-observe
       - home
       - removable-media
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ compression: lzo
 
 architectures:
   - build-on: amd64
-    run-on: [all]
+    run-on: [amd64, armhf, arm64, ppc64el, s390x]
 
 package-repositories:
  - type: apt


### PR DESCRIPTION
Snapcraft is supposed to allow building on one arch, and running on another. In this case, it's not working. Likely due to btop's code detecting the fact that it's in a snapped env and building against that specific arch. 