### PR TITLE
Add keybind for toggling memory display mode in PROC box

### DIFF
--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -343,6 +343,9 @@ namespace Input {
 				else if (key == "c")
 					Config::flip("proc_per_core");
 
+				else if (key == "%")
+					Config::flip("proc_mem_bytes");
+
 				else if (key == "delete" and not Config::getS("proc_filter").empty())
 					Config::set("proc_filter", ""s);
 

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -195,6 +195,7 @@ namespace Menu {
 		{"c", "Toggle per-core cpu usage of processes."},
 		{"r", "Reverse sorting order in processes box."},
 		{"e", "Toggle processes tree view."},
+		{"%", "Toggles memory display mode in processes box."},
 		{"Selected +, -", "Expand/collapse the selected process in tree view."},
 		{"Selected t", "Terminate selected process with SIGTERM - 15."},
 		{"Selected k", "Kill selected process with SIGKILL - 9."},


### PR DESCRIPTION
Closes #622. Uses "%" for the keybind, but am willing to change this if needed.