### PR TITLE
fix: increase interface name length to 15

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1361,6 +1361,7 @@ namespace Net {
 	int x = 1, y, width = 20, height;
 	int b_x, b_y, b_width, b_height, d_graph_height, u_graph_height;
 	bool shown = true, redraw = true;
+	const int MAX_IFNAMSIZ = 15;
 	string old_ip;
 	std::unordered_map<string, Draw::Graph> graphs;
 	string box;
@@ -1381,7 +1382,7 @@ namespace Net {
 		out.reserve(width * height);
 		const string title_left = Theme::c("net_box") + Fx::ub + Symbols::title_left;
 		const string title_right = Theme::c("net_box") + Fx::ub + Symbols::title_right;
-		const int i_size = min((int)selected_iface.size(), 10);
+		const int i_size = min((int)selected_iface.size(), MAX_IFNAMSIZ);
 		const long long down_max = (net_auto ? safeVal(graph_max, "download"s) : ((long long)(Config::getI("net_download")) << 20) / 8);
 		const long long up_max = (net_auto ? safeVal(graph_max, "upload"s) : ((long long)(Config::getI("net_upload")) << 20) / 8);
 
@@ -1403,7 +1404,7 @@ namespace Net {
 			//? Interface selector and buttons
 
 			out += Mv::to(y, x+width - i_size - 9) + title_left + Fx::b + Theme::c("hi_fg") + "<b " + Theme::c("title")
-				+ uresize(selected_iface, 10) + Theme::c("hi_fg") + " n>" + title_right
+				+ uresize(selected_iface, MAX_IFNAMSIZ) + Theme::c("hi_fg") + " n>" + title_right
 				+ Mv::to(y, x+width - i_size - 15) + title_left + Theme::c("hi_fg") + (safeVal(net.stat, "download"s).offset + safeVal(net.stat, "upload"s).offset > 0 ? Fx::b : "") + 'z'
 				+ Theme::c("title") + "ero" + title_right;
 			Input::mouse_mappings["b"] = {y, x+width - i_size - 8, 1, 3};


### PR DESCRIPTION
The interface name is too short to distinguish between the interfaces (unless you look at the GW IP address).

The maximum length an interface can have is 15 characters. Thus increasing the value from 10 to 15 shouldn't be a big deal.

# Before

<img width="688" alt="image" src="https://github.com/aristocratos/btop/assets/223439/98880a59-2d38-4a39-b8c6-a732c9544135">

# After

<img width="686" alt="image" src="https://github.com/aristocratos/btop/assets/223439/f4133efe-5366-41bc-9778-98b471943f5b">

fixes #713