### PR TITLE
Use fmt for logging and allow to log to system daemon directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ target_compile_definitions(btop PRIVATE
   _GLIBCXX_ASSERTIONS _LIBCPP_ENABLE_ASSERTIONS=1
   # Only has an effect with optimizations enabled
   $<$<NOT:$<CONFIG:Debug>>:_FORTIFY_SOURCE=2>
+  FMT_HEADER_ONLY
 )
 
 # Enable GPU support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ include(CMakeDependentOption)
 option(BTOP_STATIC "Link btop statically" OFF)
 option(BTOP_LTO "Enable LTO" ON)
 option(BTOP_USE_MOLD "Use mold to link btop" OFF)
+option(BTOP_SYSLOG "Log with syslog instead of log file" OFF)
+option(BTOP_JOURNALD "Directly log to journald instead of log file" OFF)
 option(BTOP_PEDANTIC "Enable a bunch of additional warnings" OFF)
 option(BTOP_WERROR "Compile with warnings as errors" OFF)
 option(BTOP_GPU "Enable GPU support" ON)
@@ -60,6 +62,7 @@ add_executable(btop
   src/btop_config.cpp
   src/btop_draw.cpp
   src/btop_input.cpp
+  src/btop_log.cpp
   src/btop_menu.cpp
   src/btop_shared.cpp
   src/btop_theme.cpp
@@ -180,6 +183,22 @@ endif()
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(btop PRIVATE Threads::Threads)
+
+# Logging
+if(BTOP_JOURNALD)
+  find_package(Systemd REQUIRED)
+  target_compile_definitions(btop PRIVATE HAVE_JOURNALD)
+  target_link_libraries(btop PRIVATE Systemd::Journald)
+  message(STATUS "Using journald as logging backend")
+elseif(BTOP_SYSLOG)
+  check_include_file_cxx("syslog.h" HAVE_SYSLOG)
+  if(HAVE_SYSLOG)
+    target_compile_definitions(btop PRIVATE HAVE_SYSLOG)
+    message(STATUS "Using syslog as logging backend")
+  endif()
+else()
+  message(STATUS "Using plain log file")
+endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   target_link_libraries(btop PRIVATE $<LINK_LIBRARY:FRAMEWORK,CoreFoundation)

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,13 @@ else
 	LTO := $(THREADS)
 endif
 
+#? Enable journald direct logging
+ifeq ($(ENABLE_JOURNALD),true)
+	override ADDFLAGS += $(shell echo "int main() {}" | $(CXX) -include "systemd/sd-journal.h" -lsystemd -o /dev/null -x c++ - >/dev/null 2>&1 && echo "-DHAVE_JOURNALD -lsystemd")
+else ifeq ($(ENABLE_SYSLOG),true)
+	override ADDFLAGS += $(strip $(shell echo "int main() {}" | $(CXX) -include "syslog.h" -o /dev/null -x c++ - >/dev/null 2>&1 && echo "-DHAVE_SYSLOG"))
+endif
+
 #? The Directories, Source, Includes, Objects and Binary
 SRCDIR		:= src
 INCDIRS		:= include $(wildcard lib/**/include)

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ override GOODFLAGS := $(foreach flag,$(TESTFLAGS),$(strip $(shell echo "int main
 override REQFLAGS   := -std=c++20
 WARNFLAGS			:= -Wall -Wextra -pedantic
 OPTFLAGS			:= -O2 -ftree-vectorize -flto=$(LTO)
-LDCXXFLAGS			:= -pthread -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -D_FILE_OFFSET_BITS=64 $(GOODFLAGS) $(ADDFLAGS)
+LDCXXFLAGS			:= -pthread -DFMT_HEADER_ONLY -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -D_FILE_OFFSET_BITS=64 $(GOODFLAGS) $(ADDFLAGS)
 override CXXFLAGS	+= $(REQFLAGS) $(LDCXXFLAGS) $(OPTFLAGS) $(WARNFLAGS)
 override LDFLAGS	+= $(LDCXXFLAGS) $(OPTFLAGS) $(WARNFLAGS)
 INC					:= $(foreach incdir,$(INCDIRS),-isystem $(incdir)) -I$(SRCDIR)

--- a/README.md
+++ b/README.md
@@ -1053,6 +1053,13 @@ optional arguments:
                         and screen draw functions and sets loglevel to DEBUG
 ```
 
+It's also possible to specify a log level using the `BTOP_LOG_LEVEL` environment variable.
+It takes the same values as the `log_level` configuation option + "DISABLED", being case insensitive.
+```bash
+BTOP_LOG_LEVEL=info btop
+```
+will launch btop with the info logging level.
+
 ## LICENSE
 
 [Apache License 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -493,6 +493,8 @@ Also needs a UTF8 locale and a font that covers:
    | `-DBTOP_STATIC=<ON\|OFF>`       | Enables static linking (OFF by default)                                 |
    | `-DBTOP_LTO=<ON\|OFF>`          | Enables link time optimization (ON by default)                          |
    | `-DBTOP_USE_MOLD=<ON\|OFF>`     | Use mold to link btop (OFF by default)                                  |
+   | `-DBTOP_SYSLOG=<ON\|OFF>`       | Log to syslog instead of a log file (OFF by default)                    |
+   | `-DBTOP_JOURNALD=<ON\|OFF>`     | Log to journald instead of a log file (OFF by default)                  |
    | `-DBTOP_PEDANTIC=<ON\|OFF>`     | Compile with additional warnings (OFF by default)                       |
    | `-DBTOP_WERROR=<ON\|OFF>`       | Compile with warnings as errors (OFF by default)                        |
    | `-DBTOP_GPU=<ON\|OFF>`          | Enable GPU support (ON by default)                                      |
@@ -764,6 +766,7 @@ Also needs a UTF8 locale and a font that covers:
    | `-DBTOP_STATIC=<ON\|OFF>`       | Enables static linking (OFF by default)                                 |
    | `-DBTOP_LTO=<ON\|OFF>`          | Enables link time optimization (ON by default)                          |
    | `-DBTOP_USE_MOLD=<ON\|OFF>`     | Use mold to link btop (OFF by default)                                  |
+   | `-DBTOP_SYSLOG=<ON\|OFF>`       | Log to syslog instead of a log file (OFF by default)                    |
    | `-DBTOP_PEDANTIC=<ON\|OFF>`     | Compile with additional warnings (OFF by default)                       |
    | `-DBTOP_WERROR=<ON\|OFF>`       | Compile with warnings as errors (OFF by default)                        |
    | `-DCMAKE_INSTALL_PREFIX=<path>` | The installation prefix ('/usr/local' by default)                       |

--- a/cmake/Modules/FindSystemd.cmake
+++ b/cmake/Modules/FindSystemd.cmake
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Find systemd
+#
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  find_path(Systemd_INCLUDE_DIR NAMES systemd/sd-journal.h)
+  find_library(Systemd_LIBRARY NAMES systemd)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Systemd REQUIRED_VARS Systemd_LIBRARY Systemd_INCLUDE_DIR)
+
+  if(Systemd_FOUND AND NOT TARGET Systemd::Systemd)
+    add_library(Systemd::Systemd UNKNOWN IMPORTED)
+    set_target_properties(Systemd::Systemd PROPERTIES
+      IMPORTED_LOCATION "${Systemd_LIBRARY}"
+    )
+  endif()
+
+  if(Systemd_FOUND AND NOT TARGET Systemd::Journald)
+    add_library(Systemd::Journald ALIAS Systemd::Systemd)
+  endif()
+
+  mark_as_advanced(Systemd_INCLUDE_DIR Systemd_LIBRARY)
+endif()
+

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -847,7 +847,9 @@ int main(int argc, char **argv) {
 		}
 		else {
 			Config::conf_file = Config::conf_dir / "btop.conf";
+#if !(defined(HAVE_JOURNALD) || defined(HAVE_SYSLOG))
 			Logger::logfile = Config::conf_dir / "btop.log";
+#endif
 			Theme::user_theme_dir = Config::conf_dir / "themes";
 			if (not fs::exists(Theme::user_theme_dir) and not fs::create_directory(Theme::user_theme_dir, ec)) Theme::user_theme_dir.clear();
 		}

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -43,13 +43,14 @@ tab-size = 4
 	#include <semaphore>
 #endif
 
-#include "btop_shared.hpp"
-#include "btop_tools.hpp"
 #include "btop_config.hpp"
-#include "btop_input.hpp"
-#include "btop_theme.hpp"
 #include "btop_draw.hpp"
+#include "btop_input.hpp"
+#include "btop_log.hpp"
 #include "btop_menu.hpp"
+#include "btop_shared.hpp"
+#include "btop_theme.hpp"
+#include "btop_tools.hpp"
 
 using std::atomic;
 using std::cout;

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -284,10 +284,10 @@ void clean_quit(int sig) {
 
 	if (not Global::exit_error_msg.empty()) {
 		sig = 1;
-		Logger::error(Global::exit_error_msg);
+		Logger::error("{}", Global::exit_error_msg);
 		fmt::println(std::cerr, "{}ERROR: {}{}{}", Global::fg_red, Global::fg_white, Global::exit_error_msg, Fx::reset);
 	}
-	Logger::info("Quitting! Runtime: " + sec_to_dhms(time_s() - Global::start_time));
+	Logger::info("Quitting! Runtime: {}", sec_to_dhms(time_s() - Global::start_time));
 
 	const auto excode = (sig != -1 ? sig : 0);
 
@@ -892,15 +892,15 @@ int main(int argc, char **argv) {
 		}
 		else Logger::set(Config::getS("log_level"));
 
-		Logger::info("Logger set to " + (Global::debug ? "DEBUG" : Config::getS("log_level")));
+		Logger::info("Logger set to {}", (Global::debug ? "DEBUG" : Config::getS("log_level")));
 
-		for (const auto& err_str : load_warnings) Logger::warning(err_str);
+		for (const auto& err_str : load_warnings) Logger::warning("{}", err_str);
 	}
 
 	//? Try to find and set a UTF-8 locale
 	if (std::setlocale(LC_ALL, "") != nullptr and not s_contains((string)std::setlocale(LC_ALL, ""), ";")
 	and str_to_upper(s_replace((string)std::setlocale(LC_ALL, ""), "-", "")).ends_with("UTF8")) {
-		Logger::debug("Using locale " + (string)std::setlocale(LC_ALL, ""));
+		Logger::debug("Using locale {}", std::setlocale(LC_ALL, ""));
 	}
 	else {
 		string found;
@@ -910,7 +910,7 @@ int main(int argc, char **argv) {
 				found = std::getenv(loc_env);
 				if (std::setlocale(LC_ALL, found.c_str()) == nullptr) {
 					set_failure = true;
-					Logger::warning("Failed to set locale " + found + " continuing anyway.");
+					Logger::warning("Failed to set locale {} continuing anyway.", found);
 				}
 			}
 		}
@@ -943,7 +943,7 @@ int main(int argc, char **argv) {
 				Logger::warning("No UTF-8 locale detected! Some symbols might not display correctly.");
 			}
 			else if (std::setlocale(LC_ALL, string(cur_locale + ".UTF-8").c_str()) != nullptr) {
-				Logger::debug("Setting LC_ALL=" + cur_locale + ".UTF-8");
+				Logger::debug("Setting LC_ALL={}.UTF-8", cur_locale);
 			}
 			else if(std::setlocale(LC_ALL, "en_US.UTF-8") != nullptr) {
 				Logger::debug("Setting LC_ALL=en_US.UTF-8");
@@ -961,7 +961,7 @@ int main(int argc, char **argv) {
 		}
 	#endif
 		else if (not set_failure)
-			Logger::debug("Setting LC_ALL=" + found);
+			Logger::debug("Setting LC_ALL={}", found);
 	}
 
 	//? Initialize terminal and set options
@@ -970,7 +970,7 @@ int main(int argc, char **argv) {
 		clean_quit(1);
 	}
 
-	if (Term::current_tty != "unknown") Logger::info("Running on " + Term::current_tty);
+	if (Term::current_tty != "unknown") Logger::info("Running on {}", Term::current_tty);
 	if (not Global::arg_tty and Config::getB("force_tty")) {
 		Config::set("tty_mode", true);
 		Logger::info("Forcing tty mode: setting 16 color mode and using tty friendly graph symbols");

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -880,19 +880,32 @@ int main(int argc, char **argv) {
 	}
 
 	//? Config init
-	{	vector<string> load_warnings;
+	{
+		vector<string> load_warnings;
 		Config::load(Config::conf_file, load_warnings);
 
 		if (Config::current_boxes.empty()) Config::check_boxes(Config::getS("shown_boxes"));
 		Config::set("lowcolor", (Global::arg_low_color ? true : not Config::getB("truecolor")));
 
+		std::string log_level_env {};
+		{
+			char* log_env = std::getenv("BTOP_LOG_LEVEL");
+			if (log_env != nullptr) {
+				log_level_env = Tools::str_to_upper(log_env);
+			}
+		}
 		if (Global::debug) {
 			Logger::set("DEBUG");
 			Logger::debug("Starting in DEBUG mode!");
 		}
-		else Logger::set(Config::getS("log_level"));
-
-		Logger::info("Logger set to {}", (Global::debug ? "DEBUG" : Config::getS("log_level")));
+		else if (v_contains(Logger::log_levels, log_level_env)) {
+			Logger::set(log_level_env);
+			Logger::info("Log level set to {}", log_level_env);
+		}
+		else {
+			Logger::set(Config::getS("log_level"));
+			Logger::info("Log level set to {}", Config::getS("log_level"));
+		}
 
 		for (const auto& err_str : load_warnings) Logger::warning("{}", err_str);
 	}

--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -25,6 +25,7 @@ tab-size = 4
 #include <fmt/core.h>
 
 #include "btop_config.hpp"
+#include "btop_log.hpp"
 #include "btop_shared.hpp"
 #include "btop_tools.hpp"
 

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -226,7 +226,7 @@ namespace Draw {
 				c_upos = ulen(first);
 			}
 			catch (const std::exception& e) {
-				Logger::error("In TextEdit::operator() : " + string{e.what()});
+				Logger::error("In TextEdit::operator() : {}", e.what());
 				return "";
 			}
 		}

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -23,13 +23,14 @@ tab-size = 4
 #include <stdexcept>
 #include <string>
 
-#include "btop_draw.hpp"
 #include "btop_config.hpp"
-#include "btop_theme.hpp"
-#include "btop_shared.hpp"
-#include "btop_tools.hpp"
+#include "btop_draw.hpp"
 #include "btop_input.hpp"
+#include "btop_log.hpp"
 #include "btop_menu.hpp"
+#include "btop_shared.hpp"
+#include "btop_theme.hpp"
+#include "btop_tools.hpp"
 
 
 using std::array;

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -295,7 +295,7 @@ namespace Draw {
 	}
 
 	bool update_clock(bool force) {
-		const auto& clock_format = Config::getS("clock_format");
+		const std::string_view clock_format = Config::getS("clock_format");
 		if (not Cpu::shown or clock_format.empty()) {
 			if (clock_format.empty() and not Global::clock.empty()) Global::clock.clear();
 			return false;

--- a/src/btop_log.cpp
+++ b/src/btop_log.cpp
@@ -6,6 +6,9 @@
 #include <iostream>
 #include <mutex>
 #include <string>
+#include <string_view>
+
+#include <fmt/core.h>
 
 #include "btop_shared.hpp"
 #include "btop_tools.hpp"
@@ -40,7 +43,7 @@ namespace Logger {
 
 	void set(const string& level) { loglevel = v_index(log_levels, level); }
 
-	void log_write(const size_t level, const string& msg) {
+	void log_write(const size_t level, const std::string_view msg) {
 		if (loglevel < level or logfile.empty()) {
 			return;
 		}
@@ -64,9 +67,9 @@ namespace Logger {
 				std::ofstream lwrite(logfile, std::ios::app);
 				if (first) {
 					first = false;
-					lwrite << "\n" << strf_time(tdf) << "===> btop++ v." << Global::Version << "\n";
+					fmt::print(lwrite, "\n{}===> btop++ v.{}\n", strf_time(tdf), Global::Version);
 				}
-				lwrite << strf_time(tdf) << log_levels.at(level) << ": " << msg << "\n";
+				fmt::print(lwrite, "{}{}: {}\n", strf_time(tdf), log_levels.at(level), msg);
 			}
 			else {
 				logfile.clear();
@@ -74,7 +77,7 @@ namespace Logger {
 		}
 		catch (const std::exception& e) {
 			logfile.clear();
-			throw std::runtime_error("Exception in Logger::log_write() : " + string{e.what()});
+			throw std::runtime_error(fmt::format("Exception in Logger::log_write() : {}", e.what()));
 		}
 	}
 } // namespace Logger

--- a/src/btop_log.cpp
+++ b/src/btop_log.cpp
@@ -111,7 +111,7 @@ namespace Logger {
 				std::call_once(log_file_header, [&lwrite] {
 					fmt::print(lwrite, "\n{}===> btop++ v.{}\n", strf_time(tdf), Global::Version);
 				});
-				fmt::print(lwrite, "{}{}: {}\n", strf_time(tdf), log_levels.at(level), msg);
+				fmt::print(lwrite, "{}{:10}{}\n", strf_time(tdf), log_levels.at(level), msg);
 			}
 			else {
 				logfile.clear();

--- a/src/btop_log.cpp
+++ b/src/btop_log.cpp
@@ -18,7 +18,7 @@ namespace fs = std::filesystem;
 
 namespace Logger {
 	using namespace Tools;
-	std::atomic<bool> busy(false);
+	std::mutex log_mtx {};
 	bool first = true;
 	const string tdf = "%Y/%m/%d (%T) | ";
 
@@ -48,7 +48,7 @@ namespace Logger {
 		if (loglevel < level or logfile.empty()) {
 			return;
 		}
-		atomic_lock lck(busy, true);
+		std::lock_guard lock {log_mtx};
 		lose_priv neutered{};
 		std::error_code ec;
 		try {

--- a/src/btop_log.cpp
+++ b/src/btop_log.cpp
@@ -9,6 +9,7 @@
 #include <string_view>
 
 #include <fmt/core.h>
+#include <fmt/ostream.h>
 
 #include "btop_shared.hpp"
 #include "btop_tools.hpp"

--- a/src/btop_log.cpp
+++ b/src/btop_log.cpp
@@ -27,10 +27,10 @@ namespace Logger {
 	using namespace Tools;
 	std::mutex log_mtx{};
 	bool first = true;
-	const string tdf = "%Y/%m/%d (%T) | ";
 
 	size_t loglevel;
 	fs::path logfile;
+	constexpr const std::string_view tdf = "%Y/%m/%d (%T) | ";
 
 	//* Wrapper for lowering priviliges if using SUID bit and currently isn't using real userid
 	class lose_priv {

--- a/src/btop_log.cpp
+++ b/src/btop_log.cpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "btop_log.hpp"
+
+#include <filesystem>
+#include <iostream>
+#include <mutex>
+#include <string>
+
+#include "btop_shared.hpp"
+#include "btop_tools.hpp"
+
+namespace fs = std::filesystem;
+
+namespace Logger {
+	using namespace Tools;
+	std::atomic<bool> busy(false);
+	bool first = true;
+	const string tdf = "%Y/%m/%d (%T) | ";
+
+	size_t loglevel;
+	fs::path logfile;
+
+	//* Wrapper for lowering priviliges if using SUID bit and currently isn't using real userid
+	class lose_priv {
+		int status = -1;
+
+	public:
+		lose_priv() {
+			if (geteuid() != Global::real_uid) {
+				this->status = seteuid(Global::real_uid);
+			}
+		}
+		~lose_priv() {
+			if (status == 0) {
+				status = seteuid(Global::set_uid);
+			}
+		}
+	};
+
+	void set(const string& level) { loglevel = v_index(log_levels, level); }
+
+	void log_write(const size_t level, const string& msg) {
+		if (loglevel < level or logfile.empty()) {
+			return;
+		}
+		atomic_lock lck(busy, true);
+		lose_priv neutered{};
+		std::error_code ec;
+		try {
+			if (fs::exists(logfile) and fs::file_size(logfile, ec) > 1024 << 10 and not ec) {
+				auto old_log = logfile;
+				old_log += ".1";
+
+				if (fs::exists(old_log)) {
+					fs::remove(old_log, ec);
+				}
+
+				if (not ec) {
+					fs::rename(logfile, old_log, ec);
+				}
+			}
+			if (not ec) {
+				std::ofstream lwrite(logfile, std::ios::app);
+				if (first) {
+					first = false;
+					lwrite << "\n" << strf_time(tdf) << "===> btop++ v." << Global::Version << "\n";
+				}
+				lwrite << strf_time(tdf) << log_levels.at(level) << ": " << msg << "\n";
+			}
+			else {
+				logfile.clear();
+			}
+		}
+		catch (const std::exception& e) {
+			logfile.clear();
+			throw std::runtime_error("Exception in Logger::log_write() : " + string{e.what()});
+		}
+	}
+} // namespace Logger

--- a/src/btop_log.hpp
+++ b/src/btop_log.hpp
@@ -21,7 +21,7 @@ namespace Logger {
 	extern std::filesystem::path logfile;
 
 	//* Set log level, valid arguments: "DISABLED", "ERROR", "WARNING", "INFO" and "DEBUG"
-	void set(const std::string& level);
+	void set(const std::string& level) noexcept;
 
 	void log(const size_t level, const std::string_view msg, const std::source_location location);
 

--- a/src/btop_log.hpp
+++ b/src/btop_log.hpp
@@ -3,8 +3,10 @@
 #pragma once
 
 #include <filesystem>
-#include <string>
+#include <string_view>
 #include <vector>
+
+#include <fmt/core.h>
 
 namespace Logger {
 	const std::vector<std::string> log_levels = {
@@ -19,9 +21,25 @@ namespace Logger {
 	//* Set log level, valid arguments: "DISABLED", "ERROR", "WARNING", "INFO" and "DEBUG"
 	void set(const std::string& level);
 
-	void log_write(const size_t level, const std::string& msg);
-	inline void error(const std::string msg) { log_write(1, msg); }
-	inline void warning(const std::string msg) { log_write(2, msg); }
-	inline void info(const std::string msg) { log_write(3, msg); }
-	inline void debug(const std::string msg) { log_write(4, msg); }
+	void log_write(const size_t level, const std::string_view msg);
+
+	template <typename... T>
+	inline void error(const fmt::format_string<T...> fmt, T&&... args) {
+		log_write(1, fmt::format(fmt, std::forward<T>(args)...));
+	}
+
+	template <typename... T>
+	inline void warning(const fmt::format_string<T...> fmt, T&&... args) {
+		log_write(2, fmt::format(fmt, std::forward<T>(args)...));
+	}
+
+	template <typename... T>
+	inline void info(const fmt::format_string<T...> fmt, T&&... args) {
+		log_write(3, fmt::format(fmt, std::forward<T>(args)...));
+	}
+
+	template <typename... T>
+	inline void debug(const fmt::format_string<T...> fmt, T&&... args) {
+		log_write(4, fmt::format(fmt, std::forward<T>(args)...));
+	}
 } // namespace Logger

--- a/src/btop_log.hpp
+++ b/src/btop_log.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <filesystem>
+#include <source_location>
 #include <string_view>
 #include <vector>
 
@@ -16,30 +17,64 @@ namespace Logger {
 		"INFO",
 		"DEBUG",
 	};
+
 	extern std::filesystem::path logfile;
 
 	//* Set log level, valid arguments: "DISABLED", "ERROR", "WARNING", "INFO" and "DEBUG"
 	void set(const std::string& level);
 
-	void log_write(const size_t level, const std::string_view msg);
+	void log(const size_t level, const std::string_view msg, const std::source_location location);
 
-	template <typename... T>
-	inline void error(const fmt::format_string<T...> fmt, T&&... args) {
-		log_write(1, fmt::format(fmt, std::forward<T>(args)...));
-	}
+	template<typename... Args>
+	struct error { // NOLINT(readability-identifier-naming)
+		constexpr error(
+			const fmt::format_string<Args...> fmt, Args&&... args,
+			const std::source_location location = std::source_location::current()
+		) {
+			log(1, fmt::format(fmt, std::forward<Args>(args)...), location);
+		}
+	};
 
-	template <typename... T>
-	inline void warning(const fmt::format_string<T...> fmt, T&&... args) {
-		log_write(2, fmt::format(fmt, std::forward<T>(args)...));
-	}
+	template<typename... Args>
+	struct warning { // NOLINT(readability-identifier-naming)
+		constexpr warning(
+			const fmt::format_string<Args...> fmt, Args&&... args,
+			const std::source_location location = std::source_location::current()
+		) {
+			log(2, fmt::format(fmt, std::forward<Args>(args)...), location);
+		}
+	};
 
-	template <typename... T>
-	inline void info(const fmt::format_string<T...> fmt, T&&... args) {
-		log_write(3, fmt::format(fmt, std::forward<T>(args)...));
-	}
+	template<typename... Args>
+	struct info { // NOLINT(readability-identifier-naming)
+		constexpr info(
+			const fmt::format_string<Args...> fmt, Args&&... args,
+			const std::source_location location = std::source_location::current()
+		) {
+			log(3, fmt::format(fmt, std::forward<Args>(args)...), location);
+		}
+	};
 
-	template <typename... T>
-	inline void debug(const fmt::format_string<T...> fmt, T&&... args) {
-		log_write(4, fmt::format(fmt, std::forward<T>(args)...));
-	}
+	template<typename... Args>
+	struct debug { // NOLINT(readability-identifier-naming)
+		constexpr debug(
+			const fmt::format_string<Args...> fmt, Args&&... args,
+			const std::source_location location = std::source_location::current()
+		) {
+			log(4, fmt::format(fmt, std::forward<Args>(args)...), location);
+		}
+	};
+
+	// Deduction guide to allow default arguement after variadic template
+	template<typename... Args>
+	error(const std::string_view, Args&&...) -> error<Args...>;
+
+	template<typename... Args>
+	warning(const std::string_view, Args&&...) -> warning<Args...>;
+
+	template<typename... Args>
+	info(const std::string_view, Args&&...) -> info<Args...>;
+
+	template<typename... Args>
+	debug(const std::string_view, Args&&...) -> debug<Args...>;
 } // namespace Logger

--- a/src/btop_log.hpp
+++ b/src/btop_log.hpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace Logger {
+	const std::vector<std::string> log_levels = {
+		"DISABLED",
+		"ERROR",
+		"WARNING",
+		"INFO",
+		"DEBUG",
+	};
+	extern std::filesystem::path logfile;
+
+	//* Set log level, valid arguments: "DISABLED", "ERROR", "WARNING", "INFO" and "DEBUG"
+	void set(const std::string& level);
+
+	void log_write(const size_t level, const std::string& msg);
+	inline void error(const std::string msg) { log_write(1, msg); }
+	inline void warning(const std::string msg) { log_write(2, msg); }
+	inline void info(const std::string msg) { log_write(3, msg); }
+	inline void debug(const std::string msg) { log_write(4, msg); }
+} // namespace Logger

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -1367,7 +1367,7 @@ namespace Menu {
 					theme_refresh = true;
 				else if (option == "log_level") {
 					Logger::set(optList.at(i));
-					Logger::info("Logger set to " + optList.at(i));
+					Logger::info("Logger set to {}", optList.at(i));
 				}
 				else if (is_in(option, "proc_sorting", "cpu_sensor", "show_gpu_info") or option.starts_with("graph_symbol") or option.starts_with("cpu_graph_"))
 					screen_redraw = true;

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -24,12 +24,13 @@ tab-size = 4
 #include <cmath>
 #include <filesystem>
 
-#include "btop_menu.hpp"
-#include "btop_tools.hpp"
 #include "btop_config.hpp"
-#include "btop_theme.hpp"
 #include "btop_draw.hpp"
+#include "btop_log.hpp"
+#include "btop_menu.hpp"
 #include "btop_shared.hpp"
+#include "btop_theme.hpp"
+#include "btop_tools.hpp"
 
 using robin_hood::unordered_flat_map;
 using std::array;

--- a/src/btop_theme.cpp
+++ b/src/btop_theme.cpp
@@ -20,9 +20,10 @@ tab-size = 4
 #include <fstream>
 #include <unistd.h>
 
-#include "btop_tools.hpp"
 #include "btop_config.hpp"
+#include "btop_log.hpp"
 #include "btop_theme.hpp"
+#include "btop_tools.hpp"
 
 using std::round;
 using std::stoi;

--- a/src/btop_theme.cpp
+++ b/src/btop_theme.cpp
@@ -156,7 +156,7 @@ namespace Theme {
 			hexa.erase(0, 1);
 			for (auto& c : hexa) {
 				if (not isxdigit(c)) {
-					Logger::error("Invalid hex value: " + hexa);
+					Logger::error("Invalid hex value: {}", hexa);
 					return "";
 				}
 			}
@@ -184,9 +184,9 @@ namespace Theme {
 						to_string(stoi(hexa.substr(4, 2), nullptr, 16)) + "m";
 				}
 			}
-			else Logger::error("Invalid size of hex value: " + hexa);
+			else Logger::error("Invalid size of hex value: {}", hexa);
 		}
-		else Logger::error("Hex value missing: " + hexa);
+		else Logger::error("Hex value missing: {}", hexa);
 		return "";
 	}
 
@@ -255,7 +255,7 @@ namespace Theme {
 					else if (not source.at(name).empty()) {
 						t_rgb = ssplit(source.at(name));
 						if (t_rgb.size() != 3) {
-							Logger::error("Invalid RGB decimal value: \"" + source.at(name) + "\"");
+							Logger::error("Invalid RGB decimal value: \"{}\"", source.at(name));
 						} else {
 							colors[name] = dec_to_color(stoi(t_rgb[0]), stoi(t_rgb[1]), stoi(t_rgb[2]), t_to_256, depth);
 							rgbs[name] = array{stoi(t_rgb[0]), stoi(t_rgb[1]), stoi(t_rgb[2])};
@@ -264,7 +264,7 @@ namespace Theme {
 					}
 				}
 				if (not colors.contains(name) and not is_in(name, "meter_bg", "process_start", "process_mid", "process_end", "graph_text")) {
-					Logger::debug("Missing color value for \"" + name + "\". Using value from default.");
+					Logger::debug("Missing color value for \"{}\". Using value from default.", name);
 					colors[name] = hex_to_color(color, t_to_256, depth);
 					rgbs[name] = hex_to_dec(color);
 				}
@@ -380,7 +380,7 @@ namespace Theme {
 
 			std::ifstream themefile(filepath);
 			if (themefile.good()) {
-				Logger::debug("Loading theme file: " + filename);
+				Logger::debug("Loading theme file: {}", filename);
 				while (not themefile.bad()) {
 					themefile.ignore(SSmax, '[');
 					if (themefile.eof()) break;

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -18,13 +18,15 @@ tab-size = 4
 
 #include <cmath>
 #include <codecvt>
-#include <iostream>
-#include <fstream>
 #include <ctime>
-#include <sstream>
+#include <fstream>
 #include <iomanip>
-#include <utility>
+#include <iostream>
 #include <ranges>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
 
 #include <unistd.h>
 #include <termios.h>
@@ -485,11 +487,11 @@ namespace Tools {
 		return new_str;
 	}
 
-	string strf_time(const string& strf) {
+	string strf_time(const std::string_view strf) {
 		auto in_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 		std::tm bt {};
 		std::stringstream ss;
-		ss << std::put_time(localtime_r(&in_time_t, &bt), strf.c_str());
+		ss << std::put_time(localtime_r(&in_time_t, &bt), strf.data());
 		return ss.str();
 	}
 

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -519,7 +519,7 @@ namespace Tools {
 			for (string readstr; getline(file, readstr); out += readstr);
 		}
 		catch (const std::exception& e) {
-			Logger::error("readfile() : Exception when reading " + string{path} + " : " + e.what());
+			Logger::error("readfile() : Exception when reading {} : {}", path.string(), e.what());
 			return fallback;
 		}
 		return (out.empty() ? fallback : out);
@@ -596,15 +596,15 @@ namespace Tools {
 			report_line = fmt::format(custom_locale, "Timer [{}] took {:L} μs", name, elapsed_time);
 
 		if (delayed_report)
-			report_buffer.emplace_back(report_line);
+			report_buffer.push_back(std::move(report_line));
 		else
-			Logger::debug(report_line);
+			Logger::debug("{}", report_line);
 	}
 
 	void DebugTimer::force_report() {
 		if (report_buffer.empty()) return;
 		for (const auto& line : report_buffer)
-			Logger::debug(line);
+			Logger::debug("{}", line);
 		report_buffer.clear();
 	}
 

--- a/src/btop_tools.hpp
+++ b/src/btop_tools.hpp
@@ -26,6 +26,7 @@ tab-size = 4
 #include <ranges>
 #include <regex>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <tuple>
 #include <vector>
@@ -303,7 +304,7 @@ namespace Tools {
 	std::string operator*(const string& str, int64_t n);
 
 	//* Return current time in <strf> format
-	string strf_time(const string& strf);
+	string strf_time(const std::string_view strf);
 
 	string hostname();
 	string username();

--- a/src/btop_tools.hpp
+++ b/src/btop_tools.hpp
@@ -340,38 +340,7 @@ namespace Tools {
 
 	//* Convert a celsius value to celsius, fahrenheit, kelvin or rankin and return tuple with new value and unit.
 	auto celsius_to(const long long& celsius, const string& scale) -> tuple<long long, string>;
-}
 
-//* Simple logging implementation
-namespace Logger {
-	const vector<string> log_levels = {
-		"DISABLED",
-		"ERROR",
-		"WARNING",
-		"INFO",
-		"DEBUG",
-	};
-	extern std::filesystem::path logfile;
-
-	enum Level : size_t {
-		DISABLED = 0,
-		ERROR = 1,
-		WARNING = 2,
-		INFO = 3,
-		DEBUG = 4,
-	};
-
-	//* Set log level, valid arguments: "DISABLED", "ERROR", "WARNING", "INFO" and "DEBUG"
-	void set(const string& level);
-
-	void log_write(const Level level, const string& msg);
-	inline void error(const string msg) { log_write(ERROR, msg); }
-	inline void warning(const string msg) { log_write(WARNING, msg); }
-	inline void info(const string msg) { log_write(INFO, msg); }
-	inline void debug(const string msg) { log_write(DEBUG, msg); }
-}
-
-namespace Tools {
 	//* Creates a named timer that is started on construct (by default) and reports elapsed time in microseconds to Logger::debug() on destruct if running
 	//* Unless delayed_report is set to false, all reporting is buffered and delayed until DebugTimer is destructed or .force_report() is called
 	//* Usage example: Tools::DebugTimer timer(name:"myTimer", [start:true], [delayed_report:true]) // Create timer and start
@@ -386,7 +355,6 @@ namespace Tools {
 	public:
 		string name{};
 		bool delayed_report{};
-		Logger::Level log_level = Logger::DEBUG;
 		DebugTimer() = default;
 		DebugTimer(const string name, bool start = true, bool delayed_report = true);
 		~DebugTimer();
@@ -403,6 +371,4 @@ namespace Tools {
 	};
 
 }
-
-
 

--- a/src/btop_tools.hpp
+++ b/src/btop_tools.hpp
@@ -38,11 +38,9 @@ tab-size = 4
 		#define HOST_NAME_MAX 64
 	#endif
 #endif
-#define FMT_HEADER_ONLY
+
 #include "fmt/core.h"
-#include "fmt/format.h"
 #include "fmt/ostream.h"
-#include "fmt/ranges.h"
 
 using std::array;
 using std::atomic;

--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -60,6 +60,7 @@ tab-size = 4
 #include <memory>
 
 #include "../btop_config.hpp"
+#include "../btop_log.hpp"
 #include "../btop_shared.hpp"
 #include "../btop_tools.hpp"
 

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -40,8 +40,9 @@ tab-size = 4
 	#include <pwd.h>
 #endif
 
-#include "../btop_shared.hpp"
 #include "../btop_config.hpp"
+#include "../btop_log.hpp"
+#include "../btop_shared.hpp"
 #include "../btop_tools.hpp"
 
 using std::clamp;

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -53,6 +53,7 @@ tab-size = 4
 #include <string>
 
 #include "../btop_config.hpp"
+#include "../btop_log.hpp"
 #include "../btop_shared.hpp"
 #include "../btop_tools.hpp"
 

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -43,14 +43,16 @@ tab-size = 4
 #include <sys/types.h>
 #include <netinet/in.h> // for inet_ntop
 #include <unistd.h>
-#include <stdexcept>
 
 #include <cmath>
 #include <fstream>
 #include <numeric>
 #include <ranges>
 #include <regex>
+#include <stdexcept>
 #include <string>
+
+#include <fmt/core.h>
 
 #include "../btop_config.hpp"
 #include "../btop_log.hpp"
@@ -248,7 +250,7 @@ namespace Cpu {
 	}
 
 	bool get_sensors() {
-		Logger::debug("get_sensors(): show_coretemp=" + std::to_string(Config::getB("show_coretemp")) + " check_temp=" + std::to_string(Config::getB("check_temp")));
+		Logger::debug("get_sensors(): show_coretemp={} check_temp={}", Config::getB("show_coretemp"), Config::getB("check_temp"));
 		got_sensors = false;
 		if (Config::getB("show_coretemp") and Config::getB("check_temp")) {
 			ThermalSensors sensors;
@@ -497,8 +499,8 @@ namespace Cpu {
 				if (cpu.core_percent.at(i).size() > 40) cpu.core_percent.at(i).pop_front();
 
 			} catch (const std::exception &e) {
-				Logger::error("Cpu::collect() : " + (string)e.what());
-				throw std::runtime_error("collect() : " + (string)e.what());
+				Logger::error("Cpu::collect() : {}", e.what());
+				throw std::runtime_error(fmt::format("collect() : {}", e.what()));
 			}
 		}
 
@@ -781,7 +783,7 @@ namespace Mem {
 					continue;
 				struct statvfs vfs;
 				if (statvfs(mountpoint.c_str(), &vfs) < 0) {
-					Logger::warning("Failed to get disk/partition stats with statvfs() for: " + mountpoint);
+					Logger::warning("Failed to get disk/partition stats with statvfs() for: {}", mountpoint);
 					continue;
 				}
 				disk.total = vfs.f_blocks * vfs.f_frsize;
@@ -855,7 +857,7 @@ namespace Net {
 			getifaddr_wrapper if_wrap{};
 			if (if_wrap.status != 0) {
 				errors++;
-				Logger::error("Net::collect() -> getifaddrs() failed with id " + to_string(if_wrap.status));
+				Logger::error("Net::collect() -> getifaddrs() failed with id {}", if_wrap.status);
 				redraw = true;
 				return empty_net;
 			}
@@ -888,7 +890,7 @@ namespace Net {
 							net[iface].ipv4 = ip;
 						} else {
 							int errsv = errno;
-							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface {}, errno: {}", iface, strerror(errsv));
 						}
 					}
 				}
@@ -899,7 +901,7 @@ namespace Net {
 							net[iface].ipv6 = ip;
 						} else {
 							int errsv = errno;
-							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface {}, errno: {}", iface, strerror(errsv));
 						}
 					}
 				} // else, ignoring family==AF_LINK (see man 3 getifaddrs)


### PR DESCRIPTION
This PR improves the logger in a few ways:
1. The logger now lives in it's own file, which avoids unnecessary recompilation
2. The logger uses `fmt`, See #535 
   - The logging functions now have the same syntax as `fmt::format`
   - The logging backend logs with `fmt::print` instead of `std::ofstream`
3. `FMT_HEADER_ONLY` is now defined by Make and passed to the compiler. Other files including `<fmt/*.h>` are now independent of the definition in `btop_tools.hpp`
4. By default, if `<syslog.h>` is present, btop will log it's messages there
5. When compiled with `make ENABLE_JOURNALD=true` btop can directly log to journald. This can log interesting metadata like the source file location for each message
6. Parse `BTOP_LOG_LEVEL` environment variable and set the log level accordingly

On systemd systems, with either `syslog` or `journald` logging, btops logs can be read with `journalctl -t btop`

If this is not a good default, it's an easy fix to put this behind a `ENABLE_...` flag!
I'm curious if this is a nice feature or not. Looking forward for feedback :)