### PR TITLE
cmake: link CMAKE_DL_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,9 @@ if(LINUX AND BTOP_GPU)
 
     target_link_libraries(btop ROCm)
   endif()
+  if(NOT BTOP_STATIC)
+    target_link_libraries(btop ${CMAKE_DL_LIBS})
+  endif()
 endif()
 
 if(BTOP_USE_MOLD)


### PR DESCRIPTION
Without the explicit command below, I get a build failure when building from sources on Ubuntu 20.04 and adding GPU support.

The build was done with Spack, see https://github.com/spack/spack/pull/42139

If it is of any use, I attach a log of the failed build (before this change): [spack-build-out.txt](https://github.com/aristocratos/btop/files/13975792/spack-build-out.txt)

