### PR TITLE
Replace  getnameinfo  with  inet_ntop [on Linux]

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -26,6 +26,8 @@ tab-size = 4
 #include <netdb.h>
 #include <ifaddrs.h>
 #include <net/if.h>
+#include <arpa/inet.h> // for inet_ntop()
+
 
 #if !(defined(STATIC_BUILD) && defined(__GLIBC__))
 	#include <pwd.h>
@@ -1388,7 +1390,13 @@ namespace Net {
 				return empty_net;
 			}
 			int family = 0;
-			char ip[NI_MAXHOST];
+			static_assert(INET6_ADDRSTRLEN >= INET_ADDRSTRLEN); // 46 >= 16, compile-time assurance.
+#if defined(IPBUFFER_MAXSIZE)
+#error Overwriting a previous macro with the same name: IPBUFFER_MAXSIZE, this means you likely need to rename this one here!
+#else
+#define IPBUFFER_MAXSIZE (INET6_ADDRSTRLEN) // manually using the known biggest value, guarded by the above static_assert
+#endif
+			char ip[IPBUFFER_MAXSIZE];
 			interfaces.clear();
 			string ipv4, ipv6;
 
@@ -1410,19 +1418,35 @@ namespace Net {
 					net[iface].ipv6.clear();
 				}
 
+
 				//? Get IPv4 address
 				if (family == AF_INET) {
-					if (net[iface].ipv4.empty() and 
-						getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in), ip, NI_MAXHOST, NULL, 0, NI_NUMERICHOST) == 0)
-						net[iface].ipv4 = ip;
+					if (net[iface].ipv4.empty()) {
+						if (NULL != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr)->sin_addr), ip, IPBUFFER_MAXSIZE)) {
+							net[iface].ipv4 = ip;
+						} else {
+							int errsv = errno;
+							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+						}
+					}
 				}
 				//? Get IPv6 address
 				else if (family == AF_INET6) {
-					if (net[iface].ipv6.empty() and 
-						getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in6), ip, NI_MAXHOST, NULL, 0, NI_NUMERICHOST) == 0)
-						net[iface].ipv6 = ip;
+					if (net[iface].ipv6.empty()) {
+						if (NULL != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in6*>(ifa->ifa_addr)->sin6_addr), ip, IPBUFFER_MAXSIZE)) {
+							net[iface].ipv6 = ip;
+						} else {
+							int errsv = errno;
+							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+						}
+					}
 				} //else, ignoring family==AF_PACKET (see man 3 getifaddrs) which is the first one in the `for` loop.
 			}
+#if defined(IPBUFFER_MAXSIZE)
+#undef IPBUFFER_MAXSIZE
+#else
+#error whoa, the programmer forgot something, eg. was this renamed?
+#endif
 
 			//? Get total recieved and transmitted bytes + device address if no ip was found
 			for (const auto& iface : interfaces) {

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -1391,11 +1391,7 @@ namespace Net {
 			}
 			int family = 0;
 			static_assert(INET6_ADDRSTRLEN >= INET_ADDRSTRLEN); // 46 >= 16, compile-time assurance.
-#if defined(IPBUFFER_MAXSIZE)
-#error Overwriting a previous macro with the same name: IPBUFFER_MAXSIZE, this means you likely need to rename this one here!
-#else
-#define IPBUFFER_MAXSIZE (INET6_ADDRSTRLEN) // manually using the known biggest value, guarded by the above static_assert
-#endif
+			enum { IPBUFFER_MAXSIZE = INET6_ADDRSTRLEN }; // manually using the known biggest value, guarded by the above static_assert
 			char ip[IPBUFFER_MAXSIZE];
 			interfaces.clear();
 			string ipv4, ipv6;
@@ -1442,11 +1438,6 @@ namespace Net {
 					}
 				} //else, ignoring family==AF_PACKET (see man 3 getifaddrs) which is the first one in the `for` loop.
 			}
-#if defined(IPBUFFER_MAXSIZE)
-#undef IPBUFFER_MAXSIZE
-#else
-#error whoa, the programmer forgot something, eg. was this renamed?
-#endif
 
 			//? Get total recieved and transmitted bytes + device address if no ip was found
 			for (const auto& iface : interfaces) {


### PR DESCRIPTION
saves 979 bytes of reserved buffer because:
NI_MAXHOST is 1025 bytes
and
INET6_ADDRSTRLEN is 46


Depends on PR #457 being merged first.

I'm not sure how, having this PR created before PR #457 is merged, will work, but we'll see what I'll have to do(git-wise) to not mess things up. I'm not against making it a new PR if this one is breaking things too much (ie. because the commit from PR #457 is included in this PR, which can't be good)


<s>**EDIT:** I didn't physically test the IPv6 part (I've disabled ipv6 in too many places, but maybe I will do it in a virtualbox)</s>
**EDIT2:** I've now tested the IPv6 part too, `btop` shows IPv6 only if there's no IPv4 and only if the window is horizontally large enough to show the numeric IPv6. For some reason the previous behavior was different in that: 1. removing the IPv4 from the interface while `btop` is running, keeps showing the old IPv4, 2. the IPv6 shown has "%devnamehere" appended to it (eg. "%enp0s3"), but otherwise with this PR it behaves as I would normally expect it, fixing the above 2 issues. So, I guess, there's more good reasons to use `inet_ntop` than I had previously thought.

**EDIT3:** When using `gnome-control-center network` (eg. a shell command) to configure the interface, (manually-, only? probably not)assigning the interface an IP in the block 169.254.0.0/16 will cause this IP to be first when seen by `ip addr` (command) and thus `btop` shows this as the IP (due to PR #457) but old `btop` shows the last IP which would be the right one, in this case. This is because https://en.wikipedia.org/wiki/Private_network#Link-local_addresses and I guess this is why they're first in the list. So this only happens for the 169.254.0.0/16 IPs.