### PR TITLE
proc tree: fix display bug when displaying full cmd

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1474,7 +1474,7 @@ namespace Proc {
 					width_left -= (ulen(p.name) + 1);
 				}
 				if (width_left > 7) {
-					const string& cmd = width_left > 40 ? p.cmd : p.short_cmd;
+					const string& cmd = width_left > 40 ? rtrim(p.cmd) : p.short_cmd;
 					if (not cmd.empty() and cmd != p.name) {
 						out += g_color + '(' + uresize(cmd, width_left - 3, p_wide_cmd[p.pid]) + ") ";
 						width_left -= (ulen(cmd, true) + 3);

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1473,8 +1473,8 @@ namespace Proc {
 					out += c_color + uresize(p.name, width_left - 1) + end + ' ';
 					width_left -= (ulen(p.name) + 1);
 				}
-				if (width_left > 30 || (width_left > 7 && p.short_cmd != p.name)) {
-					out += g_color + '(' + uresize(width_left > 30 ? p.cmd : p.short_cmd, width_left - 3, p_wide_cmd[p.pid]) + ") ";
+				if (width_left > 40 or (width_left > 7 and p.short_cmd != p.name)) {
+					out += g_color + '(' + uresize(width_left > 40 ? p.cmd : p.short_cmd, width_left - 3, p_wide_cmd[p.pid]) + ") ";
 					width_left -= (ulen(p.short_cmd, true) + 3);
 				}
 				out += string(max(0, width_left), ' ') + Mv::to(y+2+lc, x+2+tree_size);

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1473,9 +1473,12 @@ namespace Proc {
 					out += c_color + uresize(p.name, width_left - 1) + end + ' ';
 					width_left -= (ulen(p.name) + 1);
 				}
-				if (width_left > 40 or (width_left > 7 and p.short_cmd != p.name)) {
-					out += g_color + '(' + uresize(width_left > 40 ? p.cmd : p.short_cmd, width_left - 3, p_wide_cmd[p.pid]) + ") ";
-					width_left -= (ulen(p.short_cmd, true) + 3);
+				if (width_left > 7) {
+					const string& cmd = width_left > 40 ? p.cmd : p.short_cmd;
+					if (not cmd.empty() and cmd != p.name) {
+						out += g_color + '(' + uresize(cmd, width_left - 3, p_wide_cmd[p.pid]) + ") ";
+						width_left -= (ulen(cmd, true) + 3);
+					}
 				}
 				out += string(max(0, width_left), ' ') + Mv::to(y+2+lc, x+2+tree_size);
 			}


### PR DESCRIPTION
Also don't show the cmd if it's empty, this seems to happen for kernel processes. Also update width threshold to 40.