### PR TITLE
Add hpp files to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-[*.{cpp,h,sh,md,cfg,sample}]
+[*.{cpp,h,hpp,sh,md,cfg,sample}]
 indent_style = tab
 indent_size = 4
 


### PR DESCRIPTION
This project uses `.hpp` extension for headers, but previously .editorconfig only specified formatting for `.h` files.