### PR TITLE
osx: replace getnameinfo with inet_ntop

### DIFF
--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -41,6 +41,7 @@ tab-size = 4
 #include <sys/statvfs.h>
 #include <sys/sysctl.h>
 #include <sys/types.h>
+#include <netinet/in.h> // for inet_ntop
 #include <unistd.h>
 #include <stdexcept>
 
@@ -863,7 +864,9 @@ namespace Net {
 				return empty_net;
 			}
 			int family = 0;
-			char ip[NI_MAXHOST];
+			static_assert(INET6_ADDRSTRLEN >= INET_ADDRSTRLEN); // 46 >= 16, compile-time assurance.
+			enum { IPBUFFER_MAXSIZE = INET6_ADDRSTRLEN }; // manually using the known biggest value, guarded by the above static_assert
+			char ip[IPBUFFER_MAXSIZE];
 			interfaces.clear();
 			string ipv4, ipv6;
 
@@ -884,16 +887,26 @@ namespace Net {
 				}
 				//? Get IPv4 address
 				if (family == AF_INET) {
-					if (net[iface].ipv4.empty() and
-						getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in), ip, NI_MAXHOST, NULL, 0, NI_NUMERICHOST) == 0)
-						net[iface].ipv4 = ip;
+					if (net[iface].ipv4.empty()) {
+						if (NULL != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr)->sin_addr), ip, IPBUFFER_MAXSIZE)) {
+							net[iface].ipv4 = ip;
+						} else {
+							int errsv = errno;
+							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+						}
+					}
 				}
 				//? Get IPv6 address
 				else if (family == AF_INET6) {
-					if (net[iface].ipv6.empty() and
-						getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in6), ip, NI_MAXHOST, NULL, 0, NI_NUMERICHOST) == 0)
-						net[iface].ipv6 = ip;
-				}
+					if (net[iface].ipv6.empty()) {
+						if (NULL != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in6*>(ifa->ifa_addr)->sin6_addr), ip, IPBUFFER_MAXSIZE)) {
+							net[iface].ipv6 = ip;
+						} else {
+							int errsv = errno;
+							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+						}
+					}
+				} // else, ignoring family==AF_LINK (see man 3 getifaddrs)
 			}
 
 			unordered_flat_map<string, std::tuple<uint64_t, uint64_t>> ifstats;


### PR DESCRIPTION
this is like PR #462 for FreeBSD,
and like PR #458 for Linux.

--------------

I can't test the build and run for these, as I've been unable to get macOS in virtualbox (tried 4 iso\`s). But I'll look in github actions for the build, and just **hope** the runs work fine on bare metal.

<details>
<summary>outdated info</summary>

Unsure about those `#include`\`s: is `#include <arpa/inet.h>` the same as `#include <sys/arpa/inet.h>` ? 
I've got them from:
```
LEGACY SYNOPSIS
     #include <sys/types.h>
     #include <sys/socket.h>
     #include <sys/netinet/in.h>
     #include <sys/arpa/inet.h>

     These include files are necessary for all functions.
```
src: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/inet_ntop.3.html

</details>


PS: Thank you for this learning experience btw :) (with all the PRs, not just this one)