### PR TITLE
Fix variable initialization to 'auto' for getB()

### DIFF
--- a/src/btop_config.hpp
+++ b/src/btop_config.hpp
@@ -113,10 +113,3 @@ namespace Config {
 	//* Write the config file to disk
 	void write();
 }
-
-
-
-
-
-
-

--- a/src/btop_config.hpp
+++ b/src/btop_config.hpp
@@ -65,7 +65,7 @@ namespace Config {
 	bool _locked(const string& name);
 
 	//* Return bool for config key <name>
-	inline const bool& getB(const string& name) { return bools.at(name); }
+    inline bool getB(const string& name) { return bools.at(name); }
 
 	//* Return integer for config key <name>
 	inline const int& getI(const string& name) { return ints.at(name); }
@@ -81,7 +81,7 @@ namespace Config {
 	bool stringValid(const string& name, const string& value);
 
 	//* Set config key <name> to bool <value>
-	inline void set(const string& name, const bool& value) {
+    inline void set(const string& name, bool value) {
 		if (_locked(name)) boolsTmp.insert_or_assign(name, value);
 		else bools.at(name) = value;
 	}

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -232,8 +232,8 @@ namespace Draw {
                      const string title, const string title2, const int num) {
 		string out;
 		if (line_color.empty()) line_color = Theme::c("div_line");
-        const auto tty_mode = Config::getB("tty_mode");
-        const auto rounded = Config::getB("rounded_corners");
+        auto tty_mode = Config::getB("tty_mode");
+        auto rounded = Config::getB("rounded_corners");
 		const string numbering = (num == 0) ? "" : Theme::c("hi_fg") + (tty_mode ? std::to_string(num) : Symbols::superscript.at(clamp(num, 0, 9)));
 		const auto& right_up = (tty_mode or not rounded ? Symbols::right_up : Symbols::round_right_up);
 		const auto& left_up = (tty_mode or not rounded ? Symbols::left_up : Symbols::round_left_up);
@@ -300,7 +300,7 @@ namespace Draw {
 		}
 
 		auto& out = Global::clock;
-		const auto& cpu_bottom = Config::getB("cpu_bottom");
+        auto cpu_bottom = Config::getB("cpu_bottom");
 		const auto& x = Cpu::x;
 		const auto y = (cpu_bottom ? Cpu::y + Cpu::height - 1 : Cpu::y);
 		const auto& width = Cpu::width;
@@ -503,9 +503,9 @@ namespace Cpu {
 	string draw(const cpu_info& cpu, const bool force_redraw, const bool data_same) {
 		if (Runner::stopping) return "";
 		if (force_redraw) redraw = true;
-		const bool show_temps = (Config::getB("check_temp") and got_sensors);
+        bool show_temps = (Config::getB("check_temp") and got_sensors);
         auto single_graph = Config::getB("cpu_single_graph");
-		const bool hide_cores = show_temps and (cpu_temp_only or not Config::getB("show_coretemp"));
+        bool hide_cores = show_temps and (cpu_temp_only or not Config::getB("show_coretemp"));
 		const int extra_width = (hide_cores ? max(6, 6 * b_column_size) : 0);
 		auto& graph_up_field = Config::getS("cpu_graph_upper");
 		auto& graph_lo_field = Config::getS("cpu_graph_lower");
@@ -1590,7 +1590,7 @@ namespace Draw {
 		//* Calculate and draw cpu box outlines
 		if (Cpu::shown) {
 			using namespace Cpu;
-			const bool show_temp = (Config::getB("check_temp") and got_sensors);
+            bool show_temp = (Config::getB("check_temp") and got_sensors);
 			width = round((double)Term::width * width_p / 100);
 			height = max(8, (int)ceil((double)Term::height * (trim(boxes) == "cpu" ? 100 : height_p) / 100));
 			x = 1;

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -106,8 +106,8 @@ namespace Draw {
 		if (redraw) banner.clear();
 		if (banner.empty()) {
 			string b_color, bg, fg, oc, letter;
-			auto& lowcolor = Config::getB("lowcolor");
-			auto& tty_mode = Config::getB("tty_mode");
+            auto lowcolor = Config::getB("lowcolor");
+            auto tty_mode = Config::getB("tty_mode");
 			for (size_t z = 0; const auto& line : Global::Banner_src) {
 				if (const auto w = ulen(line[1]); w > width) width = w;
 				if (tty_mode) {
@@ -232,8 +232,8 @@ namespace Draw {
                      const string title, const string title2, const int num) {
 		string out;
 		if (line_color.empty()) line_color = Theme::c("div_line");
-		const auto& tty_mode = Config::getB("tty_mode");
-		const auto& rounded = Config::getB("rounded_corners");
+        const auto tty_mode = Config::getB("tty_mode");
+        const auto rounded = Config::getB("rounded_corners");
 		const string numbering = (num == 0) ? "" : Theme::c("hi_fg") + (tty_mode ? std::to_string(num) : Symbols::superscript.at(clamp(num, 0, 9)));
 		const auto& right_up = (tty_mode or not rounded ? Symbols::right_up : Symbols::round_right_up);
 		const auto& left_up = (tty_mode or not rounded ? Symbols::left_up : Symbols::round_left_up);
@@ -504,16 +504,16 @@ namespace Cpu {
 		if (Runner::stopping) return "";
 		if (force_redraw) redraw = true;
 		const bool show_temps = (Config::getB("check_temp") and got_sensors);
-		auto& single_graph = Config::getB("cpu_single_graph");
+        auto single_graph = Config::getB("cpu_single_graph");
 		const bool hide_cores = show_temps and (cpu_temp_only or not Config::getB("show_coretemp"));
 		const int extra_width = (hide_cores ? max(6, 6 * b_column_size) : 0);
 		auto& graph_up_field = Config::getS("cpu_graph_upper");
 		auto& graph_lo_field = Config::getS("cpu_graph_lower");
-		auto& tty_mode = Config::getB("tty_mode");
+        auto tty_mode = Config::getB("tty_mode");
 		auto& graph_symbol = (tty_mode ? "tty" : Config::getS("graph_symbol_cpu"));
 		auto& graph_bg = Symbols::graph_symbols.at((graph_symbol == "default" ? Config::getS("graph_symbol") + "_up" : graph_symbol + "_up")).at(6);
 		auto& temp_scale = Config::getS("temp_scale");
-		auto& cpu_bottom = Config::getB("cpu_bottom");
+        auto cpu_bottom = Config::getB("cpu_bottom");
 		const string& title_left = Theme::c("cpu_box") + (cpu_bottom ? Symbols::title_left_down : Symbols::title_left);
 		const string& title_right = Theme::c("cpu_box") + (cpu_bottom ? Symbols::title_right_down : Symbols::title_right);
 		static int bat_pos = 0, bat_len = 0;
@@ -725,14 +725,14 @@ namespace Mem {
 	string draw(const mem_info& mem, const bool force_redraw, const bool data_same) {
 		if (Runner::stopping) return "";
 		if (force_redraw) redraw = true;
-		auto& show_swap = Config::getB("show_swap");
-		auto& swap_disk = Config::getB("swap_disk");
-		auto& show_disks = Config::getB("show_disks");
-		auto& show_io_stat = Config::getB("show_io_stat");
-		auto& io_mode = Config::getB("io_mode");
-		auto& io_graph_combined = Config::getB("io_graph_combined");
-		auto& use_graphs = Config::getB("mem_graphs");
-		auto& tty_mode = Config::getB("tty_mode");
+        auto show_swap = Config::getB("show_swap");
+        auto swap_disk = Config::getB("swap_disk");
+        auto show_disks = Config::getB("show_disks");
+        auto show_io_stat = Config::getB("show_io_stat");
+        auto io_mode = Config::getB("io_mode");
+        auto io_graph_combined = Config::getB("io_graph_combined");
+        auto use_graphs = Config::getB("mem_graphs");
+        auto tty_mode = Config::getB("tty_mode");
 		auto& graph_symbol = (tty_mode ? "tty" : Config::getS("graph_symbol_mem"));
 		auto& graph_bg = Symbols::graph_symbols.at((graph_symbol == "default" ? Config::getS("graph_symbol") + "_up" : graph_symbol + "_up")).at(6);
 		auto totalMem = Mem::get_totalMem();
@@ -979,9 +979,9 @@ namespace Net {
 	string draw(const net_info& net, const bool force_redraw, const bool data_same) {
 		if (Runner::stopping) return "";
 		if (force_redraw) redraw = true;
-		auto& net_sync = Config::getB("net_sync");
-		auto& net_auto = Config::getB("net_auto");
-		auto& tty_mode = Config::getB("tty_mode");
+        auto net_sync = Config::getB("net_sync");
+        auto net_auto = Config::getB("net_auto");
+        auto tty_mode = Config::getB("tty_mode");
 		auto& graph_symbol = (tty_mode ? "tty" : Config::getS("graph_symbol_net"));
 		string ip_addr = (net.ipv4.empty() ? net.ipv6 : net.ipv4);
 		if (old_ip != ip_addr) {
@@ -1090,7 +1090,7 @@ namespace Proc {
 		auto selected = Config::getI("proc_selected");
 		auto last_selected = Config::getI("proc_last_selected");
 		const int select_max = (Config::getB("show_detailed") ? Proc::select_max - 8 : Proc::select_max);
-		auto& vim_keys = Config::getB("vim_keys");
+        auto vim_keys = Config::getB("vim_keys");
 
 		int numpids = Proc::numpids;
 		if ((cmd_key == "up" or (vim_keys and cmd_key == "k")) and selected > 0) {
@@ -1147,16 +1147,16 @@ namespace Proc {
 
 	string draw(const vector<proc_info>& plist, const bool force_redraw, const bool data_same) {
 		if (Runner::stopping) return "";
-		auto& proc_tree = Config::getB("proc_tree");
+        auto proc_tree = Config::getB("proc_tree");
 		const bool show_detailed = (Config::getB("show_detailed") and cmp_equal(Proc::detailed.last_pid, Config::getI("detailed_pid")));
 		const bool proc_gradient = (Config::getB("proc_gradient") and not Config::getB("lowcolor") and Theme::gradients.contains("proc"));
-		auto& proc_colors = Config::getB("proc_colors");
-		auto& tty_mode = Config::getB("tty_mode");
+        auto proc_colors = Config::getB("proc_colors");
+        auto tty_mode = Config::getB("tty_mode");
 		auto& graph_symbol = (tty_mode ? "tty" : Config::getS("graph_symbol_proc"));
 		auto& graph_bg = Symbols::graph_symbols.at((graph_symbol == "default" ? Config::getS("graph_symbol") + "_up" : graph_symbol + "_up")).at(6);
-		auto& mem_bytes = Config::getB("proc_mem_bytes");
-		auto& vim_keys = Config::getB("vim_keys");
-		auto& show_graphs = Config::getB("proc_cpu_graphs");
+        auto mem_bytes = Config::getB("proc_mem_bytes");
+        auto vim_keys = Config::getB("vim_keys");
+        auto show_graphs = Config::getB("proc_cpu_graphs");
 		start = Config::getI("proc_start");
 		selected = Config::getI("proc_selected");
 		const int y = show_detailed ? Proc::y + 8 : Proc::y;
@@ -1263,7 +1263,7 @@ namespace Proc {
 			}
 
 			//? Filter
-			auto& filtering = Config::getB("proc_filtering"); // ? filter(20) : Config::getS("proc_filter"))
+            auto filtering = Config::getB("proc_filtering"); // ? filter(20) : Config::getS("proc_filter"))
 			const auto filter_text = (filtering) ? filter(max(6, width - 58)) : uresize(Config::getS("proc_filter"), max(6, width - 58));
 			out += Mv::to(y, x+9) + title_left + (not filter_text.empty() ? Fx::b : "") + Theme::c("hi_fg") + 'f'
 				+ Theme::c("title") + (not filter_text.empty() ? ' ' + filter_text : "ilter")
@@ -1557,10 +1557,10 @@ namespace Draw {
 	void calcSizes() {
 		atomic_wait(Runner::active);
 		Config::unlock();
-		auto& boxes = Config::getS("shown_boxes");
-		auto& cpu_bottom = Config::getB("cpu_bottom");
-		auto& mem_below_net = Config::getB("mem_below_net");
-		auto& proc_left = Config::getB("proc_left");
+        auto boxes = Config::getS("shown_boxes");
+        auto cpu_bottom = Config::getB("cpu_bottom");
+        auto mem_below_net = Config::getB("mem_below_net");
+        auto proc_left = Config::getB("proc_left");
 
 		Cpu::box.clear();
 		Mem::box.clear();
@@ -1629,9 +1629,9 @@ namespace Draw {
 		//* Calculate and draw mem box outlines
 		if (Mem::shown) {
 			using namespace Mem;
-			auto& show_disks = Config::getB("show_disks");
-			auto& swap_disk = Config::getB("swap_disk");
-			auto& mem_graphs = Config::getB("mem_graphs");
+            auto show_disks = Config::getB("show_disks");
+            auto swap_disk = Config::getB("swap_disk");
+            auto mem_graphs = Config::getB("mem_graphs");
 
 			width = round((double)Term::width * (Proc::shown ? width_p : 100) / 100);
 			height = ceil((double)Term::height * (100 - Cpu::height_p * Cpu::shown - Net::height_p * Net::shown) / 100) + 1;

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -238,8 +238,8 @@ namespace Input {
 	void process(const string& key) {
 		if (key.empty()) return;
 		try {
-			auto& filtering = Config::getB("proc_filtering");
-			auto& vim_keys = Config::getB("vim_keys");
+            auto filtering = Config::getB("proc_filtering");
+            auto vim_keys = Config::getB("vim_keys");
 			auto help_key = (vim_keys ? "H" : "h");
 			auto kill_key = (vim_keys ? "K" : "k");
 			//? Global input actions

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -929,7 +929,7 @@ namespace Menu {
         static int selected{};  // defaults to 0
 		static vector<string> colors_selected;
 		static vector<string> colors_normal;
-		auto& tty_mode = Config::getB("tty_mode");
+        auto tty_mode = Config::getB("tty_mode");
 		if (bg.empty()) selected = 0;
 		int retval = Changed;
 
@@ -1034,8 +1034,8 @@ namespace Menu {
 			{"cpu_sensor", std::cref(Cpu::available_sensors)},
 			{"selected_battery", std::cref(Config::available_batteries)},
 		};
-		auto& tty_mode = Config::getB("tty_mode");
-		auto& vim_keys = Config::getB("vim_keys");
+        auto tty_mode = Config::getB("tty_mode");
+        auto vim_keys = Config::getB("vim_keys");
 		if (max_items == 0) {
 			for (const auto& cat : categories) {
 				if ((int)cat.size() > max_items) max_items = cat.size();

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -632,8 +632,8 @@ namespace Menu {
 	msgBox::msgBox() {}
 	msgBox::msgBox(int width, int boxtype, vector<string> content, string title)
 	: width(width), boxtype(boxtype) {
-		const auto& tty_mode = Config::getB("tty_mode");
-		const auto& rounded = Config::getB("rounded_corners");
+        auto tty_mode = Config::getB("tty_mode");
+        auto rounded = Config::getB("rounded_corners");
 		const auto& right_up = (tty_mode or not rounded ? Symbols::right_up : Symbols::round_right_up);
 		const auto& left_up = (tty_mode or not rounded ? Symbols::left_up : Symbols::round_left_up);
 		const auto& right_down = (tty_mode or not rounded ? Symbols::right_down : Symbols::round_right_down);
@@ -722,7 +722,7 @@ namespace Menu {
 	};
 
 	int signalChoose(const string& key) {
-		auto& s_pid = (Config::getB("show_detailed") and Config::getI("selected_pid") == 0 ? Config::getI("detailed_pid") : Config::getI("selected_pid"));
+        auto s_pid = (Config::getB("show_detailed") and Config::getI("selected_pid") == 0 ? Config::getI("detailed_pid") : Config::getI("selected_pid"));
         static int x{}; // defaults to 0
         static int y{}; // defaults to 0
         static int selected_signal = -1;
@@ -852,7 +852,7 @@ namespace Menu {
 	}
 
 	int signalSend(const string& key) {
-		auto& s_pid = (Config::getB("show_detailed") and Config::getI("selected_pid") == 0 ? Config::getI("detailed_pid") : Config::getI("selected_pid"));
+        auto s_pid = (Config::getB("show_detailed") and Config::getI("selected_pid") == 0 ? Config::getI("detailed_pid") : Config::getI("selected_pid"));
 		if (s_pid == 0) return Closed;
 		if (redraw) {
 			atomic_wait(Runner::active);

--- a/src/btop_theme.cpp
+++ b/src/btop_theme.cpp
@@ -157,7 +157,7 @@ namespace Theme {
 		}
 	}
 
-	string hex_to_color(string hexa, const bool& t_to_256, const string& depth) {
+    string hex_to_color(string hexa, bool t_to_256, const string& depth) {
 		if (hexa.size() > 1) {
 			hexa.erase(0, 1);
             for (auto& c : hexa) {
@@ -196,7 +196,7 @@ namespace Theme {
 		return "";
 	}
 
-	string dec_to_color(int r, int g, int b, const bool& t_to_256, const string& depth) {
+    string dec_to_color(int r, int g, int b, bool t_to_256, const string& depth) {
 		string pre = Fx::e + (depth == "fg" ? "38" : "48") + ";" + (t_to_256 ? "5;" : "2;");
 		r = std::clamp(r, 0, 255);
 		g = std::clamp(g, 0, 255);
@@ -234,7 +234,7 @@ namespace Theme {
 		void generateColors(const unordered_flat_map<string, string>& source) {
 			vector<string> t_rgb;
 			string depth;
-			const bool& t_to_256 = Config::getB("lowcolor");
+            bool t_to_256 = Config::getB("lowcolor");
 			colors.clear(); rgbs.clear();
 			for (const auto& [name, color] : Default_theme) {
 				if (name == "main_bg" and not Config::getB("theme_background")) {
@@ -297,7 +297,7 @@ namespace Theme {
 		//* Generate color gradients from two or three colors, 101 values indexed 0-100
 		void generateGradients() {
 			gradients.clear();
-			const bool& t_to_256 = Config::getB("lowcolor");
+            bool t_to_256 = Config::getB("lowcolor");
 
 			//? Insert values for processes greyscale gradient and processes color gradient
             rgbs.insert({

--- a/src/btop_theme.hpp
+++ b/src/btop_theme.hpp
@@ -40,13 +40,13 @@ namespace Theme {
 	//* Args	hexa: ["#000000"-"#ffffff"] for color, ["#00"-"#ff"] for greyscale
 	//*			t_to_256: [true|false] convert 24bit value to 256 color value
 	//* 		depth: ["fg"|"bg"] for either a foreground color or a background color
-	string hex_to_color(string hexa, const bool& t_to_256=false, const string& depth="fg");
+    string hex_to_color(string hexa, bool t_to_256=false, const string& depth="fg");
 
 	//* Generate escape sequence for 24-bit or 256 color and return as a string
 	//* Args	r: [0-255], g: [0-255], b: [0-255]
 	//*			t_to_256: [true|false] convert 24bit value to 256 color value
 	//* 		depth: ["fg"|"bg"] for either a foreground color or a background color
-	string dec_to_color(int r, int g, int b, const bool& t_to_256=false, const string& depth="fg");
+    string dec_to_color(int r, int g, int b, bool t_to_256=false, const string& depth="fg");
 
 	//* Update list of paths for available themes
 	void updateThemes();

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -349,7 +349,7 @@ namespace Tools {
 	string floating_humanizer(uint64_t value, const bool shorten, size_t start, const bool bit, const bool per_second) {
 		string out;
 		const size_t mult = (bit) ? 8 : 1;
-		const bool mega = Config::getB("base_10_sizes");
+        bool mega = Config::getB("base_10_sizes");
 
         // taking advantage of type deduction for array creation (since C++17)
         // combined with string literals (operator""s)

--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -614,9 +614,9 @@ namespace Mem {
 		if (Runner::stopping or (no_update and not current_mem.percent.at("used").empty()))
 			return current_mem;
 
-		auto &show_swap = Config::getB("show_swap");
-		auto &show_disks = Config::getB("show_disks");
-		auto &swap_disk = Config::getB("swap_disk");
+        auto show_swap = Config::getB("show_swap");
+        auto show_disks = Config::getB("show_disks");
+        auto swap_disk = Config::getB("swap_disk");
 		auto &mem = current_mem;
 		static const bool snapped = (getenv("BTOP_SNAPPED") != NULL);
 
@@ -670,7 +670,7 @@ namespace Mem {
 			double uptime = system_uptime();
 			auto &disks_filter = Config::getS("disks_filter");
 			bool filter_exclude = false;
-			// auto &only_physical = Config::getB("only_physical");
+            // auto only_physical = Config::getB("only_physical");
 			auto &disks = mem.disks;
 			vector<string> filter;
 			if (not disks_filter.empty()) {
@@ -806,8 +806,8 @@ namespace Net {
 	auto collect(const bool no_update) -> net_info & {
 		auto &net = current_net;
 		auto &config_iface = Config::getS("net_iface");
-		auto &net_sync = Config::getB("net_sync");
-		auto &net_auto = Config::getB("net_auto");
+        auto net_sync = Config::getB("net_sync");
+        auto net_auto = Config::getB("net_auto");
 		auto new_timestamp = time_ms();
 
 		if (not no_update and errors < 3) {
@@ -1080,11 +1080,11 @@ namespace Proc {
 	//* Collects and sorts process information from /proc
 	auto collect(const bool no_update) -> vector<proc_info> & {
 		const auto &sorting = Config::getS("proc_sorting");
-		const auto &reverse = Config::getB("proc_reversed");
+        auto reverse = Config::getB("proc_reversed");
 		const auto &filter = Config::getS("proc_filter");
-		const auto &per_core = Config::getB("proc_per_core");
-		const auto &tree = Config::getB("proc_tree");
-		const auto &show_detailed = Config::getB("show_detailed");
+        auto per_core = Config::getB("proc_per_core");
+        auto tree = Config::getB("proc_tree");
+        auto show_detailed = Config::getB("show_detailed");
 		const size_t detailed_pid = Config::getI("detailed_pid");
 		bool should_filter = current_filter != filter;
 		if (should_filter) current_filter = filter;

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -808,10 +808,10 @@ namespace Mem {
 
 	auto collect(const bool no_update) -> mem_info& {
 		if (Runner::stopping or (no_update and not current_mem.percent.at("used").empty())) return current_mem;
-		auto& show_swap = Config::getB("show_swap");
-		auto& swap_disk = Config::getB("swap_disk");
-		auto& show_disks = Config::getB("show_disks");
-		auto& zfs_arc_cached = Config::getB("zfs_arc_cached");
+        auto show_swap = Config::getB("show_swap");
+        auto swap_disk = Config::getB("swap_disk");
+        auto show_disks = Config::getB("show_disks");
+        auto zfs_arc_cached = Config::getB("zfs_arc_cached");
 		auto totalMem = get_totalMem();
 		auto& mem = current_mem;
 
@@ -899,9 +899,9 @@ namespace Mem {
 			try {
 				auto& disks_filter = Config::getS("disks_filter");
 				bool filter_exclude = false;
-				auto& use_fstab = Config::getB("use_fstab");
-				auto& only_physical = Config::getB("only_physical");
-				auto& zfs_hide_datasets = Config::getB("zfs_hide_datasets");
+                auto use_fstab = Config::getB("use_fstab");
+                auto only_physical = Config::getB("only_physical");
+                auto zfs_hide_datasets = Config::getB("zfs_hide_datasets");
 				auto& disks = mem.disks;
 				ifstream diskread;
 
@@ -1327,8 +1327,8 @@ namespace Net {
 	auto collect(const bool no_update) -> net_info& {
 		auto& net = current_net;
 		auto& config_iface = Config::getS("net_iface");
-		auto& net_sync = Config::getB("net_sync");
-		auto& net_auto = Config::getB("net_auto");
+        auto net_sync = Config::getB("net_sync");
+        auto net_auto = Config::getB("net_auto");
 		auto new_timestamp = time_ms();
 
 		if (not no_update and errors < 3) {

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -1614,12 +1614,12 @@ namespace Proc {
 	//* Collects and sorts process information from /proc
 	auto collect(const bool no_update) -> vector<proc_info>& {
 		const auto& sorting = Config::getS("proc_sorting");
-		const auto& reverse = Config::getB("proc_reversed");
+        auto reverse = Config::getB("proc_reversed");
 		const auto& filter = Config::getS("proc_filter");
-		const auto& per_core = Config::getB("proc_per_core");
-		const auto& should_filter_kernel = Config::getB("proc_filter_kernel");
-		const auto& tree = Config::getB("proc_tree");
-		const auto& show_detailed = Config::getB("show_detailed");
+        auto per_core = Config::getB("proc_per_core");
+        auto should_filter_kernel = Config::getB("proc_filter_kernel");
+        auto tree = Config::getB("proc_tree");
+        auto show_detailed = Config::getB("show_detailed");
 		const size_t detailed_pid = Config::getI("detailed_pid");
 		bool should_filter = current_filter != filter;
 		if (should_filter) current_filter = filter;

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -666,9 +666,9 @@ namespace Mem {
 		if (Runner::stopping or (no_update and not current_mem.percent.at("used").empty()))
 			return current_mem;
 
-		auto &show_swap = Config::getB("show_swap");
-		auto &show_disks = Config::getB("show_disks");
-		auto &swap_disk = Config::getB("swap_disk");
+        auto show_swap = Config::getB("show_swap");
+        auto show_disks = Config::getB("show_disks");
+        auto swap_disk = Config::getB("swap_disk");
 		auto &mem = current_mem;
 		static const bool snapped = (getenv("BTOP_SNAPPED") != NULL);
 
@@ -712,7 +712,7 @@ namespace Mem {
 			double uptime = system_uptime();
 			auto &disks_filter = Config::getS("disks_filter");
 			bool filter_exclude = false;
-			// auto &only_physical = Config::getB("only_physical");
+            // auto only_physical = Config::getB("only_physical");
 			auto &disks = mem.disks;
 			vector<string> filter;
 			if (not disks_filter.empty()) {
@@ -845,8 +845,8 @@ namespace Net {
 	auto collect(const bool no_update) -> net_info & {
 		auto &net = current_net;
 		auto &config_iface = Config::getS("net_iface");
-		auto &net_sync = Config::getB("net_sync");
-		auto &net_auto = Config::getB("net_auto");
+        auto net_sync = Config::getB("net_sync");
+        auto net_auto = Config::getB("net_auto");
 		auto new_timestamp = time_ms();
 
 		if (not no_update and errors < 3) {
@@ -1108,11 +1108,11 @@ namespace Proc {
 	//* Collects and sorts process information from /proc
 	auto collect(const bool no_update) -> vector<proc_info> & {
 		const auto &sorting = Config::getS("proc_sorting");
-		const auto &reverse = Config::getB("proc_reversed");
+        auto reverse = Config::getB("proc_reversed");
 		const auto &filter = Config::getS("proc_filter");
-		const auto &per_core = Config::getB("proc_per_core");
-		const auto &tree = Config::getB("proc_tree");
-		const auto &show_detailed = Config::getB("show_detailed");
+        auto per_core = Config::getB("proc_per_core");
+        auto tree = Config::getB("proc_tree");
+        auto show_detailed = Config::getB("show_detailed");
 		const size_t detailed_pid = Config::getI("detailed_pid");
 		bool should_filter = current_filter != filter;
 		if (should_filter) current_filter = filter;


### PR DESCRIPTION
It does not make sense to return a `const bool&` as we are dealing with Boolean literals that are `prvalue`s of type bool.

The compiler is smart enough to do the necessary optimizations wherever is applicable.

@aristocratos can you double-check the whole code in case it breaks somewhere? I have updated the code for OS X and FreeBSD, but I don't use those two aforementioned OS-es to test them myself.