### PR TITLE
cmake: Remove version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
 endif()
 
 project("btop"
-  VERSION 1.3.0
   DESCRIPTION "A monitor of resources"
   HOMEPAGE_URL "https://github.com/aristocratos/btop"
   LANGUAGES CXX


### PR DESCRIPTION
This version variable is currently not used but could you still bump the version on a new release? Or we could just remove it for now.