### PR TITLE
Show the first IP of the interface in NET box [on Linux]

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -1393,27 +1393,35 @@ namespace Net {
 			string ipv4, ipv6;
 
 			//? Iteration over all items in getifaddrs() list
-            for (auto* ifa = if_wrap(); ifa != NULL; ifa = ifa->ifa_next) {
+			for (auto* ifa = if_wrap(); ifa != NULL; ifa = ifa->ifa_next) {
 				if (ifa->ifa_addr == NULL) continue;
 				family = ifa->ifa_addr->sa_family;
 				const auto& iface = ifa->ifa_name;
-
-				//? Get IPv4 address
-				if (family == AF_INET) {
-					if (getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in), ip, NI_MAXHOST, NULL, 0, NI_NUMERICHOST) == 0)
-						net[iface].ipv4 = ip;
-				}
-				//? Get IPv6 address
-				else if (family == AF_INET6) {
-					if (getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in6), ip, NI_MAXHOST, NULL, 0, NI_NUMERICHOST) == 0)
-						net[iface].ipv6 = ip;
-				}
 
 				//? Update available interfaces vector and get status of interface
 				if (not v_contains(interfaces, iface)) {
 					interfaces.push_back(iface);
 					net[iface].connected = (ifa->ifa_flags & IFF_RUNNING);
+
+					// An interface can have more than one IP of the same family associated with it,
+					// but we pick only the first one to show in the NET box.
+					// Note: Interfaces without any IPv4 and IPv6 set are still valid and monitorable!
+					net[iface].ipv4.clear();
+					net[iface].ipv6.clear();
 				}
+
+				//? Get IPv4 address
+				if (family == AF_INET) {
+					if (net[iface].ipv4.empty() and 
+						getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in), ip, NI_MAXHOST, NULL, 0, NI_NUMERICHOST) == 0)
+						net[iface].ipv4 = ip;
+				}
+				//? Get IPv6 address
+				else if (family == AF_INET6) {
+					if (net[iface].ipv6.empty() and 
+						getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in6), ip, NI_MAXHOST, NULL, 0, NI_NUMERICHOST) == 0)
+						net[iface].ipv6 = ip;
+				} //else, ignoring family==AF_PACKET (see man 3 getifaddrs) which is the first one in the `for` loop.
 			}
 
 			//? Get total recieved and transmitted bytes + device address if no ip was found


### PR DESCRIPTION
... instead of the last.

Also, indented the `for` statement with tabs rather than spaces.

Closes #456

<details>
<summary>irrelevant details here</summary>

Notes:
I moved up the `if (not v_contains(interfaces, iface)) {` because I'm also able to use it to reset/empty the IP string value for the current interface in the `for` loop, thus allowing me to detect the first time this specific `iface` is seen in the IPv4/IPv6 context and thus assigning only the first encounter of the IP address for this `iface` while parsing getifaddrs() results, even if the results aren't grouped by the `iface`.

This PR, unlike the OP patch in #456, will continuously refresh the interfaces and their IPs, and thus is still sensitive to interface IP changes.
</details>


Side Note: I'll make another PR for the `inet_ntop` part of #456 ideally after this PR is merged(to avoid unnecessary conflicts), and it's okay if this PR closes it.