### PR TITLE
macOS: fix crash if there exists a uid not associated with any user

### DIFF
--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1252,7 +1252,7 @@ namespace Proc {
                         if (pwd != nullptr) {
                             new_proc.user = pwd->pw_name;
                         } else {
-                            new_proc.user = "unknown";
+                            new_proc.user = std::to_string(kproc.kp_eproc.e_ucred.cr_uid);
                             Logger::warning("Could not retrieve user information for user ID:" + std::to_string(kproc.kp_eproc.e_ucred.cr_uid) + " (pid:" + std::to_string(pid) + ")");
                         }
 					}

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1253,7 +1253,6 @@ namespace Proc {
                             new_proc.user = pwd->pw_name;
                         } else {
                             new_proc.user = std::to_string(kproc.kp_eproc.e_ucred.cr_uid);
-                            Logger::warning("Could not retrieve user information for user ID:" + std::to_string(kproc.kp_eproc.e_ucred.cr_uid) + " (pid:" + std::to_string(pid) + ")");
                         }
 					}
 					new_proc.p_nice = kproc.kp_proc.p_nice;

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1249,7 +1249,12 @@ namespace Proc {
 						new_proc.ppid = kproc.kp_eproc.e_ppid;
 						new_proc.cpu_s = kproc.kp_proc.p_starttime.tv_sec * 1'000'000 + kproc.kp_proc.p_starttime.tv_usec;
 						struct passwd *pwd = getpwuid(kproc.kp_eproc.e_ucred.cr_uid);
-						new_proc.user = pwd->pw_name;
+                        if (pwd != nullptr) {
+                            new_proc.user = pwd->pw_name;
+                        } else {
+                            new_proc.user = "unknown";
+                            Logger::warning("Could not retrieve user information for user ID:" + std::to_string(kproc.kp_eproc.e_ucred.cr_uid) + " (pid:" + std::to_string(pid) + ")");
+                        }
 					}
 					new_proc.p_nice = kproc.kp_proc.p_nice;
 					new_proc.state = kproc.kp_proc.p_stat;


### PR DESCRIPTION
Fixes crash if there exists a uid not associated with any user.
Fixes #830 

Equivalent behaviour to linux:
|  MacOS |  Linux  |
|---|---|
| <img width="568" alt="Screenshot 2024-04-28 at 3 52 33 AM" src="https://github.com/aristocratos/btop/assets/25097841/0ff6cbd6-7aeb-4d9d-8d4c-bd02ede61b7d">  |  <img width="779" alt="Screenshot 2024-04-28 at 3 49 47 AM" src="https://github.com/aristocratos/btop/assets/25097841/dbde1e51-a4b4-4e34-a118-4cf70efa942b"> |