### PR TITLE
Convert parameters and config keys to std::string_view

### DIFF
--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -17,10 +17,12 @@ tab-size = 4
 */
 
 #include <array>
-#include <ranges>
 #include <atomic>
 #include <fstream>
+#include <ranges>
 #include <string_view>
+
+#include <fmt/core.h>
 
 #include "btop_config.hpp"
 #include "btop_shared.hpp"
@@ -193,7 +195,7 @@ namespace Config {
 								"#* The level set includes all lower levels, i.e. \"DEBUG\" will show all logging info."}
 	};
 
-	unordered_flat_map<string, string> strings = {
+	unordered_flat_map<std::string_view, string> strings = {
 		{"color_theme", "Default"},
 		{"shown_boxes", "cpu mem net proc"},
 		{"graph_symbol", "braille"},
@@ -219,9 +221,9 @@ namespace Config {
 		{"proc_command", ""},
 		{"selected_name", ""},
 	};
-	unordered_flat_map<string, string> stringsTmp;
+	unordered_flat_map<std::string_view, string> stringsTmp;
 
-	unordered_flat_map<string, bool> bools = {
+	unordered_flat_map<std::string_view, bool> bools = {
 		{"theme_background", true},
 		{"truecolor", true},
 		{"rounded_corners", true},
@@ -267,9 +269,9 @@ namespace Config {
 		{"show_detailed", false},
 		{"proc_filtering", false},
 	};
-	unordered_flat_map<string, bool> boolsTmp;
+	unordered_flat_map<std::string_view, bool> boolsTmp;
 
-	unordered_flat_map<string, int> ints = {
+	unordered_flat_map<std::string_view, int> ints = {
 		{"update_ms", 2000},
 		{"net_download", 100},
 		{"net_upload", 100},
@@ -280,9 +282,9 @@ namespace Config {
 		{"proc_selected", 0},
 		{"proc_last_selected", 0},
 	};
-	unordered_flat_map<string, int> intsTmp;
+	unordered_flat_map<std::string_view, int> intsTmp;
 
-	bool _locked(const string& name) {
+	bool _locked(const std::string_view name) {
 		atomic_wait(writelock, true);
 		if (not write_new and rng::find_if(descriptions, [&name](const auto& a) { return a.at(0) == name; }) != descriptions.end())
 			write_new = true;
@@ -369,7 +371,7 @@ namespace Config {
 
 	string validError;
 
-	bool intValid(const string& name, const string& value) {
+	bool intValid(const std::string_view name, const string& value) {
 		int i_value;
 		try {
 			i_value = stoi(value);
@@ -399,7 +401,7 @@ namespace Config {
 		return false;
 	}
 
-	bool stringValid(const string& name, const string& value) {
+	bool stringValid(const std::string_view name, const string& value) {
 		if (name == "log_level" and not v_contains(Logger::log_levels, value))
 			validError = "Invalid log_level: " + value;
 
@@ -407,7 +409,7 @@ namespace Config {
 			validError = "Invalid graph symbol identifier: " + value;
 
 		else if (name.starts_with("graph_symbol_") and (value != "default" and not v_contains(valid_graph_symbols, value)))
-			validError = "Invalid graph symbol identifier for" + name + ": " + value;
+			validError = fmt::format("Invalid graph symbol identifier for {}: {}", name, value);
 
 		else if (name == "shown_boxes" and not value.empty() and not check_boxes(value))
 			validError = "Invalid box name(s) in shown_boxes!";
@@ -456,7 +458,7 @@ namespace Config {
 		return false;
 	}
 
-	string getAsString(const string& name) {
+	string getAsString(const std::string_view name) {
 		if (bools.contains(name))
 			return (bools.at(name) ? "True" : "False");
 		else if (ints.contains(name))
@@ -466,7 +468,7 @@ namespace Config {
 		return "";
 	}
 
-	void flip(const string& name) {
+	void flip(const std::string_view name) {
 		if (_locked(name)) {
 			if (boolsTmp.contains(name)) boolsTmp.at(name) = not boolsTmp.at(name);
 			else boolsTmp.insert_or_assign(name, (not bools.at(name)));

--- a/src/btop_config.hpp
+++ b/src/btop_config.hpp
@@ -20,8 +20,9 @@ tab-size = 4
 
 #include <string>
 #include <vector>
-#include <robin_hood.h>
 #include <filesystem>
+
+#include <robin_hood.h>
 
 using std::string;
 using std::vector;
@@ -33,12 +34,12 @@ namespace Config {
 	extern std::filesystem::path conf_dir;
 	extern std::filesystem::path conf_file;
 
-	extern unordered_flat_map<string, string> strings;
-	extern unordered_flat_map<string, string> stringsTmp;
-	extern unordered_flat_map<string, bool> bools;
-	extern unordered_flat_map<string, bool> boolsTmp;
-	extern unordered_flat_map<string, int> ints;
-	extern unordered_flat_map<string, int> intsTmp;
+	extern unordered_flat_map<std::string_view, string> strings;
+	extern unordered_flat_map<std::string_view, string> stringsTmp;
+	extern unordered_flat_map<std::string_view, bool> bools;
+	extern unordered_flat_map<std::string_view, bool> boolsTmp;
+	extern unordered_flat_map<std::string_view, int> ints;
+	extern unordered_flat_map<std::string_view, int> intsTmp;
 
 	const vector<string> valid_graph_symbols = { "braille", "block", "tty" };
 	const vector<string> valid_graph_symbols_def = { "default", "braille", "block", "tty" };
@@ -62,44 +63,44 @@ namespace Config {
 	//* Apply selected preset
 	void apply_preset(const string& preset);
 
-	bool _locked(const string& name);
+	bool _locked(const std::string_view name);
 
 	//* Return bool for config key <name>
-	inline bool getB(const string& name) { return bools.at(name); }
+	inline bool getB(const std::string_view name) { return bools.at(name); }
 
 	//* Return integer for config key <name>
-	inline const int& getI(const string& name) { return ints.at(name); }
+	inline const int& getI(const std::string_view name) { return ints.at(name); }
 
 	//* Return string for config key <name>
-	inline const string& getS(const string& name) { return strings.at(name); }
+	inline const string& getS(const std::string_view name) { return strings.at(name); }
 
-	string getAsString(const string& name);
+	string getAsString(const std::string_view name);
 
 	extern string validError;
 
-	bool intValid(const string& name, const string& value);
-	bool stringValid(const string& name, const string& value);
+	bool intValid(const std::string_view name, const string& value);
+	bool stringValid(const std::string_view name, const string& value);
 
 	//* Set config key <name> to bool <value>
-	inline void set(const string& name, bool value) {
+	inline void set(const std::string_view name, bool value) {
 		if (_locked(name)) boolsTmp.insert_or_assign(name, value);
 		else bools.at(name) = value;
 	}
 
 	//* Set config key <name> to int <value>
-	inline void set(const string& name, const int& value) {
+	inline void set(const std::string_view name, const int& value) {
 		if (_locked(name)) intsTmp.insert_or_assign(name, value);
 		else ints.at(name) = value;
 	}
 
 	//* Set config key <name> to string <value>
-	inline void set(const string& name, const string& value) {
+	inline void set(const std::string_view name, const string& value) {
 		if (_locked(name)) stringsTmp.insert_or_assign(name, value);
 		else strings.at(name) = value;
 	}
 
 	//* Flip config key bool <name>
-	void flip(const string& name);
+	void flip(const std::string_view name);
 
 	//* Lock config and cache changes until unlocked
 	void lock();


### PR DESCRIPTION
Using std::string_view instead of std::string& silences a new warning from GCC 13, `-Wdangling-reference`

Also switch return type of `getI` from int& to int, trivial types are cheaper to copy by value