### PR TITLE
Update snapcraft.yaml to fix compile

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,6 +45,7 @@ parts:
     source-type: git
     plugin: make
     make-parameters:
+      - CXX=g++-11
       - PREFIX=/usr/local
       - STATIC=true
       - ADDFLAGS="-D SNAPPED"


### PR DESCRIPTION
Fix from error after merge of #613

Specify compiler in build script.