### PR TITLE
GH Action for a test build of the snap and issue template changes`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,6 +29,7 @@ Any bug that can be solved by just reading the [prerequisites](https://github.co
 
 **Info (please complete the following information):**
  - btop++ version: `btop -v`
+   - If using snap: `snap info btop`
  - Binary: [self compiled or static binary from release]
  - (If compiled) Compiler and version:
  - Architecture: [x86_64, aarch64, etc.] `uname -m`
@@ -40,7 +41,9 @@ Any bug that can be solved by just reading the [prerequisites](https://github.co
 
 **Additional context**
 
-contents of `~/.config/btop/btop.log`
+Contents of `~/.config/btop/btop.log`
+
+Note: The snap uses: `~/snap/btop/current/.config/btop`
 
 (try running btop with `--debug` flag if btop.log is empty)
 

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,0 +1,25 @@
+name: 🧪 Test snap can be built on x86_64
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+        
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: snapcore/action-build@v1
+        id: build
+
+      - uses: diddlesnaps/snapcraft-review-action@v1
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          isClassic: 'false'

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -3,6 +3,8 @@ name: 🧪 Test snap can be built on x86_64
 on:
   push:
     branches: [ main ]
+   tags-ignore:
+      - '*.*'     
     paths:
       - 'src/**'
       - '!src/osx/**'
@@ -10,10 +12,9 @@ on:
       - 'include/**'
       - 'Makefile'
       - '.github/workflows/continuous-build-linux.yml'    
-  pull_request:
+   pull_request:
     branches: [ main ]
-    tags-ignore:
-      - '*.*'      
+ 
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -3,9 +3,17 @@ name: 🧪 Test snap can be built on x86_64
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - '!src/osx/**'
+      - '!src/freebsd/**'
+      - 'include/**'
+      - 'Makefile'
+      - '.github/workflows/continuous-build-linux.yml'    
   pull_request:
     branches: [ main ]
-    
+    tags-ignore:
+      - '*.*'      
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,6 +37,7 @@ apps:
       - network-observe
       - home
       - removable-media
+      - opengl
 
 parts:
   btop:
@@ -47,7 +48,6 @@ parts:
       - PREFIX=/usr/local
       - STATIC=true
       - ADDFLAGS="-D SNAPPED"
-      
     build-packages:
       - coreutils
       - sed


### PR DESCRIPTION
  - Added a GH action to perform a sanity check for the snap builds.
  - Added a small insert to delineate between the snap and other binaries.
  - Added `opengl` interface for GPU support - possibly.