### PR TITLE
collect: Fix reading of battery power draw on Linux

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -835,7 +835,7 @@ namespace Cpu {
 		if (b.use_power) {
 			if (not b.power_now.empty()) {
 				try {
-					watts = (float)stoll(readfile(b.energy_now, "-1")) / 1000000.0;
+					watts = (float)stoll(readfile(b.power_now, "-1")) / 1000000.0;
 				}
 				catch (const std::invalid_argument&) { }
 				catch (const std::out_of_range&) { }


### PR DESCRIPTION
This was erroneously set to read from the current battery charge.

Fixes #770.