### PR TITLE
Support Intel GPUs before Gen-6 (patch from upstream)

### DIFF
--- a/src/linux/intel_gpu_top/intel_gpu_top.c
+++ b/src/linux/intel_gpu_top/intel_gpu_top.c
@@ -492,7 +492,7 @@ static int get_num_gts(uint64_t type)
 
 	errno = 0;
 	for (cnt = 0; cnt < MAX_GTS; cnt++) {
-		fd = igt_perf_open(type, __I915_PMU_REQUESTED_FREQUENCY(cnt));
+		fd = igt_perf_open(type, __I915_PMU_INTERRUPTS(cnt));
 		if (fd < 0)
 			break;
 


### PR DESCRIPTION
From https://gitlab.freedesktop.org/drm/igt-gpu-tools/-/commit/c727cc3fad56f16f1a9f35023ae5dd7111976fa3.

With this change `intel_gpu_top` works with Intel GMA chips instead of terminating with _Failed to initialize PMU_.

When it comes to `btop`:
- Without this change my Gen-4 Intel GPU (GMA 4500MHD) is not visible in `btop`.
- With the change both of my GPUs (Gen-4 and Gen-9 on two different PCs) are visible in `btop`.