### PR TITLE
Fix path to Linux CI file in itself

### DIFF
--- a/.github/workflows/continuous-build-linux.yml
+++ b/.github/workflows/continuous-build-linux.yml
@@ -13,7 +13,7 @@ on:
       - '!src/freebsd/**'
       - 'include/**'
       - 'Makefile'
-      - '.github/workflows/continuous-build.yml'
+      - '.github/workflows/continuous-build-linux.yml'
   pull_request:
     branches:
       - main
@@ -23,7 +23,7 @@ on:
       - '!src/freebsd/**'
       - 'include/**'
       - 'Makefile'
-      - '.github/workflows/continuous-build.yml'
+      - '.github/workflows/continuous-build-linux.yml'
 
 jobs:
   static-build:


### PR DESCRIPTION
The CI file has a list of dependent files including itself. The path was not updated when the CI was split into different files