### PR TITLE
Added: Case insensitive process filtering

### DIFF
--- a/src/btop_tools.hpp
+++ b/src/btop_tools.hpp
@@ -187,6 +187,16 @@ namespace Tools {
 		return str.find(find_val) != string::npos;
 	}
 
+	//* Check if string <str> contains string <find_val>, while ignoring case
+	inline bool s_contains_ic(const string& str, const string& find_val) {
+        auto it = std::search(
+            str.begin(), str.end(),
+            find_val.begin(), find_val.end(),
+            [](char ch1, char ch2) { return std::toupper(ch1) == std::toupper(ch2); }
+        );
+		return it != str.end();
+	}
+
 	//* Return index of <find_val> from vector <vec>, returns size of <vec> if <find_val> is not present
 	template <typename T>
 	inline size_t v_index(const vector<T>& vec, const T& find_val) {

--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -1317,7 +1317,7 @@ namespace Proc {
 			filter_found = 0;
 			for (auto &p : current_procs) {
 				if (not tree and not filter.empty()) {
-					if (not s_contains(to_string(p.pid), filter) and not s_contains(p.name, filter) and not s_contains(p.cmd, filter) and not s_contains(p.user, filter)) {
+					if (not s_contains_ic(to_string(p.pid), filter) and not s_contains_ic(p.name, filter) and not s_contains_ic(p.cmd, filter) and not s_contains_ic(p.user, filter)) {
 						p.filtered = true;
 						filter_found++;
 					} else {

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -1700,10 +1700,10 @@ namespace Proc {
 			filter_found = 0;
 			for (auto& p : current_procs) {
 				if (not tree and not filter.empty()) {
-						if (not s_contains(to_string(p.pid), filter)
-						and not s_contains(p.name, filter)
-						and not s_contains(p.cmd, filter)
-						and not s_contains(p.user, filter)) {
+						if (not s_contains_ic(to_string(p.pid), filter)
+						and not s_contains_ic(p.name, filter)
+						and not s_contains_ic(p.cmd, filter)
+						and not s_contains_ic(p.user, filter)) {
 							p.filtered = true;
 							filter_found++;
 							}

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1372,7 +1372,7 @@ namespace Proc {
 			filter_found = 0;
 			for (auto &p : current_procs) {
 				if (not tree and not filter.empty()) {
-					if (not s_contains(to_string(p.pid), filter) and not s_contains(p.name, filter) and not s_contains(p.cmd, filter) and not s_contains(p.user, filter)) {
+					if (not s_contains_ic(to_string(p.pid), filter) and not s_contains_ic(p.name, filter) and not s_contains_ic(p.cmd, filter) and not s_contains_ic(p.user, filter)) {
 						p.filtered = true;
 						filter_found++;
 					} else {


### PR DESCRIPTION
As pointed out in #159, when filtering for a process, we have to get the capitalization correct to find it.

This patch solves it.