### PR TITLE
Set FreeBSD workflow timeout

### DIFF
--- a/.github/workflows/continuous-build-freebsd.yml
+++ b/.github/workflows/continuous-build-freebsd.yml
@@ -28,6 +28,7 @@ on:
 jobs:
   build-freebsd:
     runs-on: macos-12
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Recently the FreeBSD workflow has started to hang in a boot loop when the VM starts up. The issue is being tracked upstream but there is not response at the moment.

To work around this set a timeout to not waste CI minutes. Other workflows might also want this change since they don't take 20 minutes anyway.