### PR TITLE
Added support for ZFS pool io stats monitoring

### DIFF
--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -131,7 +131,7 @@ namespace Mem {
 	struct disk_info {
 		std::filesystem::path dev;
 		string name;
-        string fstype;
+		string fstype;
 		std::filesystem::path stat = "";
 		int64_t total = 0, used = 0, free = 0;
 		int used_percent = 0, free_percent = 0;

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -131,6 +131,7 @@ namespace Mem {
 	struct disk_info {
 		std::filesystem::path dev;
 		string name;
+        string fstype;
 		std::filesystem::path stat = "";
 		int64_t total = 0, used = 0, free = 0;
 		int used_percent = 0, free_percent = 0;

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -947,8 +947,8 @@ namespace Mem {
 											disks.at(mountpoint).stat = "/sys/block/" + devname + "/stat";
 										break;
 									//? Set ZFS stat filepath
-									} else if (fs::exists("/proc/spl/kstat/zfs/" + devname + "/io", ec) and access(string("/proc/spl/kstat/zfs/" + devname + "/io").c_str(), R_OK) == 0) {
-										disks.at(mountpoint).stat = "/proc/spl/kstat/zfs/" + devname + "/io";
+									} else if (fs::exists(Shared::procPath.string() + "/spl/kstat/zfs/" + devname + "/io", ec) and access(string(Shared::procPath.string() + "/spl/kstat/zfs/" + devname + "/io").c_str(), R_OK) == 0) {
+										disks.at(mountpoint).stat = Shared::procPath.string() + "/spl/kstat/zfs/" + devname + "/io";
 										break;
 									}
 									devname.resize(devname.size() - 1);
@@ -1079,7 +1079,7 @@ namespace Mem {
 							while (cmp_greater(disk.io_activity.size(), width * 2)) disk.io_activity.pop_front();
 						}
 					} else {
-						Logger::warning("Error in Mem::collect() : when opening " + (string)disk.stat);
+						Logger::debug("Error in Mem::collect() : when opening " + (string)disk.stat);
 					}
 					diskread.close();
 				}

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -949,7 +949,6 @@ namespace Mem {
 										break;
 									//? Set ZFS stat filepath
 									} else if (fs::exists("/proc/spl/kstat/zfs/" + devname + "/io", ec) and access(string("/proc/spl/kstat/zfs/" + devname + "/io").c_str(), R_OK) == 0) {
-										Logger::warning("Adding ZFS stat path for " + (string)dev);
 										disks.at(mountpoint).stat = "/proc/spl/kstat/zfs/" + devname + "/io";
 										break;
 									}
@@ -1025,7 +1024,6 @@ namespace Mem {
 							disk_ios++;
 							for (int i = 0; i < 18; i++) { diskread >> std::ws; diskread.ignore(SSmax, ' '); }
 							diskread >> sectors_read; // nbytes read
-							Logger::warning("ZFS device " + (string)disk.name + " read bytes: " + to_string(sectors_read));
 							if (disk.io_read.empty())
 								disk.io_read.push_back(0);
 							else
@@ -1034,7 +1032,6 @@ namespace Mem {
 							while (cmp_greater(disk.io_read.size(), width * 2)) disk.io_read.pop_front();
 
 							diskread >> sectors_write; // nbytes written
-							Logger::warning("ZFS device " + (string)disk.name + " write bytes: " + to_string(sectors_write));
 							if (disk.io_write.empty())
 								disk.io_write.push_back(0);
 							else

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -937,7 +937,6 @@ namespace Mem {
 									if (mountpoint == "/mnt") disks.at(mountpoint).name = "root";
 								#endif
 								if (disks.at(mountpoint).name.empty()) disks.at(mountpoint).name = (mountpoint == "/" ? "root" : mountpoint);
-								disks.at(mountpoint).fstype = fstype;
 								string devname = disks.at(mountpoint).dev.filename();
 								int c = 0;
 								while (devname.size() >= 2) {


### PR DESCRIPTION
This pull request adds support for ZFS pool io monitoring, using file `/proc/spl/kstat/zfs/*pool_name*/io`.

Reads and writes are recorded as bytes, not sectors, so there is no need to multiply it by 512.
Since zfs stat collection is different from block device stat collection, `disk` has to store filesystem type to determine which collection method should be used.
Also, `io_ticks` for zfs are recorded separetely for reads and writes, so to get a total I added `io_ticks_read` and `io_ticks_write` variables.