### PR TITLE
Make process niceness signed ("nice" can take negative values)

### DIFF
--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -262,7 +262,7 @@ namespace Proc {
         double cpu_p{};         // defaults to = 0.0
         double cpu_c{};         // defaults to = 0.0
 		char state = '0';
-        uint64_t p_nice{};      // defaults to 0
+        int64_t p_nice{};      // defaults to 0
         uint64_t ppid{};        // defaults to 0
         uint64_t cpu_s{};       // defaults to 0
         uint64_t cpu_t{};       // defaults to 0


### PR DESCRIPTION
Currently, negative process niceness leads to underflow and huge values displayed in the UI.