### PR TITLE
Add clang support via cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ stage/
 build
 bin
 btop
+cmake-*
 .*/
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,99 @@
+# Required for platform variables
+cmake_minimum_required(VERSION 3.25)
+
+project(btop
+        VERSION 1.2.13
+        DESCRIPTION "Resource monitor that shows usage and stats for processor, memory, disks, network and processes."
+        LANGUAGES CXX)
+
+include(CheckCXXCompilerFlag)
+include(CheckIPOSupported)
+
+find_package(Threads REQUIRED)
+
+# Colorful compiler output
+set(CMAKE_COLOR_DIAGNOSTICS ON)
+
+# Detect host platform
+if (BSD)
+    set(PLATFORM_DIR freebsd)
+elseif (LINUX)
+    set(PLATFORM_DIR linux)
+elseif (APPLE)
+    set(PLATFORM_DIR osx)
+endif ()
+
+# Gather source files
+set(BTOP_SOURCES
+        src/btop.cpp
+        src/btop_config.cpp
+        src/btop_draw.cpp
+        src/btop_input.cpp
+        src/btop_menu.cpp
+        src/btop_shared.cpp
+        src/btop_theme.cpp
+        src/btop_tools.cpp
+        src/${PLATFORM_DIR}/btop_collect.cpp
+        )
+
+add_executable(btop ${BTOP_SOURCES})
+
+# Set c++ standard and enable fPIE
+set_target_properties(btop PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+        POSITION_INDEPENDENT_CODE YES
+        )
+
+target_compile_definitions(btop PRIVATE
+        $<$<CONFIG:Release>:_FORTIFY_SOURCE=2>
+        _GLIBCXX_ASSERTIONS
+        )
+
+check_cxx_compiler_flag(-fstack-clash-protection HAS_FLAG_STACK_CLASH_PROTECTION)
+if (HAS_FLAG_STACK_CLASH_PROTECTION)
+    set(COMPILE_FLAGS ${COMPILE_FLAGS} -fstack-clash-protection)
+endif ()
+check_cxx_compiler_flag(-fcf-protection HAS_FLAG_CF_PROTECTION)
+if (HAS_FLAG_CF_PROTECTION)
+    set(COMPILE_FLAGS ${COMPILE_FLAGS} -fcf-protection)
+endif ()
+check_cxx_compiler_flag(-fstack-protector HAS_FLAG_STACK_PROTECTOR)
+if (HAS_FLAG_STACK_PROTECTOR)
+    set(COMPILE_FLAGS ${COMPILE_FLAGS} -fstack-protector)
+endif ()
+# Enables -ftree-loop-vectorize with GCC which is also enabled by default with -O2
+# and is known to clang as well, unlike -ftree-loop-vectorize
+check_cxx_compiler_flag(-ftree-vectorize HAS_FLAG_TREE_VECTORIZE)
+if (HAS_FLAG_TREE_VECTORIZE)
+    set(COMPILE_FLAGS ${COMPILE_FLAGS} -ftree-vectorize)
+endif ()
+# Enable more warnings
+# Suppress clang specific messages in robin_hood.h and widechar_width.hpp
+target_compile_options(btop PRIVATE
+        -Wall -Wextra -Wpedantic
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-deprecated-builtins -Wno-deprecated-declarations>
+        ${COMPILE_FLAGS}
+        )
+
+# Make external deps known and local files to be included with <>
+target_include_directories(btop PRIVATE
+        include
+        src
+        )
+
+target_link_libraries(btop PRIVATE Threads::Threads)
+
+# Enable LTO
+check_ipo_supported(RESULT ipo_supported)
+if (ipo_supported)
+    set_target_properties(btop PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif ()
+
+# Make clang work
+# Use libcxx with clang, see: https://github.com/llvm/llvm-project/issues/55673#issuecomment-1135973337
+# Enable experimental features needed to use std::ranges::views
+target_compile_options(btop PRIVATE $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>)
+target_link_options(btop PRIVATE $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>)
+target_compile_definitions(btop PRIVATE $<$<CXX_COMPILER_ID:Clang>:_LIBCPP_ENABLE_EXPERIMENTAL>)

--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -332,7 +332,7 @@ namespace Config {
 			new_presets.push_back(preset);
 		}
 
-		preset_list = move(new_presets);
+		preset_list = std::move(new_presets);
 		return true;
 	}
 
@@ -515,7 +515,7 @@ namespace Config {
 		for (auto& box : new_boxes) {
 			if (not v_contains(valid_boxes, box)) return false;
 		}
-		current_boxes = move(new_boxes);
+		current_boxes = std::move(new_boxes);
 		return true;
 	}
 

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -1326,11 +1326,11 @@ namespace Menu {
 			optionsMenu("");
 		}
 		if (screen_redraw) {
-			auto overlay_bkp = move(Global::overlay);
-			auto clock_bkp = move(Global::clock);
+			auto overlay_bkp = std::move(Global::overlay);
+			auto clock_bkp = std::move(Global::clock);
 			Draw::calcSizes();
-			Global::overlay = move(overlay_bkp);
-			Global::clock = move(clock_bkp);
+			Global::overlay = std::move(overlay_bkp);
+			Global::clock = std::move(clock_bkp);
 			recollect = true;
 		}
 		if (recollect) {

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -17,6 +17,7 @@ tab-size = 4
 */
 
 #include <cmath>
+#include <codecvt>
 #include <iostream>
 #include <fstream>
 #include <ctime>
@@ -283,7 +284,7 @@ namespace Tools {
 
 	auto ssplit(const string& str, const char& delim) -> vector<string> {
 		vector<string> out;
-		for (const auto& s : str 	| rng::views::split(delim)
+		for (const auto& s : str 	| rng::views::lazy_split(delim)
 									| rng::views::transform([](auto &&rng) {
 										return string_view(&*rng.begin(), rng::distance(rng));
 		})) {

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -282,9 +282,13 @@ namespace Tools {
         return string{str_v};
 	}
 
+#   ifdef __clang__
+#       define split lazy_split
+#   endif
+
 	auto ssplit(const string& str, const char& delim) -> vector<string> {
 		vector<string> out;
-		for (const auto& s : str 	| rng::views::lazy_split(delim)
+        for (const auto& s : str 	| rng::views::split(delim)
 									| rng::views::transform([](auto &&rng) {
 										return string_view(&*rng.begin(), rng::distance(rng));
 		})) {
@@ -292,6 +296,10 @@ namespace Tools {
 		}
 		return out;
 	}
+
+#   ifdef __clang__
+#       undef split
+#   endif
 
     string ljust(string str, const size_t x, bool utf, bool wide, bool limit) {
 		if (utf) {


### PR DESCRIPTION
I'm not sure if this is wanted at all, but I managed to compile btop with clang.

This is still WIP and is not feature complete. I have only tested it on my am64 linux machine with clang-15.0.6 and cmake-25.1. 

I used cmake as a build system because it allowed me to include or exclude compiler flags based on the compiler quite easily

There are a few hickups: 
- We cannot use libstdc++ with clang, see https://github.com/llvm/llvm-project/issues/55673#issuecomment-1135973337.
- std::views::split isn't implemented in libc++ so I switched to std::views::lazy_split. I'm not sure if it breaks anything yet.
- We need to enable libc++'s experimental features to use <ranges>

To compile:
```
cd $BTOP_SRC_DIR
CXX=clang++ cmake -B cmake-build-release -G Ninja -DCMAKE_BUILD_TYPE=Release
cmake --build cmake-build-release -v
# Note: -G Ninja is optional
```