### PR TITLE
fix zero temp (#467)

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -448,7 +448,7 @@ namespace Cpu {
 						const int file_id = atoi(file.path().filename().c_str() + 4); // skip "temp" prefix
 						string file_path = file.path();
 
-						if (!s_contains(file_path, file_suffix)) {
+						if (!s_contains(file_path, file_suffix) or s_contains(file_path, "nvme")) {
 							continue;
 						}
 


### PR DESCRIPTION
Hi,

this fixes #467 at least on AWS. The issue is that `found_sensors` contains some random sensor that isn't even really showing any temperature (`/sys/devices/pci0000:00/0000:00:04.0/nvme/nvme0/hwmon0/temp1_` on my system). 

My 'fix' is to just ignore nvme devices as temperature sensors. I suspect that on other systems other strange sensors may show up, but on my AWS VM at least, this solves the issue: temperature is just not showing (which is correct as no real temp sensor is showing up in `/sys`)