### PR TITLE
Improve load average retrieval on linux and prefer `emplace_back`

### DIFF
--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -112,7 +112,7 @@ namespace Cpu {
 		vector<deque<long long>> core_percent;
 		vector<deque<long long>> temp;
 		long long temp_max = 0;
-		array<float, 3> load_avg;
+		array<double, 3> load_avg;
 	};
 
 	//* Collect cpu stats and temperatures

--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -392,13 +392,9 @@ namespace Cpu {
 			return current_cpu;
 		auto &cpu = current_cpu;
 
-		double avg[3];
-
-		if (getloadavg(avg, sizeof(avg)) < 0) {
+		if (getloadavg(cpu.load_avg.data(), cpu.load_avg.size()) < 0) {
 			Logger::error("failed to get load averages");
 		}
-
-		cpu.load_avg = { (float)avg[0], (float)avg[1], (float)avg[2]};
 
 		vector<array<long, CPUSTATES>> cpu_time(Shared::coreCount);
 		size_t size = sizeof(long) * CPUSTATES * Shared::coreCount;

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -447,13 +447,9 @@ namespace Cpu {
 			return current_cpu;
 		auto &cpu = current_cpu;
 
-		double avg[3];
-
-		if (getloadavg(avg, sizeof(avg)) < 0) {
+		if (getloadavg(cpu.load_avg.data(), cpu.load_avg.size()) < 0) {
 			Logger::error("failed to get load averages");
 		}
-
-		cpu.load_avg = { (float)avg[0], (float)avg[1], (float)avg[2]};
 
 		natural_t cpu_count;
 		natural_t i;


### PR DESCRIPTION
Get the load average directly from the stdlib without parsing a file.

Improve readability of `Cpu::collect()` function on linux and use emplace_back where appropriate.