### PR TITLE
Modernize using nullptr.

### DIFF
--- a/.github/workflows/continuous-build-linux.yml
+++ b/.github/workflows/continuous-build-linux.yml
@@ -13,7 +13,7 @@ on:
       - '!src/freebsd/**'
       - 'include/**'
       - 'Makefile'
-      - '.github/workflows/continuous-build.yml'
+      - '.github/workflows/continuous-build-linux.yml'
   pull_request:
     branches:
       - main
@@ -23,7 +23,7 @@ on:
       - '!src/freebsd/**'
       - 'include/**'
       - 'Makefile'
-      - '.github/workflows/continuous-build.yml'
+      - '.github/workflows/continuous-build-linux.yml'
 
 jobs:
   static-build:

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -244,14 +244,14 @@ void clean_quit(int sig) {
 	Runner::stop();
 	if (Global::_runner_started) {
 	#ifdef __APPLE__
-		if (pthread_join(Runner::runner_id, NULL) != 0) {
+		if (pthread_join(Runner::runner_id, nullptr) != 0) {
 			Logger::warning("Failed to join _runner thread on exit!");
 			pthread_cancel(Runner::runner_id);
 		}
 	#else
 		struct timespec ts;
 		ts.tv_sec = 5;
-		if (pthread_timedjoin_np(Runner::runner_id, NULL, &ts) != 0) {
+		if (pthread_timedjoin_np(Runner::runner_id, nullptr, &ts) != 0) {
 			Logger::warning("Failed to join _runner thread on exit!");
 			pthread_cancel(Runner::runner_id);
 		}
@@ -356,7 +356,7 @@ namespace Runner {
 	public:
 		int status;
 		thread_lock(pthread_mutex_t& mtx) : pt_mutex(mtx) {
-			pthread_mutex_init(&pt_mutex, NULL);
+			pthread_mutex_init(&pt_mutex, nullptr);
 			status = pthread_mutex_lock(&pt_mutex);
 		}
 		~thread_lock() {
@@ -444,7 +444,7 @@ namespace Runner {
 		// sigaddset(&mask, SIGTSTP);
 		sigaddset(&mask, SIGWINCH);
 		sigaddset(&mask, SIGTERM);
-		pthread_sigmask(SIG_BLOCK, &mask, NULL);
+		pthread_sigmask(SIG_BLOCK, &mask, nullptr);
 
 		//? pthread_mutex_lock to lock thread and monitor health from main thread
 		thread_lock pt_lck(mtx);
@@ -666,7 +666,7 @@ namespace Runner {
 			active = false;
 			// exit(1);
 			pthread_cancel(Runner::runner_id);
-			if (pthread_create(&Runner::runner_id, NULL, &Runner::_runner, NULL) != 0) {
+			if (pthread_create(&Runner::runner_id, nullptr, &Runner::_runner, nullptr) != 0) {
 				Global::exit_error_msg = "Failed to re-create _runner thread!";
 				clean_quit(1);
 			}
@@ -754,7 +754,7 @@ int main(int argc, char **argv) {
 
 	//? Setup paths for config, log and user themes
 	for (const auto& env : {"XDG_CONFIG_HOME", "HOME"}) {
-		if (std::getenv(env) != NULL and access(std::getenv(env), W_OK) != -1) {
+		if (std::getenv(env) != nullptr and access(std::getenv(env), W_OK) != -1) {
 			Config::conf_dir = fs::path(std::getenv(env)) / (((string)env == "HOME") ? ".config/btop" : "btop");
 			break;
 		}
@@ -821,7 +821,7 @@ int main(int argc, char **argv) {
 	}
 
 	//? Try to find and set a UTF-8 locale
-	if (std::setlocale(LC_ALL, "") != NULL and not s_contains((string)std::setlocale(LC_ALL, ""), ";")
+	if (std::setlocale(LC_ALL, "") != nullptr and not s_contains((string)std::setlocale(LC_ALL, ""), ";")
 	and str_to_upper(s_replace((string)std::setlocale(LC_ALL, ""), "-", "")).ends_with("UTF8")) {
 		Logger::debug("Using locale " + (string)std::setlocale(LC_ALL, ""));
 	}
@@ -829,9 +829,9 @@ int main(int argc, char **argv) {
 		string found;
 		bool set_failure{}; // defaults to false
 		for (const auto loc_env : array{"LANG", "LC_ALL"}) {
-			if (std::getenv(loc_env) != NULL and str_to_upper(s_replace((string)std::getenv(loc_env), "-", "")).ends_with("UTF8")) {
+			if (std::getenv(loc_env) != nullptr and str_to_upper(s_replace((string)std::getenv(loc_env), "-", "")).ends_with("UTF8")) {
 				found = std::getenv(loc_env);
-				if (std::setlocale(LC_ALL, found.c_str()) == NULL) {
+				if (std::setlocale(LC_ALL, found.c_str()) == nullptr) {
 					set_failure = true;
 					Logger::warning("Failed to set locale " + found + " continuing anyway.");
 				}
@@ -844,7 +844,7 @@ int main(int argc, char **argv) {
 						for (auto& l : ssplit(loc, ';')) {
 							if (str_to_upper(s_replace(l, "-", "")).ends_with("UTF8")) {
 								found = l.substr(l.find('=') + 1);
-								if (std::setlocale(LC_ALL, found.c_str()) != NULL) {
+								if (std::setlocale(LC_ALL, found.c_str()) != nullptr) {
 									break;
 								}
 							}
@@ -865,10 +865,10 @@ int main(int argc, char **argv) {
 			if (cur_locale.empty()) {
 				Logger::warning("No UTF-8 locale detected! Some symbols might not display correctly.");
 			}
-			else if (std::setlocale(LC_ALL, string(cur_locale + ".UTF-8").c_str()) != NULL) {
+			else if (std::setlocale(LC_ALL, string(cur_locale + ".UTF-8").c_str()) != nullptr) {
 				Logger::debug("Setting LC_ALL=" + cur_locale + ".UTF-8");
 			}
-			else if(std::setlocale(LC_ALL, "en_US.UTF-8") != NULL) {
+			else if(std::setlocale(LC_ALL, "en_US.UTF-8") != nullptr) {
 				Logger::debug("Setting LC_ALL=en_US.UTF-8");
 			}
 			else {
@@ -940,7 +940,7 @@ int main(int argc, char **argv) {
 
 	//? Start runner thread
 	Runner::thread_sem_init();
-	if (pthread_create(&Runner::runner_id, NULL, &Runner::_runner, NULL) != 0) {
+	if (pthread_create(&Runner::runner_id, nullptr, &Runner::_runner, nullptr) != 0) {
 		Global::exit_error_msg = "Failed to create _runner thread!";
 		clean_quit(1);
 	}

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -293,7 +293,7 @@ namespace Draw {
 		static size_t clock_len{};  // defaults to 0
 		static string clock_str;
 
-		if (auto n_time = time(NULL); not force and n_time == c_time)
+		if (auto n_time = time(nullptr); not force and n_time == c_time)
 			return false;
 		else {
 			c_time = n_time;

--- a/src/btop_input.hpp
+++ b/src/btop_input.hpp
@@ -32,7 +32,7 @@ using std::string;
 
 /* The input functions relies on the following std::cin options being set:
 	cin.sync_with_stdio(false);
-	cin.tie(NULL);
+	cin.tie(nullptr);
 	These will automatically be set when running Term::init() from btop_tools.cpp
 */
 

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -80,7 +80,7 @@ namespace Term {
 			else settings.c_lflag &= ~(ICANON);
 			if (tcsetattr(STDIN_FILENO, TCSANOW, &settings)) return false;
 			if (on) setlinebuf(stdin);
-			else setbuf(stdin, NULL);
+			else setbuf(stdin, nullptr);
 			return true;
 		}
 	}
@@ -121,15 +121,15 @@ namespace Term {
 			initialized = (bool)isatty(STDIN_FILENO);
 			if (initialized) {
 				tcgetattr(STDIN_FILENO, &initial_settings);
-				current_tty = (ttyname(STDIN_FILENO) != NULL ? static_cast<string>(ttyname(STDIN_FILENO)) : "unknown");
+				current_tty = (ttyname(STDIN_FILENO) != nullptr ? static_cast<string>(ttyname(STDIN_FILENO)) : "unknown");
 
 				//? Disable stream sync
 				cin.sync_with_stdio(false);
 				cout.sync_with_stdio(false);
 
 				//? Disable stream ties
-				cin.tie(NULL);
-				cout.tie(NULL);
+				cin.tie(nullptr);
+				cout.tie(nullptr);
 				echo(false);
 				linebuffered(false);
 				refresh();
@@ -531,8 +531,8 @@ namespace Tools {
 
 	string username() {
 		auto user = getenv("LOGNAME");
-		if (user == NULL or strlen(user) == 0) user = getenv("USER");
-		return (user != NULL ? user : "");
+		if (user == nullptr or strlen(user) == 0) user = getenv("USER");
+		return (user != nullptr ? user : "");
 	}
 
 }

--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -123,7 +123,7 @@ namespace Shared {
 		mib[1] = HW_NCPU;
 		int ncpu;
 		size_t len = sizeof(ncpu);
-		if (sysctl(mib, 2, &ncpu, &len, NULL, 0) == -1) {
+		if (sysctl(mib, 2, &ncpu, &len, nullptr, 0) == -1) {
 			Logger::warning("Could not determine number of cores, defaulting to 1.");
 		} else {
 			coreCount = ncpu;
@@ -143,21 +143,21 @@ namespace Shared {
 
 		int64_t memsize = 0;
 		size_t size = sizeof(memsize);
-		if (sysctlbyname("hw.physmem", &memsize, &size, NULL, 0) < 0) {
+		if (sysctlbyname("hw.physmem", &memsize, &size, nullptr, 0) < 0) {
 			Logger::warning("Could not get memory size");
 		}
 		totalMem = memsize;
 
 		struct timeval result;
 		size = sizeof(result);
-		if (sysctlbyname("kern.boottime", &result, &size, NULL, 0) < 0) {
+		if (sysctlbyname("kern.boottime", &result, &size, nullptr, 0) < 0) {
 			Logger::warning("Could not get boot time");
 		} else {
 			bootTime = result.tv_sec;
 		}
 
 		size = sizeof(kfscale);
-		if (sysctlbyname("kern.fscale", &kfscale, &size, NULL, 0) == -1) {
+		if (sysctlbyname("kern.fscale", &kfscale, &size, nullptr, 0) == -1) {
 			kfscale = 2048;
 		}
 
@@ -185,7 +185,7 @@ namespace Shared {
 
 	//* RAII wrapper for kvm_openfiles
 	class kvm_openfiles_wrapper {
-		kvm_t* kd = NULL;
+		kvm_t* kd = nullptr;
 	public:
 		kvm_openfiles_wrapper(const char* execf, const char* coref, const char* swapf, int flags, char* err) {
 			this->kd = kvm_openfiles(execf, coref, swapf, flags, err);
@@ -217,7 +217,7 @@ namespace Cpu {
 		string name;
 		char buffer[1024];
 		size_t size = sizeof(buffer);
-		if (sysctlbyname("hw.model", &buffer, &size, NULL, 0) < 0) {
+		if (sysctlbyname("hw.model", &buffer, &size, nullptr, 0) < 0) {
 			Logger::error("Failed to get CPU name");
 			return name;
 		}
@@ -264,13 +264,13 @@ namespace Cpu {
 		if (Config::getB("show_coretemp") and Config::getB("check_temp")) {
 			int32_t temp;
 			size_t size = sizeof(temp);
-			if (sysctlbyname("dev.cpu.0.temperature", &temp, &size, NULL, 0) < 0) {
+			if (sysctlbyname("dev.cpu.0.temperature", &temp, &size, nullptr, 0) < 0) {
 				Logger::warning("Could not get temp sensor - maybe you need to load the coretemp module");
 			} else {
 				got_sensors = true;
 				int temp;
 				size_t size = sizeof(temp);
-				sysctlbyname("dev.cpu.0.coretemp.tjmax", &temp, &size, NULL, 0); //asuming the max temp is same for all cores
+				sysctlbyname("dev.cpu.0.coretemp.tjmax", &temp, &size, nullptr, 0); //asuming the max temp is same for all cores
 				temp = (temp - 2732) / 10; // since it's an int, it's multiplied by 10, and offset to absolute zero...
 				current_cpu.temp_max = temp;
 			}
@@ -284,7 +284,7 @@ namespace Cpu {
 		int found = 0;
 		bool got_package = false;
 		size_t size = sizeof(p_temp);
-		if (sysctlbyname("hw.acpi.thermal.tz0.temperature", &p_temp, &size, NULL, 0) >= 0) {
+		if (sysctlbyname("hw.acpi.thermal.tz0.temperature", &p_temp, &size, nullptr, 0) >= 0) {
 			got_package = true;
 			p_temp = (p_temp - 2732) / 10; // since it's an int, it's multiplied by 10, and offset to absolute zero...
 		}
@@ -292,7 +292,7 @@ namespace Cpu {
 		size = sizeof(temp);
 		for (int i = 0; i < Shared::coreCount; i++) {
 			string s = "dev.cpu." + std::to_string(i) + ".temperature";
-			if (sysctlbyname(s.c_str(), &temp, &size, NULL, 0) >= 0) {
+			if (sysctlbyname(s.c_str(), &temp, &size, nullptr, 0) >= 0) {
 				temp = (temp - 2732) / 10;
 				if (not got_package) {
 					p_temp += temp;
@@ -317,7 +317,7 @@ namespace Cpu {
 		unsigned int freq = 1;
 		size_t size = sizeof(freq);
 
-		if (sysctlbyname("dev.cpu.0.freq", &freq, &size, NULL, 0) < 0) {
+		if (sysctlbyname("dev.cpu.0.freq", &freq, &size, nullptr, 0) < 0) {
 			return "";
 		}
 		return std::to_string(freq / 1000.0 ).substr(0, 3); // seems to be in MHz
@@ -373,17 +373,17 @@ namespace Cpu {
 		uint32_t percent = -1;
 		size_t size = sizeof(percent);
 		string status = "discharging";
-		if (sysctlbyname("hw.acpi.battery.life", &percent, &size, NULL, 0) < 0) {
+		if (sysctlbyname("hw.acpi.battery.life", &percent, &size, nullptr, 0) < 0) {
 			has_battery = false;
 		} else {
 			has_battery = true;
 			size_t size = sizeof(seconds);
-			if (sysctlbyname("hw.acpi.battery.time", &seconds, &size, NULL, 0) < 0) {
+			if (sysctlbyname("hw.acpi.battery.time", &seconds, &size, nullptr, 0) < 0) {
 				seconds = 0;
 			}
 			int state;
 			size = sizeof(state);
-			if (sysctlbyname("hw.acpi.battery.state", &state, &size, NULL, 0) < 0) {
+			if (sysctlbyname("hw.acpi.battery.state", &state, &size, nullptr, 0) < 0) {
 				status = "unknown";
 			} else {
 				if (state == 2) {
@@ -409,7 +409,7 @@ namespace Cpu {
 
 		vector<array<long, CPUSTATES>> cpu_time(Shared::coreCount);
 		size_t size = sizeof(long) * CPUSTATES * Shared::coreCount;
-		if (sysctlbyname("kern.cp_times", &cpu_time[0], &size, NULL, 0) == -1) {
+		if (sysctlbyname("kern.cp_times", &cpu_time[0], &size, nullptr, 0) == -1) {
 			Logger::error("failed to get CPU times");
 		}
 		long long global_totals = 0;
@@ -565,13 +565,13 @@ namespace Mem {
 		static std::unique_ptr<struct devinfo, decltype(std::free)*> curDevInfo (reinterpret_cast<struct devinfo*>(std::calloc(1, sizeof(struct devinfo))), std::free);
 		cur.dinfo = curDevInfo.get();
 
-		if (devstat_getdevs(NULL, &cur) != -1) {
+		if (devstat_getdevs(nullptr, &cur) != -1) {
 			for (int i = 0; i < cur.dinfo->numdevs; i++) {
 				auto d = cur.dinfo->devices[i];
 				string devStatName = "/dev/" + string(d.device_name) + std::to_string(d.unit_number);
 				for (auto& [ignored, disk] : disks) { // find matching mountpoints - could be multiple as d.device_name is only ada (and d.unit_number is the device number), while the disk.dev is like /dev/ada0s1
 					if (disk.dev.string().rfind(devStatName, 0) == 0) {
-						devstat_compute_statistics(&d, NULL, etime, DSM_TOTAL_BYTES_READ, &total_bytes_read, DSM_TOTAL_BYTES_WRITE, &total_bytes_write, DSM_NONE);
+						devstat_compute_statistics(&d, nullptr, etime, DSM_TOTAL_BYTES_READ, &total_bytes_read, DSM_TOTAL_BYTES_WRITE, &total_bytes_write, DSM_NONE);
 						assign_values(disk, total_bytes_read, total_bytes_write);
 						string mountpoint = mapping.at(disk.dev);
 						Logger::debug("dev " + devStatName + " -> " + mountpoint  + " read=" + std::to_string(total_bytes_read) + " write=" + std::to_string(total_bytes_write));
@@ -594,7 +594,7 @@ namespace Mem {
 				while (not std::feof(f())) {
 					if (fgets(buf, len, f())) {
 						char *name = std::strtok(buf, ": \n");
-						char *value = std::strtok(NULL, ": \n");
+						char *value = std::strtok(nullptr, ": \n");
 						if (string(name).find("dataset_name") != string::npos) {
 							// create entry if datasetname matches with anything in mapping
 							// relies on the fact that the dataset name is last value in the list
@@ -627,7 +627,7 @@ namespace Mem {
 		auto show_disks = Config::getB("show_disks");
 		auto swap_disk = Config::getB("swap_disk");
 		auto &mem = current_mem;
-		static bool snapped = (getenv("BTOP_SNAPPED") != NULL);
+		static bool snapped = (getenv("BTOP_SNAPPED") != nullptr);
 
 		int mib[4];
 		u_int memActive, memWire, cachedMem, freeMem;
@@ -635,12 +635,12 @@ namespace Mem {
 
    		len = 4; sysctlnametomib("vm.stats.vm.v_active_count", mib, &len);
 		len = sizeof(memActive);
-		sysctl(mib, 4, &(memActive), &len, NULL, 0);
+		sysctl(mib, 4, &(memActive), &len, nullptr, 0);
 		memActive *= Shared::pageSize;
 
 		len = 4; sysctlnametomib("vm.stats.vm.v_wire_count", mib, &len);
 		len = sizeof(memWire);
-		sysctl(mib, 4, &(memWire), &len, NULL, 0);
+		sysctl(mib, 4, &(memWire), &len, nullptr, 0);
 		memWire *= Shared::pageSize;
 
 		mem.stats.at("used") = memWire + memActive;
@@ -648,19 +648,19 @@ namespace Mem {
 
 		len = sizeof(cachedMem);
    		len = 4; sysctlnametomib("vm.stats.vm.v_cache_count", mib, &len);
-   		sysctl(mib, 4, &(cachedMem), &len, NULL, 0);
+   		sysctl(mib, 4, &(cachedMem), &len, nullptr, 0);
    		cachedMem *= Shared::pageSize;
    		mem.stats.at("cached") = cachedMem;
 
 		len = sizeof(freeMem);
    		len = 4; sysctlnametomib("vm.stats.vm.v_free_count", mib, &len);
-   		sysctl(mib, 4, &(freeMem), &len, NULL, 0);
+   		sysctl(mib, 4, &(freeMem), &len, nullptr, 0);
    		freeMem *= Shared::pageSize;
    		mem.stats.at("free") = freeMem;
 
 		if (show_swap) {
 			char buf[_POSIX2_LINE_MAX];
-			Shared::kvm_openfiles_wrapper kd(NULL, _PATH_DEVNULL, NULL, O_RDONLY, buf);
+			Shared::kvm_openfiles_wrapper kd(nullptr, _PATH_DEVnullptr, nullptr, O_RDONLY, buf);
    			struct kvm_swap swap[16];
    			int nswap = kvm_getswapinfo(kd(), swap, 16, 0);
 			int totalSwap = 0, usedSwap = 0;
@@ -850,8 +850,8 @@ namespace Net {
 			string ipv4, ipv6;
 
 			//? Iteration over all items in getifaddrs() list
-			for (auto *ifa = if_wrap(); ifa != NULL; ifa = ifa->ifa_next) {
-				if (ifa->ifa_addr == NULL) continue;
+			for (auto *ifa = if_wrap(); ifa != nullptr; ifa = ifa->ifa_next) {
+				if (ifa->ifa_addr == nullptr) continue;
 				family = ifa->ifa_addr->sa_family;
 				const auto &iface = ifa->ifa_name;
 				//? Update available interfaces vector and get status of interface
@@ -868,7 +868,7 @@ namespace Net {
 				//? Get IPv4 address
 				if (family == AF_INET) {
 					if (net[iface].ipv4.empty()) {
-						if (NULL != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr)->sin_addr), ip, IPBUFFER_MAXSIZE)) {
+						if (nullptr != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr)->sin_addr), ip, IPBUFFER_MAXSIZE)) {
 
 							net[iface].ipv4 = ip;
 						} else {
@@ -880,7 +880,7 @@ namespace Net {
 				//? Get IPv6 address
 				else if (family == AF_INET6) {
 					if (net[iface].ipv6.empty()) {
-						if (NULL != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in6*>(ifa->ifa_addr)->sin6_addr), ip, IPBUFFER_MAXSIZE)) {
+						if (nullptr != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in6*>(ifa->ifa_addr)->sin6_addr), ip, IPBUFFER_MAXSIZE)) {
 							net[iface].ipv6 = ip;
 						} else {
 							int errsv = errno;
@@ -893,15 +893,15 @@ namespace Net {
 			unordered_flat_map<string, std::tuple<uint64_t, uint64_t>> ifstats;
 			int mib[] = {CTL_NET, PF_ROUTE, 0, 0, NET_RT_IFLIST, 0};
 			size_t len;
-			if (sysctl(mib, 6, NULL, &len, NULL, 0) < 0) {
+			if (sysctl(mib, 6, nullptr, &len, nullptr, 0) < 0) {
 				Logger::error("failed getting network interfaces");
 			} else {
 				std::unique_ptr<char[]> buf(new char[len]);
-				if (sysctl(mib, 6, buf.get(), &len, NULL, 0) < 0) {
+				if (sysctl(mib, 6, buf.get(), &len, nullptr, 0) < 0) {
 					Logger::error("failed getting network interfaces");
 				} else {
 					char *lim = buf.get() + len;
-					char *next = NULL;
+					char *next = nullptr;
 					for (next = buf.get(); next < lim;) {
 						struct if_msghdr *ifm = (struct if_msghdr *)next;
 						next += ifm->ifm_msglen;
@@ -1078,7 +1078,7 @@ namespace Proc {
 
 		//? Process runtime : current time - start time (both in unix time - seconds since epoch)
 		struct timeval currentTime;
-		gettimeofday(&currentTime, NULL);
+		gettimeofday(&currentTime, nullptr);
 		detailed.elapsed = sec_to_dhms(currentTime.tv_sec - detailed.entry.cpu_s); // only interested in second granularity, so ignoring tc_usec
 		if (detailed.elapsed.size() > 8) detailed.elapsed.resize(detailed.elapsed.size() - 3);
 
@@ -1133,7 +1133,7 @@ namespace Proc {
 
 		vector<array<long, CPUSTATES>> cpu_time(Shared::coreCount);
 		size_t size = sizeof(long) * CPUSTATES * Shared::coreCount;
-		if (sysctlbyname("kern.cp_times", &cpu_time[0], &size, NULL, 0) == -1) {
+		if (sysctlbyname("kern.cp_times", &cpu_time[0], &size, nullptr, 0) == -1) {
 			Logger::error("failed to get CPU times");
 		}
 		cputimes = 0;
@@ -1152,12 +1152,12 @@ namespace Proc {
 			should_filter = true;
 			found.clear();
 			struct timeval currentTime;
-			gettimeofday(&currentTime, NULL);
+			gettimeofday(&currentTime, nullptr);
 			const double timeNow = currentTime.tv_sec + (currentTime.tv_usec / 1'000'000);
 
 			int count = 0;
 			char buf[_POSIX2_LINE_MAX];
-			Shared::kvm_openfiles_wrapper kd(NULL, _PATH_DEVNULL, NULL, O_RDONLY, buf);
+			Shared::kvm_openfiles_wrapper kd(nullptr, _PATH_DEVnullptr, nullptr, O_RDONLY, buf);
    			const struct kinfo_proc* kprocs = kvm_getprocs(kd(), KERN_PROC_PROC, 0, &count);
 
    			for (int i = 0; i < count; i++) {
@@ -1179,7 +1179,7 @@ namespace Proc {
 
 				//? Get program name, command, username, parent pid, nice and status
 				if (no_cache) {
-					if (kproc->ki_comm == NULL or kproc->ki_comm == "idle"s) {
+					if (kproc->ki_comm == nullptr or kproc->ki_comm == "idle"s) {
 						current_procs.pop_back();
 						found.pop_back();
 						continue;
@@ -1342,8 +1342,8 @@ namespace Tools {
 		struct timeval ts, currTime;
 		std::size_t len = sizeof(ts);
 		int mib[2] = {CTL_KERN, KERN_BOOTTIME};
-		if (sysctl(mib, 2, &ts, &len, NULL, 0) != -1) {
-			gettimeofday(&currTime, NULL);
+		if (sysctl(mib, 2, &ts, &len, nullptr, 0) != -1) {
+			gettimeofday(&currTime, nullptr);
 			return currTime.tv_sec - ts.tv_sec;
 		}
 		return 0.0;

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -1399,8 +1399,8 @@ namespace Net {
 			string ipv4, ipv6;
 
 			//? Iteration over all items in getifaddrs() list
-			for (auto* ifa = if_wrap(); ifa != NULL; ifa = ifa->ifa_next) {
-				if (ifa->ifa_addr == NULL) continue;
+			for (auto* ifa = if_wrap(); ifa != nullptr; ifa = ifa->ifa_next) {
+				if (ifa->ifa_addr == nullptr) continue;
 				family = ifa->ifa_addr->sa_family;
 				const auto& iface = ifa->ifa_name;
 
@@ -1420,7 +1420,7 @@ namespace Net {
 				//? Get IPv4 address
 				if (family == AF_INET) {
 					if (net[iface].ipv4.empty()) {
-						if (NULL != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr)->sin_addr), ip, IPBUFFER_MAXSIZE)) {
+						if (nullptr != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr)->sin_addr), ip, IPBUFFER_MAXSIZE)) {
 							net[iface].ipv4 = ip;
 						} else {
 							int errsv = errno;
@@ -1431,7 +1431,7 @@ namespace Net {
 				//? Get IPv6 address
 				else if (family == AF_INET6) {
 					if (net[iface].ipv6.empty()) {
-						if (NULL != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in6*>(ifa->ifa_addr)->sin6_addr), ip, IPBUFFER_MAXSIZE)) {
+						if (nullptr != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in6*>(ifa->ifa_addr)->sin6_addr), ip, IPBUFFER_MAXSIZE)) {
 							net[iface].ipv6 = ip;
 						} else {
 							int errsv = errno;
@@ -1841,7 +1841,7 @@ namespace Proc {
 						try {
 							struct passwd* udet;
 							udet = getpwuid(stoi(uid));
-							if (udet != NULL and udet->pw_name != NULL) {
+							if (udet != nullptr and udet->pw_name != nullptr) {
 								new_proc.user = string(udet->pw_name);
 							}
 							else {

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -129,7 +129,7 @@ namespace Shared {
 		}
 
 		size_t physicalCoreCountSize = sizeof(physicalCoreCount);
-		if (sysctlbyname("hw.physicalcpu", &physicalCoreCount, &physicalCoreCountSize, NULL, 0) < 0) {
+		if (sysctlbyname("hw.physicalcpu", &physicalCoreCount, &physicalCoreCountSize, nullptr, 0) < 0) {
 			Logger::error("Could not get physical core count");
 		}
 
@@ -155,7 +155,7 @@ namespace Shared {
 
 		int64_t memsize = 0;
 		size_t size = sizeof(memsize);
-		if (sysctlbyname("hw.memsize", &memsize, &size, NULL, 0) < 0) {
+		if (sysctlbyname("hw.memsize", &memsize, &size, nullptr, 0) < 0) {
 			Logger::warning("Could not get memory size");
 		}
 		totalMem = memsize;
@@ -206,7 +206,7 @@ namespace Cpu {
 		string name;
 		char buffer[1024];
 		size_t size = sizeof(buffer);
-		if (sysctlbyname("machdep.cpu.brand_string", &buffer, &size, NULL, 0) < 0) {
+		if (sysctlbyname("machdep.cpu.brand_string", &buffer, &size, nullptr, 0) < 0) {
 			Logger::error("Failed to get CPU name");
 			return name;
 		}
@@ -324,7 +324,7 @@ namespace Cpu {
 
 		int mib[] = {CTL_HW, HW_CPU_FREQ};
 
-		if (sysctl(mib, 2, &freq, &size, NULL, 0) < 0) {
+		if (sysctl(mib, 2, &freq, &size, nullptr, 0) < 0) {
 			// this fails on Apple Silicon macs. Apparently you're not allowed to know
 			return "";
 		}
@@ -455,7 +455,7 @@ namespace Cpu {
 		natural_t cpu_count;
 		natural_t i;
 		kern_return_t error;
-		processor_cpu_load_info_data_t *cpu_load_info = NULL;
+		processor_cpu_load_info_data_t *cpu_load_info = nullptr;
 
 		MachProcessorInfo info{};
 		error = host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &cpu_count, &info.info_array, &info.info_count);
@@ -672,7 +672,7 @@ namespace Mem {
 		auto show_disks = Config::getB("show_disks");
 		auto swap_disk = Config::getB("swap_disk");
 		auto &mem = current_mem;
-		static bool snapped = (getenv("BTOP_SNAPPED") != NULL);
+		static bool snapped = (getenv("BTOP_SNAPPED") != nullptr);
 
 		vm_statistics64 p;
 		mach_msg_type_number_t info_size = HOST_VM_INFO64_COUNT;
@@ -687,7 +687,7 @@ namespace Mem {
 
 		struct xsw_usage swap;
 		size_t len = sizeof(struct xsw_usage);
-		if (sysctl(mib, 2, &swap, &len, NULL, 0) == 0) {
+		if (sysctl(mib, 2, &swap, &len, nullptr, 0) == 0) {
 			mem.stats.at("swap_total") = swap.xsu_total;
 			mem.stats.at("swap_free") = swap.xsu_avail;
 			mem.stats.at("swap_used") = swap.xsu_used;
@@ -868,8 +868,8 @@ namespace Net {
 			string ipv4, ipv6;
 
 			//? Iteration over all items in getifaddrs() list
-			for (auto *ifa = if_wrap(); ifa != NULL; ifa = ifa->ifa_next) {
-				if (ifa->ifa_addr == NULL) continue;
+			for (auto *ifa = if_wrap(); ifa != nullptr; ifa = ifa->ifa_next) {
+				if (ifa->ifa_addr == nullptr) continue;
 				family = ifa->ifa_addr->sa_family;
 				const auto &iface = ifa->ifa_name;
 				//? Update available interfaces vector and get status of interface
@@ -885,7 +885,7 @@ namespace Net {
 				//? Get IPv4 address
 				if (family == AF_INET) {
 					if (net[iface].ipv4.empty()) {
-						if (NULL != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr)->sin_addr), ip, IPBUFFER_MAXSIZE)) {
+						if (nullptr != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr)->sin_addr), ip, IPBUFFER_MAXSIZE)) {
 							net[iface].ipv4 = ip;
 						} else {
 							int errsv = errno;
@@ -896,7 +896,7 @@ namespace Net {
 				//? Get IPv6 address
 				else if (family == AF_INET6) {
 					if (net[iface].ipv6.empty()) {
-						if (NULL != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in6*>(ifa->ifa_addr)->sin6_addr), ip, IPBUFFER_MAXSIZE)) {
+						if (nullptr != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in6*>(ifa->ifa_addr)->sin6_addr), ip, IPBUFFER_MAXSIZE)) {
 							net[iface].ipv6 = ip;
 						} else {
 							int errsv = errno;
@@ -909,15 +909,15 @@ namespace Net {
 			unordered_flat_map<string, std::tuple<uint64_t, uint64_t>> ifstats;
 			int mib[] = {CTL_NET, PF_ROUTE, 0, 0, NET_RT_IFLIST2, 0};
 			size_t len;
-			if (sysctl(mib, 6, NULL, &len, NULL, 0) < 0) {
+			if (sysctl(mib, 6, nullptr, &len, nullptr, 0) < 0) {
 				Logger::error("failed getting network interfaces");
 			} else {
 				std::unique_ptr<char[]> buf(new char[len]);
-				if (sysctl(mib, 6, buf.get(), &len, NULL, 0) < 0) {
+				if (sysctl(mib, 6, buf.get(), &len, nullptr, 0) < 0) {
 					Logger::error("failed getting network interfaces");
 				} else {
 					char *lim = buf.get() + len;
-					char *next = NULL;
+					char *next = nullptr;
 					for (next = buf.get(); next < lim;) {
 						struct if_msghdr *ifm = (struct if_msghdr *)next;
 						next += ifm->ifm_msglen;
@@ -1094,7 +1094,7 @@ namespace Proc {
 
 		//? Process runtime : current time - start time (both in unix time - seconds since epoch)
 		struct timeval currentTime;
-		gettimeofday(&currentTime, NULL);
+		gettimeofday(&currentTime, nullptr);
 		detailed.elapsed = sec_to_dhms(currentTime.tv_sec - (detailed.entry.cpu_s / 1'000'000));
 		if (detailed.elapsed.size() > 8) detailed.elapsed.resize(detailed.elapsed.size() - 3);
 
@@ -1156,7 +1156,7 @@ namespace Proc {
 			{  //* Get CPU totals
 				natural_t cpu_count;
 				kern_return_t error;
-				processor_cpu_load_info_data_t *cpu_load_info = NULL;
+				processor_cpu_load_info_data_t *cpu_load_info = nullptr;
 				MachProcessorInfo info{};
 				error = host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &cpu_count, &info.info_array, &info.info_count);
 				if (error != KERN_SUCCESS) {
@@ -1178,13 +1178,13 @@ namespace Proc {
 			size_t size = 0;
 			const auto timeNow = time_micros();
 
-			if (sysctl(mib, 4, NULL, &size, NULL, 0) < 0 || size == 0) {
+			if (sysctl(mib, 4, nullptr, &size, nullptr, 0) < 0 || size == 0) {
 				Logger::error("Unable to get size of kproc_infos");
 			}
 			uint64_t cpu_t = 0;
 
 			std::unique_ptr<kinfo_proc[]> processes(new kinfo_proc[size / sizeof(kinfo_proc)]);
-			if (sysctl(mib, 4, processes.get(), &size, NULL, 0) == 0) {
+			if (sysctl(mib, 4, processes.get(), &size, nullptr, 0) == 0) {
 				size_t count = size / sizeof(struct kinfo_proc);
 				for (size_t i = 0; i < count; i++) {  //* iterate over all processes in kinfo_proc
 					struct kinfo_proc& kproc = processes.get()[i];
@@ -1215,7 +1215,7 @@ namespace Proc {
 							std::unique_ptr<char[]> proc_chars(new char[Shared::arg_max]);
 							int mib[] = {CTL_KERN, KERN_PROCARGS2, (int)pid};
 							size_t argmax = Shared::arg_max;
-							if (sysctl(mib, 3, proc_chars.get(), &argmax, NULL, 0) == 0) {
+							if (sysctl(mib, 3, proc_chars.get(), &argmax, nullptr, 0) == 0) {
 								int argc = 0;
 								memcpy(&argc, &proc_chars.get()[0], sizeof(argc));
 								std::string_view proc_args(proc_chars.get(), argmax);
@@ -1378,8 +1378,8 @@ namespace Tools {
 		struct timeval ts, currTime;
 		std::size_t len = sizeof(ts);
 		int mib[2] = {CTL_KERN, KERN_BOOTTIME};
-		if (sysctl(mib, 2, &ts, &len, NULL, 0) != -1) {
-			gettimeofday(&currTime, NULL);
+		if (sysctl(mib, 2, &ts, &len, nullptr, 0) != -1) {
+			gettimeofday(&currTime, nullptr);
 			return currTime.tv_sec - ts.tv_sec;
 		}
 		return 0.0;


### PR DESCRIPTION
TLDR: The problem is that NULL is of type int and relies on proper
implicit conversion which can lead to issues when using overloaded
functions

See https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2431.pdf

It is also a C++ 'best practise'