### PR TITLE
[macos/freebsd] support gcc13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,9 @@ ifeq ($(CXX_IS_CLANG),true)
 endif
 ifeq ($(CLANG_WORKS),false)
 	#? Try to find a newer GCC version
-	ifeq ($(shell command -v g++-12 >/dev/null; echo $$?),0)
+	ifeq ($(shell command -v g++-13 >/dev/null; echo $$?),0)
+		CXX := g++-13
+	else ifeq ($(shell command -v g++-12 >/dev/null; echo $$?),0)
 		CXX := g++-12
 	else ifeq ($(shell command -v g++12 >/dev/null; echo $$?),0)
 		CXX := g++12

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ ifeq ($(CLANG_WORKS),false)
 	#? Try to find a newer GCC version
 	ifeq ($(shell command -v g++-13 >/dev/null; echo $$?),0)
 		CXX := g++-13
+	else ifeq ($(shell command -v g++13 >/dev/null; echo $$?),0)
+		CXX := g++13
 	else ifeq ($(shell command -v g++-12 >/dev/null; echo $$?),0)
 		CXX := g++-12
 	else ifeq ($(shell command -v g++12 >/dev/null; echo $$?),0)


### PR DESCRIPTION
I tried compiling on my hackintosh, but it fails because it fails to find gcc-13, and subsequently fails with apple clang of course.

Homebrew now installs gcc@13 so we better support that too.