### PR TITLE
Update everforest-dark-hard.theme

### DIFF
--- a/themes/everforest-dark-hard.theme
+++ b/themes/everforest-dark-hard.theme
@@ -1,12 +1,10 @@
-# Btop everforest dark hard theme by u/archontop.
-
 # All graphs and meters can be gradients
 # For single color graphs leave "mid" and "end" variable empty.
 # Use "start" and "end" variables for two color gradient
 # Use "start", "mid" and "end" for three color gradient
 
 # Main background, empty for terminal default, need to be empty if you want transparent background
-theme[main_bg]="#2b3339"
+theme[main_bg]="#272e33"
 
 # Main text color
 theme[main_fg]="#d3c6aa"
@@ -18,13 +16,13 @@ theme[title]="#d3c6aa"
 theme[hi_fg]="#e67e80"
 
 # Background color of selected items
-theme[selected_bg]="#4b565c"
+theme[selected_bg]="#374145"
 
 # Foreground color of selected items
 theme[selected_fg]="#dbbc7f"
 
 # Color of inactive/disabled text
-theme[inactive_fg]="#2b3339"  
+theme[inactive_fg]="#272e33"  
 
 # Color of text appearing on top of graphs, i.e uptime and current network graph scaling
 theme[graph_text]="#d3c6aa"
@@ -33,19 +31,19 @@ theme[graph_text]="#d3c6aa"
 theme[proc_misc]="#a7c080"
 
 # Cpu box outline color
-theme[cpu_box]="#4b565c"
+theme[cpu_box]="#374145"
 
 # Memory/disks box outline color
-theme[mem_box]="#4b565c"
+theme[mem_box]="#374145"
 
 # Net up/down box outline color
-theme[net_box]="#4b565c"
+theme[net_box]="#374145"
 
 # Processes box outline color
-theme[proc_box]="#4b565c"
+theme[proc_box]="#374145"
 
 # Box divider line and small boxes line color
-theme[div_line]="#4b565c"
+theme[div_line]="#374145"
 
 # Temperature graph colors
 theme[temp_start]="#a7c080"
@@ -78,14 +76,14 @@ theme[used_mid]="#dbbc7f"
 theme[used_end]="#f85552"
 
 # Download graph colors
-theme[download_start]="#8da101"
+theme[download_start]="#a7c080"
 theme[download_mid]="#83c092"
-theme[download_end]="#a7c080"
+theme[download_end]="#7fbbb3"
 
 # Upload graph colors
-theme[upload_start]="#f85552"
-theme[upload_mid]="#dbbc7f"
-theme[upload_end]="#a7c080"
+theme[upload_start]="#dbbc7f"
+theme[upload_mid]="#e69875"
+theme[upload_end]="#e67e80"
 
 # Process box color gradient for threads, mem and cpu usage
 theme[process_start]="#a7c080"


### PR DESCRIPTION
Recently Everforest developers [updated](https://github.com/sainnhe/everforest/issues/110) the color scheme. This is an edit that changes the colors in accordance with the new Everforest colors and also changes the net graph colors to have a better-looking gradient.