### PR TITLE
only use 64 bit variant of statvfs if supported/defined

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -1083,9 +1083,14 @@ namespace Mem {
 				bool new_ignored = false;
 				for (auto& [mountpoint, disk] : disks) {
 					if (std::error_code ec; not fs::exists(mountpoint, ec) or v_contains(ignore_list, mountpoint)) continue;
+					#if defined(_LARGEFILE64_SOURCE) || defined(__USE_LARGEFILE64)
 					struct statvfs64 vfs;
 					if (statvfs64(mountpoint.c_str(), &vfs) < 0) {
-						Logger::warning("Failed to get disk/partition stats for mount \""+ mountpoint + "\" with statvfs64 error code: " + to_string(errno) + ". Ignoring...");
+					#else
+					struct statvfs vfs;
+					if (statvfs(mountpoint.c_str(), &vfs) < 0) {
+					#endif
+						Logger::warning("Failed to get disk/partition stats for mount \""+ mountpoint + "\" with statvfs error code: " + to_string(errno) + ". Ignoring...");
 						ignore_list.push_back(mountpoint);
 						new_ignored = true;
 						continue;


### PR DESCRIPTION
I was testing btop on risc-v *with musl libc* and everything seams to be working perfectly!, but to build it I had to replace statvfs64 with statvfs, since statvfs64 is only defined on musl when _LARGEFILE_SOURCE64 is defined (which for some reason it was not) you could also just forcefully define it, causing musl to just define statvfs64 as statvfs, but I think my change should be quite portable, and not result in any unneeded step downs.