### PR TITLE
[fix] fix zfs on freebsd not reporting IO

### DIFF
--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -583,8 +583,8 @@ namespace Mem {
 			if (f()) {
 				char buf[512];
 				size_t len = 512;
+				uint64_t nread = 0, nwritten = 0;
 				while (not std::feof(f())) {
-					uint64_t nread = 0, nwritten = 0;
 					if (fgets(buf, len, f())) {
 						char *name = std::strtok(buf, ": \n");
 						char *value = std::strtok(NULL, ": \n");


### PR DESCRIPTION
While processing the ZFS IO stats, `nread` and `nwritten` were getting reset every time the program examined a line in the command output, therefore when it finally was going to assign values it would always assign zeros.

Linked to #482 