### PR TITLE
Added a way to install btop on deepin

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,10 @@ Also needs a UTF8 locale and a font that covers:
     ```bash
     sudo dnf install btop
 	```
+* **debian**
+    ```bash
+    sudo apt install btop
+	```
 * **RHEL/AlmaLinux 8+**
     ```bash
     sudo dnf install epel-release

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Also needs a UTF8 locale and a font that covers:
     ```bash
     sudo dnf install btop
 	```
-* **debian**
+* **deepin**
     ```bash
     sudo apt install btop
 	```


### PR DESCRIPTION
Added a way to install btop on deepin

You can install btop on deepin using
''' sudo apt install btop'''