### PR TITLE
Fix short conversion of 1000-1023 *iB

### DIFF
--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -443,7 +443,7 @@ namespace Tools {
 				out = to_string((int)round(stod(out)));
 			}
 			if (out.size() > 3) {
-				out = to_string((int)(out[0] - '0') + 1);
+				out = to_string((int)(out[0] - '0')) + ".0";
 				start++;
 			}
 			out.push_back(units[start][0]);


### PR DESCRIPTION
floating_humanizer([1000-1023], true) with base 8 returns "2K", whereas it should return "1.0K" to align with other formats. The conversion is also broken for all other units(e.g. 1023MiB is also broken and returns "2G")

AFAIK, the branch ```out.size() > 3``` could also be hardcoded to ```out = "1.0"; start++;```, since only the range 1000-1023 triggers it. I left it out for now.