### PR TITLE
fix: prefix with `fmt::` to fix ambiguous call to `format()`, that also refers to `/usr/include/c++/13.1.1/format`

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -196,7 +196,7 @@ void term_resize(bool force) {
 		sleep_ms(100);
 		if (Term::width < minWidth or Term::height < minHeight) {
 			int width = Term::width, height = Term::height;
-			cout << format("{clear}{bg_black}{fg_white}"
+			cout << fmt::format("{clear}{bg_black}{fg_white}"
 					"{mv1}Terminal size too small:"
 					"{mv2} Width = {fg_width}{width} {fg_white}Height = {fg_height}{height}"
 					"{mv3}{fg_white}Needed for current config:"
@@ -595,7 +595,7 @@ namespace Runner {
 				if (empty_bg.empty()) {
 					const int x = Term::width / 2 - 10, y = Term::height / 2 - 10;
 					output += Term::clear;
-					empty_bg = format(
+					empty_bg = fmt::format(
 						"{banner}"
 						"{mv1}{titleFg}{b}No boxes shown!"
 						"{mv2}{hiFg}1 {mainFg}| Show CPU box"
@@ -620,7 +620,7 @@ namespace Runner {
 
 			//! DEBUG stats -->
 			if (Global::debug and not Menu::active) {
-				output += format("{pre}{box:5.5} {collect:>12.12} {draw:>12.12}{post}",
+				output += fmt::format("{pre}{box:5.5} {collect:>12.12} {draw:>12.12}{post}",
 					"pre"_a = debug_bg + Theme::c("title") + Fx::b,
 					"box"_a = "box", "collect"_a = "collect", "draw"_a = "draw",
 					"post"_a = Theme::c("main_fg") + Fx::ub
@@ -629,7 +629,7 @@ namespace Runner {
 					if (not debug_times.contains(name)) debug_times[name] = {0,0};
 					const auto& [time_collect, time_draw] = debug_times.at(name);
 					if (name == "total") output += Fx::b;
-					output += format("{mvLD}{name:5.5} {collect:12d} {draw:12d}",
+					output += fmt::format("{mvLD}{name:5.5} {collect:12d} {draw:12d}",
 						"mvLD"_a = Mv::l(31) + Mv::d(1),
 						"name"_a = name,
 						"collect"_a = time_collect,


### PR DESCRIPTION
The error looks like:

```
...
src/btop.cpp:199:39: error: call of overloaded ‘format(const char [212], fmt::v10::detail::statically_named_arg<const std::__cxx11::basic_string<char>&, char, 6, fmt::v10::detail_exported::fixed_string<char, 6>{"clear"}>, fmt::v10::detail::statically_named_arg<std::__cxx11::basic_string<char>&, char, 9, fmt::v10::detail_exported::fixed_string<char, 9>{"bg_black"}>, fmt::v10::detail::statically_named_arg<std::__cxx11::basic_string<char>&, char, 9, fmt::v10::detail_exported::fixed_string<char, 9>{"fg_white"}>, fmt::v10::detail::statically_named_arg<std::__cxx11::basic_string<char>, char, 4, fmt::v10::detail_exported::fixed_string<char, 4>{"mv1"}>, fmt::v10::detail::statically_named_arg<std::__cxx11::basic_string<char>, char, 4, fmt::v10::detail_exported::fixed_string<char, 4>{"mv2"}>, fmt::v10::detail::statically_named_arg<std::__cxx11::basic_string<char>&, char, 9, fmt::v10::detail_exported::fixed_string<char, 9>{"fg_width"}>, fmt::v10::detail::statically_named_arg<int&, char, 6, fmt::v10::detail_exported::fixed_string<char, 6>{"width"}>, fmt::v10::detail::statically_named_arg<std::__cxx11::basic_string<char>&, char, 10, fmt::v10::detail_exported::fixed_string<char, 10>{"fg_height"}>, fmt::v10::detail::statically_named_arg<int&, char, 7, fmt::v10::detail_exported::fixed_string<char, 7>{"height"}>, fmt::v10::detail::statically_named_arg<std::__cxx11::basic_string<char>, char, 4, fmt::v10::detail_exported::fixed_string<char, 4>{"mv3"}>, fmt::v10::detail::statically_named_arg<std::__cxx11::basic_string<char>, char, 4, fmt::v10::detail_exported::fixed_string<char, 4>{"mv4"}>, fmt::v10::detail::statically_named_arg<int&, char, 9, fmt::v10::detail_exported::fixed_string<char, 9>{"minWidth"}>, fmt::v10::detail::statically_named_arg<int&, char, 10, fmt::v10::detail_exported::fixed_string<char, 10>{"minHeight"}>)’ is ambiguous
      199 |                         cout << format("{clear}{bg_black}{fg_white}"
...
```