### PR TITLE
Add Fedora/RHEL install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,15 @@ Also needs a UTF8 locale and a font that covers:
     sudo zypper in btop
     ```
   * For all other versions, see [openSUSE Software: btop](https://software.opensuse.org/package/btop)
+* **Fedora**
+    ```bash
+    sudo dnf install btop
+	```
+* **RHEL/AlmaLinux 8+**
+    ```bash
+    sudo dnf install epel-release
+	sudo dnf install btop
+	```
 
 
 **Binary release on Homebrew (macOS (x86_64 & ARM64) / Linux (x86_64))**


### PR DESCRIPTION
Hi,

I'm a packager for Fedora/EPEL and I built and published the btop packages in Fedora and EPEL repositories for Fedora 35+ and EL8+.  This PR simply adds the instructions for those users to easily install btop.

https://bodhi.fedoraproject.org/updates/?packages=btop