### PR TITLE
ensure statvfs64 is declared

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -22,12 +22,14 @@ tab-size = 4
 #include <cmath>
 #include <unistd.h>
 #include <numeric>
-#include <sys/statvfs.h>
 #include <netdb.h>
 #include <ifaddrs.h>
 #include <net/if.h>
 #include <arpa/inet.h> // for inet_ntop()
 
+#define _LARGEFILE64_SOURCE 1
+#define __USE_LARGEFILE64   1
+#include <sys/statvfs.h>
 
 #if !(defined(STATIC_BUILD) && defined(__GLIBC__))
 	#include <pwd.h>


### PR DESCRIPTION
I was testing btop on risc-v with musl, and I got build errors because statvfs64 is not defined, my first instinct was to just step down to statvfs(not 64) if the LFS defines are not set, #555, because of a bit of a miss understanding of mine of how they work, sorry for that >.<, anyhow this should ensure that under musl libc and glibc statvfs64 is defined.