### PR TITLE
fix: spelling mistake in btop.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ force_tty = False
 
 #* Define presets for the layout of the boxes. Preset 0 is always all boxes shown with default settings. Max 9 presets.
 #* Format: "box_name:P:G,box_name:P:G" P=(0 or 1) for alternate positions, G=graph symbol to use for box.
-#* Use withespace " " as separator between different presets.
+#* Use whitespace " " as separator between different presets.
 #* Example: "cpu:0:default,mem:0:tty,proc:1:default cpu:0:braille,proc:0:tty"
 presets = "cpu:1:default,proc:0:default cpu:0:default,mem:0:default,net:0:default cpu:0:block,net:0:tty"
 

--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -56,7 +56,7 @@ namespace Config {
 
 		{"presets",				"#* Define presets for the layout of the boxes. Preset 0 is always all boxes shown with default settings. Max 9 presets.\n"
 								"#* Format: \"box_name:P:G,box_name:P:G\" P=(0 or 1) for alternate positions, G=graph symbol to use for box.\n"
-								"#* Use withespace \" \" as separator between different presets.\n"
+								"#* Use whitespace \" \" as separator between different presets.\n"
 								"#* Example: \"cpu:0:default,mem:0:tty,proc:1:default cpu:0:braille,proc:0:tty\""},
 
 		{"vim_keys",			"#* Set to True to enable \"h,j,k,l,g,G\" keys for directional control in lists.\n"

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -207,7 +207,7 @@ namespace Menu {
 				"P=(0 or 1) for alternate positions.",
 				"G=graph symbol to use for box.",
 				"",
-				"Use withespace \" \" as separator between",
+				"Use whitespace \" \" as separator between",
 				"different presets.",
 				"",
 				"Example:",


### PR DESCRIPTION
I noticed this kept getting generated when tweaking my `btop.conf`.
I don't know if the readme is auto-generated but it appears to have the same typo.