### PR TITLE
Replace -ftree-loop-vectorize with -ftree-vectorize.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ override GOODFLAGS := $(foreach flag,$(TESTFLAGS),$(strip $(shell echo "int main
 #? Flags, Libraries and Includes
 override REQFLAGS   := -std=c++20
 WARNFLAGS			:= -Wall -Wextra -pedantic
-OPTFLAGS			:= -O2 -ftree-loop-vectorize -flto=$(THREADS)
+OPTFLAGS			:= -O2 -ftree-vectorize -flto=$(THREADS)
 LDCXXFLAGS			:= -pthread -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS $(GOODFLAGS) $(ADDFLAGS)
 override CXXFLAGS	+= $(REQFLAGS) $(LDCXXFLAGS) $(OPTFLAGS) $(WARNFLAGS)
 override LDFLAGS	+= $(LDCXXFLAGS) $(OPTFLAGS) $(WARNFLAGS)


### PR DESCRIPTION
In preparation for LLVM support use -ftree-vectorize as it is understood by clang (unlike -ftree-loop-vectorize) and it is an umbrella for the former and -ftree-slp-vectorize. See https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html.