### PR TITLE
Fix compilation with g++-10 when GPU_SUPPORT is enabled by adding the -ldl flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ target_link_libraries(btop Threads::Threads)
 # Enable GPU support
 if(LINUX AND BTOP_GPU)
   target_compile_definitions(btop PRIVATE GPU_SUPPORT)
+  target_link_libraries(btop ${CMAKE_DL_LIBS})
 
   if(BTOP_RSMI_STATIC)
     # ROCm doesn't properly add it's folders to the module path if `CMAKE_MODULE_PATH` is already

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ifneq ($(GPU_SUPPORT),true)
 endif
 
 ifeq ($(GPU_SUPPORT),true)
-	override ADDFLAGS += -DGPU_SUPPORT
+	override ADDFLAGS += -DGPU_SUPPORT -ldl
 endif
 
 FORTIFY_SOURCE ?= true


### PR DESCRIPTION
Closes #730. I ended up testing the CMAKE compilation pipeline and found the same issue, so I've changed things there as well.

 I don't have quick access to other versions of linux/compilers, so I've made the fix that works for me, but this definitely needs to be tested on newer versions of g++/clang and newer kernel versions.