### PR TITLE
Revert most of #438 and improve const-correctness

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -178,7 +178,7 @@ void term_resize(bool force) {
 		Input::interrupt = true;
 		return;
 	}
-	atomic_lock lck(resizing, true);
+	const atomic_lock lck(resizing, true);
 	if (auto refreshed = Term::refresh(true); refreshed or force) {
 		if (force and refreshed) force = false;
 	}
@@ -447,7 +447,7 @@ namespace Runner {
 		pthread_sigmask(SIG_BLOCK, &mask, nullptr);
 
 		//? pthread_mutex_lock to lock thread and monitor health from main thread
-		thread_lock pt_lck(mtx);
+		const thread_lock pt_lck(mtx);
 		if (pt_lck.status != 0) {
 			Global::exit_error_msg = "Exception in runner thread -> pthread_mutex_lock error id: " + to_string(pt_lck.status);
 			Global::thread_exception = true;
@@ -471,10 +471,10 @@ namespace Runner {
 			}
 
 			//? Atomic lock used for blocking non thread-safe actions in main thread
-			atomic_lock lck(active);
+			const atomic_lock lck(active);
 
 			//? Set effective user if SUID bit is set
-			gain_priv powers{};
+			const gain_priv powers{};
 
 			auto& conf = current_conf;
 
@@ -659,7 +659,7 @@ namespace Runner {
 	//? ------------------------------------------ Secondary thread end -----------------------------------------------
 
 	//* Runs collect and draw in a secondary thread, unlocks and locks config to update cached values
-	void run(const string& box, bool no_update, bool force_redraw) {
+	void run(const string& box, const bool no_update, const bool force_redraw) {
 		atomic_wait_for(active, true, 5000);
 		if (active) {
 			Logger::error("Stall in Runner thread, restarting!");
@@ -703,7 +703,7 @@ namespace Runner {
 	//* Stops any work being done in runner thread and checks for thread errors
 	void stop() {
 		stopping = true;
-		int ret = pthread_mutex_trylock(&mtx);
+		const int ret = pthread_mutex_trylock(&mtx);
 		if (ret != EBUSY and not Global::quitting) {
 			if (active) active = false;
 			Global::exit_error_msg = "Runner thread died unexpectedly!";

--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -479,7 +479,7 @@ namespace Config {
 	void unlock() {
 		if (not locked) return;
 		atomic_wait(Runner::active);
-		atomic_lock lck(writelock, true);
+		const atomic_lock lck(writelock, true);
 		try {
 			if (Proc::shown) {
 				ints.at("selected_pid") = Proc::selected_pid;

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -100,7 +100,7 @@ namespace Symbols {
 
 namespace Draw {
 
-	string banner_gen(int y, int x, bool centered, bool redraw) {
+	string banner_gen(int y, int x, const bool centered, const bool redraw) {
 		static string banner;
 		static size_t width = 0;
 		if (redraw) banner.clear();
@@ -116,7 +116,7 @@ namespace Draw {
 				}
 				else {
 					fg = Theme::hex_to_color(line[0], lowcolor);
-					int bg_i = 120 - z * 12;
+					const int bg_i = 120 - z * 12;
 					bg = Theme::dec_to_color(bg_i, bg_i, bg_i, lowcolor);
 				}
 				for (size_t i = 0; i < line[1].size(); i += 3) {
@@ -142,7 +142,7 @@ namespace Draw {
 	}
 
 	TextEdit::TextEdit() {}
-	TextEdit::TextEdit(string text, bool numeric) : numeric(numeric), text(text) {
+	TextEdit::TextEdit(string text, const bool numeric) : numeric(numeric), text(text) {
 		pos = this->text.size();
 		upos = ulen(this->text);
 	}
@@ -242,7 +242,7 @@ namespace Draw {
 	}
 
 	string createBox(const int x, const int y, const int width,
-					 const int height, string line_color, bool fill,
+					 const int height, string line_color, const bool fill,
 					 const string title, const string title2, const int num) {
 		string out;
 
@@ -290,7 +290,7 @@ namespace Draw {
 		return out + Fx::reset + Mv::to(y + 1, x + 1);
 	}
 
-	bool update_clock(bool force) {
+	bool update_clock(const bool force) {
 		const auto& clock_format = Config::getS("clock_format");
 		if (not Cpu::shown or clock_format.empty()) {
 			if (clock_format.empty() and not Global::clock.empty()) Global::clock.clear();
@@ -357,7 +357,7 @@ namespace Draw {
 	//* Meter class ------------------------------------------------------------------------------------------------------------>
 	Meter::Meter() {}
 
-	Meter::Meter(const int width, const string& color_gradient, bool invert)
+	Meter::Meter(const int width, const string& color_gradient, const bool invert)
 		: width(width), color_gradient(color_gradient), invert(invert) {}
 
 	string Meter::operator()(int value) {
@@ -366,7 +366,7 @@ namespace Draw {
 		if (not cache.at(value).empty()) return cache.at(value);
 		auto& out = cache.at(value);
 		for (const int& i : iota(1, width + 1)) {
-			int y = round((double)i * 100.0 / width);
+			const int y = round((double)i * 100.0 / width);
 			if (value >= y)
 				out += Theme::g(color_gradient).at(invert ? 100 - y : y) + Symbols::meter;
 			else {
@@ -380,7 +380,7 @@ namespace Draw {
 
 	//* Graph class ------------------------------------------------------------------------------------------------------------>
 	void Graph::_create(const deque<long long>& data, int data_offset) {
-		bool mult = (data.size() - data_offset > 1);
+		const bool mult = (data.size() - data_offset > 1);
 		const auto& graph_symbol = Symbols::graph_symbols.at(symbol + '_' + (invert ? "down" : "up"));
 		array<int, 2> result;
 		const float mod = (height == 1) ? 0.3 : 0.1;
@@ -452,7 +452,7 @@ namespace Draw {
 
 	Graph::Graph(int width, int height, const string& color_gradient,
 				 const deque<long long>& data, const string& symbol,
-				 bool invert, bool no_zero, long long max_value, long long offset)
+				 const bool invert, const bool no_zero, long long max_value, long long offset)
 	: width(width), height(height), color_gradient(color_gradient),
 	  invert(invert), no_zero(no_zero), offset(offset) {
 		if (Config::getB("tty_mode") or symbol == "tty") this->symbol = "tty";
@@ -478,7 +478,7 @@ namespace Draw {
 		this->_create(data, data_offset);
 	}
 
-	string& Graph::operator()(const deque<long long>& data, bool data_same) {
+	string& Graph::operator()(const deque<long long>& data, const bool data_same) {
 		if (data_same) return out;
 
 		//? Make room for new characters on graph
@@ -518,12 +518,12 @@ namespace Cpu {
 	vector<Draw::Graph> core_graphs;
 	vector<Draw::Graph> temp_graphs;
 
-	string draw(const cpu_info& cpu, bool force_redraw, bool data_same) {
+	string draw(const cpu_info& cpu, const bool force_redraw, const bool data_same) {
 		if (Runner::stopping) return "";
 		if (force_redraw) redraw = true;
-		bool show_temps = (Config::getB("check_temp") and got_sensors);
+		const bool show_temps = (Config::getB("check_temp") and got_sensors);
 		auto single_graph = Config::getB("cpu_single_graph");
-		bool hide_cores = show_temps and (cpu_temp_only or not Config::getB("show_coretemp"));
+		const bool hide_cores = show_temps and (cpu_temp_only or not Config::getB("show_coretemp"));
 		const int extra_width = (hide_cores ? max(6, 6 * b_column_size) : 0);
 		auto& graph_up_field = Config::getS("cpu_graph_upper");
 		auto& graph_lo_field = Config::getS("cpu_graph_lower");
@@ -755,7 +755,7 @@ namespace Mem {
 	unordered_flat_map<string, Draw::Meter> disk_meters_free;
 	unordered_flat_map<string, Draw::Graph> io_graphs;
 
-	string draw(const mem_info& mem, bool force_redraw, bool data_same) {
+	string draw(const mem_info& mem, const bool force_redraw, const bool data_same) {
 		if (Runner::stopping) return "";
 		if (force_redraw) redraw = true;
 		auto show_swap = Config::getB("show_swap");
@@ -827,7 +827,7 @@ namespace Mem {
 
 						if (io_mode) {
 							//? Create one combined graph for IO read/write if enabled
-							long long speed = (custom_speeds.contains(name) ? custom_speeds.at(name) : 100) << 20;
+							const long long speed = (custom_speeds.contains(name) ? custom_speeds.at(name) : 100) << 20;
 							if (io_graph_combined) {
 								deque<long long> combined(disk.io_read.size(), 0);
 								rng::transform(disk.io_read, disk.io_write, combined.begin(), std::plus<long long>());
@@ -850,7 +850,7 @@ namespace Mem {
 					}
 				}
 
-				for (int i = 0; const auto& [name, ignored] : mem.disks) {
+				for (const int i = 0; const auto& [name, ignored] : mem.disks) {
 					if (i * 2 > height - 2) break;
 					disk_meters_used[name] = Draw::Meter{disk_meter, "used"};
 					if (cmp_less_equal(mem.disks.size() * 3, height - 1))
@@ -868,8 +868,8 @@ namespace Mem {
 		int cx = 1, cy = 1;
 		string divider = (graph_height > 0 ? Mv::l(2) + Theme::c("mem_box") + Symbols::div_left + Theme::c("div_line") + Symbols::h_line * (mem_width - 1)
 						+ (show_disks ? "" : Theme::c("mem_box")) + Symbols::div_right + Mv::l(mem_width - 1) + Theme::c("main_fg") : "");
-		string up = (graph_height >= 2 ? Mv::l(mem_width - 2) + Mv::u(graph_height - 1) : "");
-		bool big_mem = mem_width > 21;
+		const string up = (graph_height >= 2 ? Mv::l(mem_width - 2) + Mv::u(graph_height - 1) : "");
+		const bool big_mem = mem_width > 21;
 
 		out += Mv::to(y + 1, x + 2) + Theme::c("title") + Fx::b + "Total:" + rjust(floating_humanizer(totalMem), mem_width - 9) + Fx::ub + Theme::c("main_fg");
 		vector<string> comb_names (mem_names.begin(), mem_names.end());
@@ -914,7 +914,7 @@ namespace Mem {
 		if (show_disks) {
 			const auto& disks = mem.disks;
 			cx = mem_width; cy = 0;
-			bool big_disk = disks_width >= 25;
+			const bool big_disk = disks_width >= 25;
 			divider = Mv::l(1) + Theme::c("div_line") + Symbols::div_left + Symbols::h_line * disks_width + Theme::c("mem_box") + Fx::ub + Symbols::div_right + Mv::l(disks_width);
 			const string hu_div = Theme::c("div_line") + Symbols::h_line + Theme::c("main_fg");
 			if (io_mode) {
@@ -1009,14 +1009,14 @@ namespace Net {
 	unordered_flat_map<string, Draw::Graph> graphs;
 	string box;
 
-	string draw(const net_info& net, bool force_redraw, bool data_same) {
+	string draw(const net_info& net, const bool force_redraw, const bool data_same) {
 		if (Runner::stopping) return "";
 		if (force_redraw) redraw = true;
 		auto net_sync = Config::getB("net_sync");
 		auto net_auto = Config::getB("net_auto");
 		auto tty_mode = Config::getB("tty_mode");
 		auto& graph_symbol = (tty_mode ? "tty" : Config::getS("graph_symbol_net"));
-		string ip_addr = (net.ipv4.empty() ? net.ipv6 : net.ipv4);
+		const string ip_addr = (net.ipv4.empty() ? net.ipv6 : net.ipv4);
 		if (old_ip != ip_addr) {
 			old_ip = ip_addr;
 			redraw = true;
@@ -1125,7 +1125,7 @@ namespace Proc {
 		const int select_max = (Config::getB("show_detailed") ? Proc::select_max - 8 : Proc::select_max);
 		auto vim_keys = Config::getB("vim_keys");
 
-		int numpids = Proc::numpids;
+		const int numpids = Proc::numpids;
 		if ((cmd_key == "up" or (vim_keys and cmd_key == "k")) and selected > 0) {
 			if (start > 0 and selected == 1) start--;
 			else selected--;
@@ -1162,7 +1162,7 @@ namespace Proc {
 			if (selected > 0) selected = select_max;
 		}
 		else if (cmd_key.starts_with("mousey")) {
-			int mouse_y = std::stoi(cmd_key.substr(6));
+			const int mouse_y = std::stoi(cmd_key.substr(6));
 			start = clamp((int)round((double)mouse_y * (numpids - select_max - 2) / (select_max - 2)), 0, max(0, numpids - select_max));
 		}
 
@@ -1178,11 +1178,13 @@ namespace Proc {
 		return (not changed ? -1 : selected);
 	}
 
-	string draw(const vector<proc_info>& plist, bool force_redraw, bool data_same) {
+	string draw(const vector<proc_info>& plist, const bool force_redraw, const bool data_same) {
 		if (Runner::stopping) return "";
 		auto proc_tree = Config::getB("proc_tree");
-		bool show_detailed = (Config::getB("show_detailed") and cmp_equal(Proc::detailed.last_pid, Config::getI("detailed_pid")));
-		bool proc_gradient = (Config::getB("proc_gradient") and not Config::getB("lowcolor") and Theme::gradients.contains("proc"));
+		const bool show_detailed =
+			(Config::getB("show_detailed") and cmp_equal(Proc::detailed.last_pid, Config::getI("detailed_pid")));
+		const bool proc_gradient =
+			(Config::getB("proc_gradient") and not Config::getB("lowcolor") and Theme::gradients.contains("proc"));
 		auto proc_colors = Config::getB("proc_colors");
 		auto tty_mode = Config::getB("tty_mode");
 		auto& graph_symbol = (tty_mode ? "tty" : Config::getS("graph_symbol_proc"));
@@ -1196,7 +1198,7 @@ namespace Proc {
 		const int height = show_detailed ? Proc::height - 8 : Proc::height;
 		const int select_max = show_detailed ? Proc::select_max - 8 : Proc::select_max;
 		auto totalMem = Mem::get_totalMem();
-		int numpids = Proc::numpids;
+		const int numpids = Proc::numpids;
 		if (force_redraw) redraw = true;
 		string out;
 		out.reserve(width * height);
@@ -1224,7 +1226,7 @@ namespace Proc {
 
 			//? Detailed box
 			if (show_detailed) {
-				bool alive = detailed.status != "Dead";
+				const bool alive = detailed.status != "Dead";
 				dgraph_x = x;
 				dgraph_width = max(width / 3, width - 121);
 				d_width = width - dgraph_width - 1;
@@ -1303,7 +1305,7 @@ namespace Proc {
 				+ (not filtering and not filter_text.empty() ? Theme::c("hi_fg") + " del" : "")
 				+ (filtering ? Theme::c("hi_fg") + ' ' + Symbols::enter : "") + Fx::ub + title_right;
 			if (not filtering) {
-				int f_len = (filter_text.empty() ? 6 : ulen(filter_text) + 2);
+				const int f_len = (filter_text.empty() ? 6 : ulen(filter_text) + 2);
 				Input::mouse_mappings["f"] = {y, x + 10, 1, f_len};
 				if (filter_text.empty() and Input::mouse_mappings.contains("delete"))
 					Input::mouse_mappings.erase("delete");
@@ -1377,7 +1379,7 @@ namespace Proc {
 
 		//? Draw details box if shown
 		if (show_detailed) {
-			bool alive = detailed.status != "Dead";
+			const bool alive = detailed.status != "Dead";
 			const int item_fit = floor((double)(d_width - 2) / 10);
 			const int item_width = floor((double)(d_width - 2) / min(item_fit, 8));
 
@@ -1428,7 +1430,7 @@ namespace Proc {
 		int lc = 0;
 		for (int n=0; auto& p : plist) {
 			if (p.filtered or (proc_tree and p.tree_index == plist.size()) or n++ < start) continue;
-			bool is_selected = (lc + 1 == selected);
+			const bool is_selected = (lc + 1 == selected);
 			if (is_selected) {
 				selected_pid = (int)p.pid;
 				selected_name = p.name;
@@ -1436,7 +1438,7 @@ namespace Proc {
 			}
 
 			//? Update graphs for processes with above 0.0% cpu usage, delete if below 0.1% 10x times
-			bool has_graph = show_graphs ? p_counters.contains(p.pid) : false;
+			const bool has_graph = show_graphs ? p_counters.contains(p.pid) : false;
 			if (show_graphs and ((p.cpu_p > 0 and not has_graph) or (not data_same and has_graph))) {
 				if (not has_graph) {
 					p_graphs[p.pid] = Draw::Graph{5, 1, "", {}, graph_symbol};
@@ -1460,13 +1462,14 @@ namespace Proc {
 				out += Theme::c("selected_bg") + Theme::c("selected_fg") + Fx::b;
 			}
 			else {
-				int calc = (selected > lc) ? selected - lc : lc - selected;
+				const int calc = (selected > lc) ? selected - lc : lc - selected;
 				if (proc_colors) {
 					end = Theme::c("main_fg") + Fx::ub;
 					array<string, 3> colors;
-					for (int i = 0; int v : {(int)round(p.cpu_p), (int)round(p.mem * 100 / totalMem), (int)p.threads / 3}) {
+					for (int i = 0;
+						 const int v : {(int)round(p.cpu_p), (int)round(p.mem * 100 / totalMem), (int)p.threads / 3}) {
 						if (proc_gradient) {
-							int val = (min(v, 100) + 100) - calc * 100 / select_max;
+							const int val = (min(v, 100) + 100) - calc * 100 / select_max;
 							if (val < 100) colors[i++] = Theme::g("proc_color").at(max(0, val));
 							else colors[i++] = Theme::g("process").at(clamp(val - 100, 0, 100));
 						}
@@ -1523,7 +1526,7 @@ namespace Proc {
 			}
 			string mem_str = (mem_bytes ? floating_humanizer(p.mem, true) : "");
 			if (not mem_bytes) {
-				double mem_p = clamp((double)p.mem * 100 / totalMem, 0.0, 100.0);
+				const double mem_p = clamp((double)p.mem * 100 / totalMem, 0.0, 100.0);
 				mem_str = to_string(mem_p);
 				if (mem_str.size() < 4)	mem_str = "0";
 				else mem_str.resize((mem_p < 10 or mem_p >= 100 ? 3 : 4));
@@ -1550,8 +1553,8 @@ namespace Proc {
 		}
 
 		//? Current selection and number of processes
-		string location = to_string(start + selected) + '/' + to_string(numpids);
-		string loc_clear = Symbols::h_line * max((size_t)0, 9 - location.size());
+		const string location = to_string(start + selected) + '/' + to_string(numpids);
+		const string loc_clear = Symbols::h_line * max((size_t)0, 9 - location.size());
 		out += Mv::to(y + height - 1, x+width - 3 - max(9, (int)location.size())) + Fx::ub + Theme::c("proc_box") + loc_clear
 			+ Symbols::title_left_down + Theme::c("title") + Fx::b + location + Fx::ub + Theme::c("proc_box") + Symbols::title_right_down;
 
@@ -1626,7 +1629,7 @@ namespace Draw {
 		//* Calculate and draw cpu box outlines
 		if (Cpu::shown) {
 			using namespace Cpu;
-			bool show_temp = (Config::getB("check_temp") and got_sensors);
+			const bool show_temp = (Config::getB("check_temp") and got_sensors);
 			width = round((double)Term::width * width_p / 100);
 			height = max(8, (int)ceil((double)Term::height * (trim(boxes) == "cpu" ? 100 : height_p) / 100));
 			x = 1;

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -97,7 +97,7 @@ namespace Input {
 
 			// TODO(pg83): read whole buffer
 			while (cin.get(ch)) {
-				std::lock_guard<std::mutex> g(lock);
+				const std::lock_guard<std::mutex> g(lock);
 				current.push_back(ch);
 				if (current.size() > 100) {
 					current.clear();
@@ -106,7 +106,7 @@ namespace Input {
 		}
 
 		size_t avail() {
-			std::lock_guard<std::mutex> g(lock);
+			const std::lock_guard<std::mutex> g(lock);
 
 			return current.size();
 		}
@@ -115,7 +115,7 @@ namespace Input {
 			std::string res;
 
 			{
-				std::lock_guard<std::mutex> g(lock);
+				const std::lock_guard<std::mutex> g(lock);
 
 				res.swap(current);
 			}
@@ -137,7 +137,7 @@ namespace Input {
 	};
 
 	bool poll(int timeout) {
-		atomic_lock lck(polling);
+		const atomic_lock lck(polling);
 		if (timeout < 1) return InputThr::instance().avail() > 0;
 		while (timeout > 0) {
 			if (interrupt) {
@@ -448,22 +448,26 @@ namespace Input {
 			//? Input actions for cpu box
 			if (Cpu::shown) {
 				bool keep_going = false;
-				bool no_update = true;
+				const bool no_update = true;
 				bool redraw = true;
 				static uint64_t last_press = 0;
 
 				if (key == "+" and Config::getI("update_ms") <= 86399900) {
-					int add = (Config::getI("update_ms") <= 86399000 and last_press >= time_ms() - 200
-						and rng::all_of(Input::history, [](const auto& str){ return str == "+"; })
-						? 1000 : 100);
+					const int add =
+						(Config::getI("update_ms") <= 86399000 and last_press >= time_ms() - 200 and
+								 rng::all_of(Input::history, [](const auto& str) { return str == "+"; })
+							 ? 1000
+							 : 100);
 					Config::set("update_ms", Config::getI("update_ms") + add);
 					last_press = time_ms();
 					redraw = true;
 				}
 				else if (key == "-" and Config::getI("update_ms") >= 200) {
-					int sub = (Config::getI("update_ms") >= 2000 and last_press >= time_ms() - 200
-						and rng::all_of(Input::history, [](const auto& str){ return str == "-"; })
-						? 1000 : 100);
+					const int sub =
+						(Config::getI("update_ms") >= 2000 and last_press >= time_ms() - 200 and
+								 rng::all_of(Input::history, [](const auto& str) { return str == "-"; })
+							 ? 1000
+							 : 100);
 					Config::set("update_ms", Config::getI("update_ms") - sub);
 					last_press = time_ms();
 					redraw = true;
@@ -480,7 +484,7 @@ namespace Input {
 			if (Mem::shown) {
 				bool keep_going = false;
 				bool no_update = true;
-				bool redraw = true;
+				const bool redraw = true;
 
 				if (key == "i") {
 					Config::flip("io_mode");
@@ -502,7 +506,7 @@ namespace Input {
 			if (Net::shown) {
 				bool keep_going = false;
 				bool no_update = true;
-				bool redraw = true;
+				const bool redraw = true;
 
 				if (is_in(key, "b", "n")) {
 					atomic_wait(Runner::active);

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -651,7 +651,7 @@ namespace Menu {
 
 	string msgBox::operator()() {
 		string out;
-		int pos = width / 2 - (boxtype == 0 ? 6 : 14);
+		const int pos = width / 2 - (boxtype == 0 ? 6 : 14);
 		auto& first_color = (selected == 0 ? Theme::c("hi_fg") : Theme::c("div_line"));
 		out = Mv::d(1) + Mv::r(pos) + Fx::b + first_color + button_left + (selected == 0 ? Theme::c("title") : Theme::c("main_fg") + Fx::ub)
 			+ (boxtype == 0 ? "    Ok    " : "    Yes    ") + first_color + button_right;
@@ -738,8 +738,7 @@ namespace Menu {
 			return Closed;
 		}
 		else if (key.starts_with("button_")) {
-			if (int new_select = stoi(key.substr(7)); new_select == selected_signal)
-				goto ChooseEntering;
+			if (const int new_select = stoi(key.substr(7)); new_select == selected_signal) goto ChooseEntering;
 			else
 				selected_signal = new_select;
 		}
@@ -766,7 +765,7 @@ namespace Menu {
 			if (selected_signal == 1) selected_signal = 31;
 			else if (selected_signal < 6) selected_signal += 25;
 			else {
-				bool offset = (selected_signal > 16);
+				const bool offset = (selected_signal > 16);
 				selected_signal -= 5;
 				if (selected_signal <= 16 and offset) selected_signal--;
 			}
@@ -776,7 +775,7 @@ namespace Menu {
 			else if (selected_signal < 1 or selected_signal == 16) selected_signal = 1;
 			else if (selected_signal > 26) selected_signal -= 25;
 			else {
-				bool offset = (selected_signal < 16);
+				const bool offset = (selected_signal < 16);
 				selected_signal += 5;
 				if (selected_signal >= 16 and offset) selected_signal++;
 				if (selected_signal > 31) selected_signal = 31;
@@ -853,12 +852,14 @@ namespace Menu {
 		if (redraw) {
 			atomic_wait(Runner::active);
 			auto& p_name = (s_pid == Config::getI("detailed_pid") ? Proc::detailed.entry.name : Config::getS("selected_name"));
-			vector<string> cont_vec = {
-				Fx::b + Theme::c("main_fg") + "Send signal: " + Fx::ub + Theme::c("hi_fg") + to_string(signalToSend)
-				+ (signalToSend > 0 and signalToSend <= 32 ? Theme::c("main_fg") + " (" + P_Signals.at(signalToSend) + ')' : ""),
+			const vector<string> cont_vec = {
+				Fx::b + Theme::c("main_fg") + "Send signal: " + Fx::ub + Theme::c("hi_fg") + to_string(signalToSend) +
+					(signalToSend > 0 and signalToSend <= 32
+						 ? Theme::c("main_fg") + " (" + P_Signals.at(signalToSend) + ')'
+						 : ""),
 
-				Fx::b + Theme::c("main_fg") + "To PID: " + Fx::ub + Theme::c("hi_fg") + to_string(s_pid) + Theme::c("main_fg") + " ("
-				+ uresize(p_name, 16) + ')' + Fx::reset,
+				Fx::b + Theme::c("main_fg") + "To PID: " + Fx::ub + Theme::c("hi_fg") + to_string(s_pid) +
+					Theme::c("main_fg") + " (" + uresize(p_name, 16) + ')' + Fx::reset,
 			};
 			messageBox = Menu::msgBox{50, 1, cont_vec, (signalToSend > 1 and signalToSend <= 32 and signalToSend != 17 ? P_Signals.at(signalToSend) : "signal")};
 			Global::overlay = messageBox();
@@ -949,8 +950,7 @@ namespace Menu {
 			return Closed;
 		}
 		else if (key.starts_with("button_")) {
-			if (int new_select = key.back() - '0'; new_select == selected)
-				goto MainEntering;
+			if (const int new_select = key.back() - '0'; new_select == selected) goto MainEntering;
 			else
 				selected = new_select;
 		}
@@ -1264,7 +1264,8 @@ namespace Menu {
 						? Theme::c("hi_fg") + '[' + Theme::c("title") + m + Theme::c("hi_fg") + ']'
 						: Theme::c("hi_fg") + to_string(i + 1) + Theme::c("title") + m + ' ')
 					+ Mv::r(10);
-				if (string button_name = "select_cat_" + to_string(i + 1); not editing and not mouse_mappings.contains(button_name))
+				if (const string button_name = "select_cat_" + to_string(i + 1);
+					not editing and not mouse_mappings.contains(button_name))
 					mouse_mappings[button_name] = {y+6, x+2 + 15*i, 3, 15};
 				i++;
 			}

--- a/src/btop_theme.cpp
+++ b/src/btop_theme.cpp
@@ -159,14 +159,14 @@ namespace Theme {
 					return "";
 				}
 			}
-			string pre = Fx::e + (depth == "fg" ? "38" : "48") + ";" + (t_to_256 ? "5;" : "2;");
+			const string pre = Fx::e + (depth == "fg" ? "38" : "48") + ";" + (t_to_256 ? "5;" : "2;");
 
 			if (hexa.size() == 2) {
-				int h_int = stoi(hexa, nullptr, 16);
+				const int h_int = stoi(hexa, nullptr, 16);
 				if (t_to_256) {
 					return pre + to_string(truecolor_to_256(h_int, h_int, h_int)) + "m";
 				} else {
-					string h_str = to_string(h_int);
+					const string h_str = to_string(h_int);
 					return pre + h_str + ";" + h_str + ";" + h_str + "m";
 				}
 			}
@@ -190,7 +190,7 @@ namespace Theme {
 	}
 
 	string dec_to_color(int r, int g, int b, bool t_to_256, const string& depth) {
-		string pre = Fx::e + (depth == "fg" ? "38" : "48") + ";" + (t_to_256 ? "5;" : "2;");
+		const string pre = Fx::e + (depth == "fg" ? "38" : "48") + ";" + (t_to_256 ? "5;" : "2;");
 		r = std::clamp(r, 0, 255);
 		g = std::clamp(g, 0, 255);
 		b = std::clamp(b, 0, 255);
@@ -209,7 +209,7 @@ namespace Theme {
 				}
 
 				if (hexa.size() == 2) {
-					int h_int = stoi(hexa, nullptr, 16);
+					const int h_int = stoi(hexa, nullptr, 16);
 					return array{h_int, h_int, h_int};
 				}
 				else if (hexa.size() == 6) {
@@ -227,7 +227,7 @@ namespace Theme {
 		void generateColors(const unordered_flat_map<string, string>& source) {
 			vector<string> t_rgb;
 			string depth;
-			bool t_to_256 = Config::getB("lowcolor");
+			const bool t_to_256 = Config::getB("lowcolor");
 			colors.clear(); rgbs.clear();
 			for (const auto& [name, color] : Default_theme) {
 				if (name == "main_bg" and not Config::getB("theme_background")) {
@@ -290,7 +290,7 @@ namespace Theme {
 		//* Generate color gradients from two or three colors, 101 values indexed 0-100
 		void generateGradients() {
 			gradients.clear();
-			bool t_to_256 = Config::getB("lowcolor");
+			const bool t_to_256 = Config::getB("lowcolor");
 
 			//? Insert values for processes greyscale gradient and processes color gradient
 			rgbs.insert({
@@ -321,11 +321,11 @@ namespace Theme {
 				if (input_colors[2][0] >= 0) {
 
 					//? Split iteration in two passes of 50 + 51 instead of one pass of 101 if gradient has start, mid and end values defined
-					int current_range = (input_colors[1][0] >= 0) ? 50 : 100;
-					for (int rgb : iota(0, 3)) {
+					const int current_range = (input_colors[1][0] >= 0) ? 50 : 100;
+					for (const int rgb : iota(0, 3)) {
 						int start = 0, offset = 0;
 						int end = (current_range == 50) ? 1 : 2;
-						for (int i : iota(0, 101)) {
+						for (const int i : iota(0, 101)) {
 							output_colors[i][rgb] = input_colors[start][rgb] + (i - offset) * (input_colors[end][rgb] - input_colors[start][rgb]) / current_range;
 
 							//? Switch source arrays from start->mid to mid->end at 50 passes if mid is defined
@@ -360,7 +360,7 @@ namespace Theme {
 				const string base_name = rtrim(c.first, "_start");
 				string section = "_start";
 				int split = colors.at(base_name + "_mid").empty() ? 50 : 33;
-				for (int i : iota(0, 101)) {
+				for (const int i : iota(0, 101)) {
 					gradients[base_name][i] = colors.at(base_name + section);
 					if (i == split) {
 						section = (split == 33) ? "_mid" : "_end";

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -64,7 +64,7 @@ namespace Term {
 		struct termios initial_settings;
 
 		//* Toggle terminal input echo
-		bool echo(bool on=true) {
+		bool echo(const bool on = true) {
 			struct termios settings;
 			if (tcgetattr(STDIN_FILENO, &settings)) return false;
 			if (on) settings.c_lflag |= ECHO;
@@ -73,7 +73,7 @@ namespace Term {
 		}
 
 		//* Toggle need for return key when reading input
-		bool linebuffered(bool on=true) {
+		bool linebuffered(const bool on = true) {
 			struct termios settings;
 			if (tcgetattr(STDIN_FILENO, &settings)) return false;
 			if (on) settings.c_lflag |= ICANON;
@@ -85,7 +85,7 @@ namespace Term {
 		}
 	}
 
-	bool refresh(bool only_check) {
+	bool refresh(const bool only_check) {
 		struct winsize w;
 		if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) < 0) return false;
 		if (width != w.ws_col or height != w.ws_row) {
@@ -99,10 +99,10 @@ namespace Term {
 	}
 
 	auto get_min_size(const string& boxes) -> array<int, 2> {
-		bool cpu = boxes.find("cpu") != string::npos;
-		bool mem = boxes.find("mem") != string::npos;
-		bool net = boxes.find("net") != string::npos;
-		bool proc = boxes.find("proc") != string::npos;
+		const bool cpu = boxes.find("cpu") != string::npos;
+		const bool mem = boxes.find("mem") != string::npos;
+		const bool net = boxes.find("net") != string::npos;
+		const bool proc = boxes.find("proc") != string::npos;
 		int width = 0;
 		if (mem) width = Mem::min_width;
 		else if (net) width = Mem::min_width;
@@ -206,7 +206,7 @@ namespace Tools {
 		return chars;
 	}
 
-	string uresize(string str, const size_t len, bool wide) {
+	string uresize(string str, const size_t len, const bool wide) {
 		if (len < 1 or str.empty())
 			return "";
 
@@ -293,7 +293,7 @@ namespace Tools {
 		return out;
 	}
 
-	string ljust(string str, const size_t x, bool utf, bool wide, bool limit) {
+	string ljust(string str, const size_t x, const bool utf, const bool wide, const bool limit) {
 		if (utf) {
 			if (limit and ulen(str, wide) > x)
 				return uresize(str, x, wide);
@@ -309,7 +309,7 @@ namespace Tools {
 		}
 	}
 
-	string rjust(string str, const size_t x, bool utf, bool wide, bool limit) {
+	string rjust(string str, const size_t x, const bool utf, const bool wide, const bool limit) {
 		if (utf) {
 			if (limit and ulen(str, wide) > x)
 				return uresize(str, x, wide);
@@ -325,7 +325,7 @@ namespace Tools {
 		}
 	}
 
-	string cjust(string str, const size_t x, bool utf, bool wide, bool limit) {
+	string cjust(string str, const size_t x, const bool utf, const bool wide, const bool limit) {
 		if (utf) {
 			if (limit and ulen(str, wide) > x)
 				return uresize(str, x, wide);
@@ -355,10 +355,13 @@ namespace Tools {
 		return (newstr.empty()) ? str : newstr + string{oldstr};
 	}
 
-	string sec_to_dhms(size_t seconds, bool no_days, bool no_seconds) {
-		size_t days = seconds / 86400; seconds %= 86400;
-		size_t hours = seconds / 3600; seconds %= 3600;
-		size_t minutes = seconds / 60; seconds %= 60;
+	string sec_to_dhms(size_t seconds, const bool no_days, const bool no_seconds) {
+		const size_t days = seconds / 86400;
+		seconds %= 86400;
+		const size_t hours = seconds / 3600;
+		seconds %= 3600;
+		const size_t minutes = seconds / 60;
+		seconds %= 60;
 		string out 	= (not no_days and days > 0 ? to_string(days) + "d " : "")
 					+ (hours < 10 ? "0" : "") + to_string(hours) + ':'
 					+ (minutes < 10 ? "0" : "") + to_string(minutes)
@@ -366,10 +369,10 @@ namespace Tools {
 		return out;
 	}
 
-	string floating_humanizer(uint64_t value, bool shorten, size_t start, bool bit, bool per_second) {
+	string floating_humanizer(uint64_t value, const bool shorten, size_t start, const bool bit, const bool per_second) {
 		string out;
 		const size_t mult = (bit) ? 8 : 1;
-		bool mega = Config::getB("base_10_sizes");
+		const bool mega = Config::getB("base_10_sizes");
 
 		// taking advantage of type deduction for array creation (since C++17)
 		// combined with string literals (operator""s)
@@ -479,16 +482,16 @@ namespace Tools {
 		return ss.str();
 	}
 
-	void atomic_wait(const atomic<bool>& atom, bool old) noexcept {
+	void atomic_wait(const atomic<bool>& atom, const bool old) noexcept {
 		while (atom.load(std::memory_order_relaxed) == old ) busy_wait();
 	}
 
-	void atomic_wait_for(const atomic<bool>& atom, bool old, const uint64_t wait_ms) noexcept {
+	void atomic_wait_for(const atomic<bool>& atom, const bool old, const uint64_t wait_ms) noexcept {
 		const uint64_t start_time = time_ms();
 		while (atom.load(std::memory_order_relaxed) == old and (time_ms() - start_time < wait_ms)) sleep_ms(1);
 	}
 
-	atomic_lock::atomic_lock(atomic<bool>& atom, bool wait) : atom(atom) {
+	atomic_lock::atomic_lock(atomic<bool>& atom, const bool wait) : atom(atom) {
 		if (wait) while (not this->atom.compare_exchange_strong(this->not_true, true));
 		else this->atom.store(true);
 	}
@@ -568,8 +571,8 @@ namespace Logger {
 
 	void log_write(const size_t level, const string& msg) {
 		if (loglevel < level or logfile.empty()) return;
-		atomic_lock lck(busy, true);
-		lose_priv neutered{};
+		const atomic_lock lck(busy, true);
+		const lose_priv neutered{};
 		std::error_code ec;
 		try {
 			if (fs::exists(logfile) and fs::file_size(logfile, ec) > 1024 << 10 and not ec) {

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -256,7 +256,7 @@ namespace Cpu {
 			//? Setup up paths to search for sensors
 			if (fs::exists(fs::path("/sys/class/hwmon")) and access("/sys/class/hwmon", R_OK) != -1) {
 				for (const auto& dir : fs::directory_iterator(fs::path("/sys/class/hwmon"))) {
-					fs::path add_path = fs::canonical(dir.path());
+					fs::path const add_path = fs::canonical(dir.path());
 					if (v_contains(search_paths, add_path) or v_contains(search_paths, add_path / "device")) continue;
 
 					if (s_contains(add_path, "coretemp"))
@@ -265,7 +265,7 @@ namespace Cpu {
 					for (const auto & file : fs::directory_iterator(add_path)) {
 						if (string(file.path().filename()) == "device") {
 							for (const auto & dev_file : fs::directory_iterator(file.path())) {
-								string dev_filename = dev_file.path().filename();
+								const string dev_filename = dev_file.path().filename();
 								if (dev_filename.starts_with("temp") and dev_filename.ends_with("_input")) {
 									search_paths.push_back(file.path());
 									break;
@@ -273,7 +273,7 @@ namespace Cpu {
 							}
 						}
 
-						string filename = file.path().filename();
+						const string filename = file.path().filename();
 						if (filename.starts_with("temp") and filename.ends_with("_input")) {
 							search_paths.push_back(add_path);
 							break;
@@ -283,10 +283,10 @@ namespace Cpu {
 			}
 			if (not got_coretemp and fs::exists(fs::path("/sys/devices/platform/coretemp.0/hwmon"))) {
 				for (auto& d : fs::directory_iterator(fs::path("/sys/devices/platform/coretemp.0/hwmon"))) {
-					fs::path add_path = fs::canonical(d.path());
+					fs::path const add_path = fs::canonical(d.path());
 
 					for (const auto & file : fs::directory_iterator(add_path)) {
-						string filename = file.path().filename();
+						const string filename = file.path().filename();
 						if (filename.starts_with("temp") and filename.ends_with("_input") and not v_contains(search_paths, add_path)) {
 								search_paths.push_back(add_path);
 								got_coretemp = true;
@@ -517,8 +517,8 @@ namespace Cpu {
 				for (const auto& split : ssplit(custom_map)) {
 					const auto vals = ssplit(split, ':');
 					if (vals.size() != 2) continue;
-					int change_id = std::stoi(vals.at(0));
-					int new_id = std::stoi(vals.at(1));
+					const int change_id = std::stoi(vals.at(0));
+					const int new_id = std::stoi(vals.at(1));
 					if (not core_map.contains(change_id) or cmp_greater(new_id, core_sensors.size())) continue;
 					core_map.at(change_id) = new_id;
 				}
@@ -556,7 +556,7 @@ namespace Cpu {
 								or not fs::exists(d.path() / "present")
 								or stoi(readfile(d.path() / "present")) != 1)
 								continue;
-							string dev_type = readfile(d.path() / "type");
+							const string dev_type = readfile(d.path() / "type");
 							if (is_in(dev_type, "Battery", "UPS")) {
 								bat_dir = d.path();
 								new_bat.base_dir = d.path();
@@ -703,7 +703,7 @@ namespace Cpu {
 					if (i == 0) cread.ignore(SSmax, ' ');
 					else {
 						cread >> cpu_name;
-						int cpuNum = std::stoi(cpu_name.substr(3));
+						const int cpuNum = std::stoi(cpu_name.substr(3));
 						if (cpuNum >= target - 1) target = cpuNum + (cread.peek() == 'c' ? 2 : 1);
 
 						//? Add zero value for core if core number is missing from /proc/stat
@@ -930,7 +930,7 @@ namespace Mem {
 		//? Get disks stats
 		if (show_disks) {
 			static vector<string> ignore_list;
-			double uptime = system_uptime();
+			const double uptime = system_uptime();
 			auto free_priv = Config::getB("disk_free_priv");
 			try {
 				auto& disks_filter = Config::getS("disks_filter");
@@ -1006,7 +1006,7 @@ namespace Mem {
 
 						//? Match filter if not empty
 						if (not filter.empty()) {
-							bool match = v_contains(filter, mountpoint);
+							const bool match = v_contains(filter, mountpoint);
 							if ((filter_exclude and match) or (not filter_exclude and not match))
 								continue;
 						}
@@ -1423,7 +1423,7 @@ namespace Net {
 						if (nullptr != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr)->sin_addr), ip, IPBUFFER_MAXSIZE)) {
 							net[iface].ipv4 = ip;
 						} else {
-							int errsv = errno;
+							const int errsv = errno;
 							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
 						}
 					}
@@ -1434,7 +1434,7 @@ namespace Net {
 						if (nullptr != inet_ntop(family, &(reinterpret_cast<struct sockaddr_in6*>(ifa->ifa_addr)->sin6_addr), ip, IPBUFFER_MAXSIZE)) {
 							net[iface].ipv6 = ip;
 						} else {
-							int errsv = errno;
+							const int errsv = errno;
 							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
 						}
 					}
@@ -1588,7 +1588,7 @@ namespace Proc {
 
 	//* Get detailed info for selected process
 	void _collect_details(const size_t pid, const uint64_t uptime, vector<proc_info>& procs) {
-		fs::path pid_path = Shared::procPath / std::to_string(pid);
+		fs::path const pid_path = Shared::procPath / std::to_string(pid);
 
 		if (pid != detailed.last_pid) {
 			detailed = {};
@@ -1696,7 +1696,7 @@ namespace Proc {
 		const size_t detailed_pid = Config::getI("detailed_pid");
 		bool should_filter = current_filter != filter;
 		if (should_filter) current_filter = filter;
-		bool sorted_change = (sorting != current_sort or reverse != current_rev or should_filter);
+		const bool sorted_change = (sorting != current_sort or reverse != current_rev or should_filter);
 		if (sorted_change) {
 			current_sort = sorting;
 			current_rev = reverse;
@@ -1733,7 +1733,7 @@ namespace Proc {
 			}
 
 			auto totalMem = Mem::get_totalMem();
-			int totalMem_len = to_string(totalMem >> 10).size();
+			const int totalMem_len = to_string(totalMem >> 10).size();
 
 			//? Update uid_user map if /etc/passwd changed since last run
 			if (not Shared::passwd_path.empty() and fs::last_write_time(Shared::passwd_path) != passwd_time) {
@@ -2044,7 +2044,7 @@ namespace Proc {
 
 			//? Move current selection/view to the selected process when collapsing/expanding in the tree
 			if (locate_selection) {
-				int loc = rng::find(current_procs, Proc::selected_pid, &proc_info::pid)->tree_index;
+				const int loc = rng::find(current_procs, Proc::selected_pid, &proc_info::pid)->tree_index;
 				if (Config::ints.at("proc_start") >= loc or Config::ints.at("proc_start") <= loc - Proc::select_max)
 					Config::ints.at("proc_start") = max(0, loc - 1);
 				Config::ints.at("proc_selected") = loc - Config::ints.at("proc_start") + 1;


### PR DESCRIPTION
Reverts the removal of `const`-qualifiers on bools.

Even if this produces the same binary it is good practice to be const-correct and not let developers accidentally change variables that shouldn't be modified