### PR TITLE
Linux: subtract ZFS ARC min size from available memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,9 @@ mem_graphs = True
 #* Show mem box below net box instead of above.
 mem_below_net = False
 
+#* Count ZFS ARC in cached and available memory.
+zfs_arc_cached = True
+
 #* If swap memory should be shown in memory box.
 show_swap = True
 


### PR DESCRIPTION
Also remove the barely-needed regex.

Thanks @intrigus for noticing the error.