### PR TITLE
Remove detailed compiler check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,34 +73,9 @@ ifeq ($(CXX_IS_CLANG),true)
 	ifneq ($(shell test $(CXX_VERSION_MAJOR) -lt $(MIN_CLANG_VERSION); echo $$?),0)
 		CLANG_WORKS := true
 	endif
-endif
-ifeq ($(CLANG_WORKS),false)
-	#? Try to find a newer GCC version
-	ifeq ($(shell command -v g++-13 >/dev/null; echo $$?),0)
-		CXX := g++-13
-	else ifeq ($(shell command -v g++13 >/dev/null; echo $$?),0)
-		CXX := g++13
-	else ifeq ($(shell command -v g++-12 >/dev/null; echo $$?),0)
-		CXX := g++-12
-	else ifeq ($(shell command -v g++12 >/dev/null; echo $$?),0)
-		CXX := g++12
-	else ifeq ($(shell command -v g++-11 >/dev/null; echo $$?),0)
-		CXX := g++-11
-	else ifeq ($(shell command -v g++11 >/dev/null; echo $$?),0)
-		CXX := g++11
-	else ifeq ($(shell command -v g++ >/dev/null; echo $$?),0)
-		CXX := g++
-	else ifeq ($(shell command -v eg++ >/dev/null; echo $$?),0)
-		CXX := eg++
-	else
-		GCC_NOT_FOUND := true
-	endif
-	ifndef GCC_NOT_FOUND
-		override CXX_VERSION := $(shell $(CXX) -dumpfullversion -dumpversion || echo 0)
-		override CXX_VERSION_MAJOR := $(shell echo $(CXX_VERSION) | cut -d '.' -f 1)
-		ifneq ($(shell test $(CXX_VERSION_MAJOR) -lt 10; echo $$?),0)
-			GCC_WORKS := true
-		endif
+else
+	ifneq ($(shell test $(CXX_VERSION_MAJOR) -lt 10; echo $$?),0)
+		GCC_WORKS := true
 	endif
 endif
 


### PR DESCRIPTION
Currently g++ is forced to be the latest intalled version

Since we give an error if the version of the compiler is not sufficient, we can remove this check/overwrite

It's now possible to specify an older version (on purpose) and new compiler version don't need to be added manually

Closes: #566 