### PR TITLE
FreeBSD: replace getnameinfo with inet_ntop

### DIFF
--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -27,6 +27,7 @@ tab-size = 4
 #include <net/route.h>
 #include <netdb.h>
 #include <netinet/tcp_fsm.h>
+#include <netinet/in.h> // for inet_ntop stuff
 #include <pwd.h>
 #include <sys/_timeval.h>
 #include <sys/endian.h>
@@ -821,7 +822,9 @@ namespace Net {
 				return empty_net;
 			}
 			int family = 0;
-			char ip[NI_MAXHOST];
+			static_assert(INET6_ADDRSTRLEN >= INET_ADDRSTRLEN); // 46 >= 16, compile-time assurance.
+			enum { IPBUFFER_MAXSIZE = INET6_ADDRSTRLEN }; // manually using the known biggest value, guarded by the above static_assert
+			char ip[IPBUFFER_MAXSIZE];
 			interfaces.clear();
 			string ipv4, ipv6;
 
@@ -843,17 +846,27 @@ namespace Net {
 				}
 				//? Get IPv4 address
 				if (family == AF_INET) {
-					if (net[iface].ipv4.empty() and
-						getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr), ip, NI_MAXHOST, NULL, 0, NI_NUMERICHOST) == 0)
-						net[iface].ipv4 = ip;
+					if (net[iface].ipv4.empty()) {
+						if (NULL != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr)->sin_addr), ip, IPBUFFER_MAXSIZE)) {
+
+							net[iface].ipv4 = ip;
+						} else {
+							int errsv = errno;
+							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+						}
+					}
 				}
 				//? Get IPv6 address
-				// else if (family == AF_INET6) {
-				// 	if (net[iface].ipv6.empty() and
-				// 		getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in6), ip, NI_MAXHOST, NULL, 0, NI_NUMERICHOST) == 0)
-				// 		net[iface].ipv6 = ip;
-				// }
-
+				else if (family == AF_INET6) {
+					if (net[iface].ipv6.empty()) {
+						if (NULL != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in6*>(ifa->ifa_addr)->sin6_addr), ip, IPBUFFER_MAXSIZE)) {
+							net[iface].ipv6 = ip;
+						} else {
+							int errsv = errno;
+							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+						}
+					}
+				}
 			}
 
 			unordered_flat_map<string, std::tuple<uint64_t, uint64_t>> ifstats;


### PR DESCRIPTION
also make IPv6 work (previously it was commented out)

(re)tested it to work in freebsd 13.1 in virtualbox, not just to compile.

Note that, unlike in Linux, if all IPv4 and IPv6  IPs are missing, then the interface MAC isn't shown in their place (but this is a different issue)