### PR TITLE
Don't depend on b_column_size to show core temps

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -694,7 +694,7 @@ namespace Cpu {
 			if (show_temps) {
 				temp_graphs.clear();
 				temp_graphs.emplace_back(5, 1, "temp", safeVal(cpu.temp, 0), graph_symbol, false, false, cpu.temp_max, -23);
-				if (not hide_cores and b_column_size > 1) {
+				if (not hide_cores) {
 					for (const auto& i : iota((size_t)1, cpu.temp.size())) {
 						temp_graphs.emplace_back(5, 1, "temp", safeVal(cpu.temp, i), graph_symbol, false, false, cpu.temp_max, -23);
 					}


### PR DESCRIPTION
b_column_size calculation always takes into account 6 columns to show temperature:
```cpp
        #ifdef GPU_SUPPORT
            b_columns = max(1, (int)ceil((double)(Shared::coreCount + 1) / (height - gpus_extra_height - 5)));
        #else
            b_columns = max(1, (int)ceil((double)(Shared::coreCount + 1) / (height - 5)));
        #endif
            if (b_columns * (21 + 12 * show_temp) < width - (width / 3)) {
                b_column_size = 2;
                b_width = (21 + 12 * show_temp) * b_columns - (b_columns - 1);
            }
            else if (b_columns * (15 + 6 * show_temp) < width - (width / 3)) {
                b_column_size = 1;
                b_width = (15 + 6 * show_temp) * b_columns - (b_columns - 1);
            }
            else if (b_columns * (8 + 6 * show_temp) < width - (width / 3)) {
                b_column_size = 0;
            }
            else {
                b_columns = (width - width / 3) / (8 + 6 * show_temp);
                b_column_size = 0;
            }
```

So I assume showing core temps should not depend on b_column_size.
This fixes core temperatures not showing for me.