### PR TITLE
Fix basic_string::_M_create exception

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -583,7 +583,7 @@ namespace Cpu {
 				cpuhz += " GHz";
 			}
 			else if (hz > 0)
-				cpuhz = to_string((int)round(hz)) + " MHz";
+				cpuhz = to_string((int)hz) + " MHz";
 
 		}
 		catch (const std::exception& e) {


### PR DESCRIPTION
when 1000>hz>999.5, round(hz)=1000
btop_draw.cpp: 793: Symbols::h_line * (7 - cpuHz.size())  exception