### PR TITLE
src/btop_menu.cpp: Fix the description of loglevel option

### DIFF
--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -360,7 +360,7 @@ namespace Menu {
 				"Show discharge power when discharging.",
 				"Show charging power when charging."},
 			{"log_level",
-				"Set loglevel for error.log",
+				"Set loglevel for \"~/.config/btop/btop.log\"",
 				"",
 				"\"ERROR\", \"WARNING\", \"INFO\" and \"DEBUG\".",
 				"",


### PR DESCRIPTION
* src/btop_menu.cpp (categories): Fix the description of loglevel option in the menu: replace missing "error.log" with actual "~/.config/btop/btop.log" (as in "btop_config.cpp".)