### PR TITLE
fix: include missed out utility header in NetBSD.

### DIFF
--- a/src/netbsd/btop_collect.cpp
+++ b/src/netbsd/btop_collect.cpp
@@ -64,6 +64,7 @@ tab-size = 4
 #include <regex>
 #include <string>
 #include <memory>
+#include <utility>
 
 #include "../btop_config.hpp"
 #include "../btop_shared.hpp"


### PR DESCRIPTION
Include the missed out `utility` header. This also fixes the build in `netbsd-CURRENT`