### PR TITLE
[macos] fix temp sensor on system with many cores

### DIFF
--- a/src/osx/smc.cpp
+++ b/src/osx/smc.cpp
@@ -37,7 +37,7 @@ static UInt32 _strtoul(char *str, int size, int base) {
 
 static void _ultostr(char *str, UInt32 val) {
 	str[0] = '\0';
-	sprintf(str, "%c%c%c%c",
+	snprintf(str, 5, "%c%c%c%c",
 			(unsigned int)val >> 24,
 			(unsigned int)val >> 16,
 			(unsigned int)val >> 8,
@@ -47,10 +47,8 @@ static void _ultostr(char *str, UInt32 val) {
 namespace Cpu {
 
 	SMCConnection::SMCConnection() {
-		IOMasterPort(kIOMasterPortDefault, &masterPort);
-
 		CFMutableDictionaryRef matchingDictionary = IOServiceMatching("AppleSMC");
-		result = IOServiceGetMatchingServices(masterPort, matchingDictionary, &iterator);
+		result = IOServiceGetMatchingServices(0, matchingDictionary, &iterator);
 		if (result != kIOReturnSuccess) {
 			throw std::runtime_error("failed to get AppleSMC");
 		}

--- a/src/osx/smc.cpp
+++ b/src/osx/smc.cpp
@@ -94,10 +94,10 @@ namespace Cpu {
 	// according to VirtualSMC docs (hackintosh fake SMC) the enumeration follows with alphabetic chars - not implemented yet here (nor in VirtualSMC)
 	long long SMCConnection::getTemp(int core) {
 		char key[] = SMC_KEY_CPU_TEMP;
-		if (core > MaxIndexCount) {
-			return -1;
-		}
 		if (core >= 0) {
+			if ((size_t)core > MaxIndexCount) {
+				return -1;
+			}
 			snprintf(key, 5, "TC%1cc", KeyIndexes[core]);
 		}
 		long long result = getSMCTemp(key);

--- a/src/osx/smc.cpp
+++ b/src/osx/smc.cpp
@@ -18,6 +18,9 @@ tab-size = 4
 
 #include "smc.hpp"
 
+static constexpr size_t MaxIndexCount = sizeof("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ") - 1;
+static constexpr const char *KeyIndexes = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
 static UInt32 _strtoul(char *str, int size, int base) {
 	UInt32 total = 0;
 	int i;
@@ -91,13 +94,16 @@ namespace Cpu {
 	// according to VirtualSMC docs (hackintosh fake SMC) the enumeration follows with alphabetic chars - not implemented yet here (nor in VirtualSMC)
 	long long SMCConnection::getTemp(int core) {
 		char key[] = SMC_KEY_CPU_TEMP;
+		if (core > MaxIndexCount) {
+			return -1;
+		}
 		if (core >= 0) {
-			snprintf(key, 5, "TC%1dc", core);
+			snprintf(key, 5, "TC%1cc", KeyIndexes[core]);
 		}
 		long long result = getSMCTemp(key);
 		if (result == -1) {
 			// try again with C
-			snprintf(key, 5, "TC%1dC", core);
+			snprintf(key, 5, "TC%1dC", KeyIndexes[core]);
 			result = getSMCTemp(key);
 		}
 		return result;


### PR DESCRIPTION
On my hackintosh (which is now upgraded to i9 13900K) the temperature readings of most cores is `-1` because the code doesn't support more than 10 cores (and mine now has 24C/32T). 

This patch fixes that.

Note: this is probably only necessary for hackintosh systems with more than 10 cores, but should be harmless for real macs too (as the first 10 entries just map to the same digit). I don't have a real x86 mac, so can't test. I do have an M1 macbook air, but apple silicon macs use a different API (CoreFoundation instead of SMC).