### PR TITLE
macOS: Copy out the select process's command line 

### DIFF
--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -400,6 +400,7 @@ namespace Input {
 						Config::set("proc_last_selected", Config::getI("proc_selected"));
 						Config::set("proc_selected", 0);
 						Config::set("show_detailed", true);
+						process("copyout-shellcmd");
 					}
 					else if (Config::getB("show_detailed")) {
 						if (Config::getI("proc_last_selected") > 0) Config::set("proc_selected", Config::getI("proc_last_selected"));
@@ -436,6 +437,10 @@ namespace Input {
 						return;
 					else if (old_selected != new_selected and (old_selected == 0 or new_selected == 0))
 						redraw = true;
+				} else if (is_in(key, "copyout-shellcmd", "v")) {
+					auto procs = Proc::collect(false);
+					auto p_info = rng::find(procs, Config::getI("selected_pid"), &Proc::proc_info::pid);
+					copy_to_clipboard(p_info->cmd);
 				}
 				else keep_going = true;
 

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -597,3 +597,13 @@ namespace Logger {
 		}
 	}
 }
+
+int copy_to_clipboard(const std::string& msg) {
+#ifdef __APPLE__
+	char buf[ARG_MAX];
+	snprintf(buf, ARG_MAX, "echo \"%s\" | pbcopy", msg.c_str());
+	return system(buf);
+#elif // __APPLE__
+	return 0;
+#endif // __APPLE__
+}

--- a/src/btop_tools.hpp
+++ b/src/btop_tools.hpp
@@ -353,3 +353,4 @@ namespace Logger {
 	inline void debug(const string msg) { log_write(4, msg); }
 }
 
+int copy_to_clipboard(const std::string& msg);

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1224,7 +1224,7 @@ namespace Proc {
 								std::string_view proc_args(proc_chars.get(), argmax);
 								if (size_t null_pos = proc_args.find('\0', sizeof(argc)); null_pos != string::npos) {
 									if (size_t start_pos = proc_args.find_first_not_of('\0', null_pos); start_pos != string::npos) {
-										while (argc-- > 0 and null_pos != string::npos and cmp_less(new_proc.cmd.size(), 1000)) {
+										while (argc-- > 0 and null_pos != string::npos and cmp_less(new_proc.cmd.size(), ARG_MAX)) {
 											null_pos = proc_args.find('\0', start_pos);
 											new_proc.cmd += (string)proc_args.substr(start_pos, null_pos - start_pos) + ' ';
 											start_pos = null_pos + 1;
@@ -1235,8 +1235,8 @@ namespace Proc {
 							}
 						}
 						if (new_proc.cmd.empty()) new_proc.cmd = f_name;
-						if (new_proc.cmd.size() > 1000) {
-							new_proc.cmd.resize(1000);
+						if (new_proc.cmd.size() > ARG_MAX) {
+							new_proc.cmd.resize(ARG_MAX);
 							new_proc.cmd.shrink_to_fit();
 						}
 						new_proc.ppid = kproc.kp_eproc.e_ppid;

--- a/src/osx/smc.cpp
+++ b/src/osx/smc.cpp
@@ -34,7 +34,7 @@ static UInt32 _strtoul(char *str, int size, int base) {
 
 static void _ultostr(char *str, UInt32 val) {
 	str[0] = '\0';
-	sprintf(str, "%c%c%c%c",
+	snprintf(str, sizeof(UInt32Char_t), "%c%c%c%c",
 	        (unsigned int)val >> 24,
 	        (unsigned int)val >> 16,
 	        (unsigned int)val >> 8,


### PR DESCRIPTION
More often than not, one desires to inspect the exact (shell) command line that was used to invoke a process, especially when that process was invoked in a non-manual fashion.

macOS Activity Monitor does not offer this feature either, to the best of the author's knowledge.

**What this PR achieves**
Upon a keystroke, the full command line of the select process is copied to a clipboard.

**How to use**
* Select a process, and keypress `v`, or
* Show the process detail by `enter`

**Sample outcome**
```
/Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper.app/Contents/MacOS/Code Helper --type=utility --utility-sub-type=audio.mojom.AudioService --lang=en-US --service-sandbox-type=audio --message-loop-type-ui --user-data-dir=/Users/SOMEUSER/Library/Application Support/Code --standard-schemes=vscode-webview,vscode-file --secure-schemes=vscode-webview,vscode-file --bypasscsp-schemes --cors-schemes=vscode-webview,vscode-file --fetch-schemes=vscode-webview,vscode-file --service-worker-schemes=vscode-webview --streaming-schemes --shared-files --field-trial-handle=1718379636,r,5493000567189891038,3303168194434618476,131072 --enable-features=AutoDisableAccessibility --disable-features=CalculateNativeWinOcclusion,SpareRendererForSitePerProcess --seatbelt-client=64
```

**Enhancements**
* Supports the full length of the command line that the underlying platform supports at the time of build.
* Convert `sprintf` to `snprintf` to zap a compiler warning (g++-12)

**Limitation**
* Only macOS is supported. FreeBSD and Linux are TODO.
