### PR TITLE
a comment about AF_LINK being ignored on purpose

### DIFF
--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -866,7 +866,7 @@ namespace Net {
 							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
 						}
 					}
-				}
+				}  //else, ignoring family==AF_LINK (see man 3 getifaddrs)
 			}
 
 			unordered_flat_map<string, std::tuple<uint64_t, uint64_t>> ifstats;


### PR DESCRIPTION
PR #462 was missing this comment. I don't know if you want it or not, but for me it's good info to know that besides `AF_INET` and `AF_INET6` there's `AF_LINK` (which is [`AF_PACKET`](https://github.com/aristocratos/btop/pull/457/files#diff-ee570ba04f2b49d02794ec9f8001902d40c7cabf47397dcc87e8f5f37254cb50R1424) on linux) that is a possibility in that `for` loop there.