### PR TITLE
Add Debian/Ubuntu binary install command to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,10 @@ Also needs a UTF8 locale and a font that covers:
 	```sh
 	pkg install btop
 	```
+* **Ubuntu/Debian**
+	```bash
+	sudo apt install -y btop
+	```
 
 
 **Binary release on Homebrew (macOS (x86_64 & ARM64) / Linux (x86_64))**


### PR DESCRIPTION
Hey. I noticed that there is no installation command in readme for debian/ubuntu linuxes and added that, as I managed to successfully install it using `sudo apt install -y btop`