### PR TITLE
Fix the GPU Monetoring for nvidia

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -948,13 +948,6 @@ namespace Gpu {
 		bool init() {
 			if (initialized) return false;
 
-			//? Dynamic loading & linking
-			nvml_dl_handle = dlopen("libnvidia-ml.so", RTLD_LAZY);
-			if (!nvml_dl_handle) {
-				Logger::info(std::string("Failed to load libnvidia-ml.so, NVIDIA GPUs will not be detected: ") + dlerror());
-				return false;
-			}
-
 			//? Try possible library names for libnvidia-ml.so
 			const array libNvAlts = {
 				"libnvidia-ml.so",


### PR DESCRIPTION
I removed the old implementation of loading `libnvidia-ml.so`, because otherwise a false negative is returned, when `libnvidia-ml.so` is not found before looking for alternative names.

PS: I'm not sure but in my opinion changing the name to `libnvidia-ml.so.1` would also fix the issue, because on all distros i had a look add (Debian, Ubuntu, Arch) both `libnvidia-ml.so.1` and `libnvidia-ml.so` are present and only on fedora only `libnvidia-ml.so.1` is present