### PR TITLE
intel_name_lookup_shim.c (get_intel_device_name): Fix SEGFAULT

### DIFF
--- a/src/linux/intel_gpu_top/intel_name_lookup_shim.c
+++ b/src/linux/intel_gpu_top/intel_name_lookup_shim.c
@@ -84,8 +84,12 @@ char *get_intel_device_name(const char *device_id) {
     char full_name[256];
     const struct intel_device_info *info = intel_get_device_info(devid);
     if (info) {
-        strcpy(dev_name, info->codename);
-        dev_name[0] = toupper(dev_name[0]);
+        if (info->codename == NULL) {
+            strcpy(dev_name, "(unknown)");
+        } else {
+            strcpy(dev_name, info->codename);
+            dev_name[0] = toupper(dev_name[0]);
+        }
         snprintf(full_name, sizeof(full_name), "Intel %s (Gen%u)", dev_name, info->graphics_ver);
         return strdup(full_name);
     }


### PR DESCRIPTION
btop would always fail with "Segmentation fault" when used on machines where the GPU does not have a codename (e.g. on embedded Intel graphics on Intel(R) Atom(TM) CPU D2500.)  The reason for this behavior is that when a GPU does not have codename (it is NULL) the call to "strcpy" segfaults as the procedure effectively tries to access a NULL pointer.

* src/linux/intel_gpu_top/intel_name_lookup_shim.c (get_intel_device_name): Add a check if "info->codename" is null; if it is, set the device name to "(unknown)" to prevent the SEGFAULT error.