### PR TITLE
[macos] don't check /sys on macos

### DIFF
--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -73,7 +73,6 @@ namespace Cpu {
 	vector<string> available_fields = {"total"};
 	vector<string> available_sensors = {"Auto"};
 	cpu_info current_cpu;
-	fs::path freq_path = "/sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq";
 	bool got_sensors = false, cpu_temp_only = false;
 	int core_offset = 0;
 
@@ -164,7 +163,6 @@ namespace Shared {
 		arg_max = sysconf(_SC_ARG_MAX);
 
 		//? Init for namespace Cpu
-		if (not fs::exists(Cpu::freq_path) or access(Cpu::freq_path.c_str(), R_OK) == -1) Cpu::freq_path.clear();
 		Cpu::current_cpu.core_percent.insert(Cpu::current_cpu.core_percent.begin(), Shared::coreCount, {});
 		Cpu::current_cpu.temp.insert(Cpu::current_cpu.temp.begin(), Shared::coreCount + 1, {});
 		Cpu::core_old_totals.insert(Cpu::core_old_totals.begin(), Shared::coreCount, 0);


### PR DESCRIPTION
This linux remnant is always going to fail on macOS. Removed.