### PR TITLE
Bump FreeBSD / NetBSD versions.

### DIFF
--- a/.github/workflows/cmake-freebsd.yml
+++ b/.github/workflows/cmake-freebsd.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Compile
         uses: vmactions/freebsd-vm@v1
         with:
-          release: '14.0'
+          release: '14.2'
           usesh: true
           prepare: pkg install -y cmake ninja lowdown
           run: |

--- a/.github/workflows/cmake-netbsd.yml
+++ b/.github/workflows/cmake-netbsd.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Compile
         uses: vmactions/netbsd-vm@v1
         with:
-          release: '10.0'
+          release: '10.1'
           usesh: true
           prepare: |
             PATH="/usr/pkg/sbin:/usr/pkg/bin:$PATH"
-            PKG_PATH="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/amd64/10.0/All/"
+            PKG_PATH="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/amd64/10.1/All/"
             export PATH PKG_PATH
             /usr/sbin/pkg_add pkgin
             pkgin -y install cmake ninja-build gcc10 coreutils git

--- a/.github/workflows/continuous-build-freebsd.yml
+++ b/.github/workflows/continuous-build-freebsd.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Compile
         uses: vmactions/freebsd-vm@v1
         with:
-          release: '14.0'
+          release: '14.2'
           usesh: true
           prepare: |
             pkg install -y gmake gcc coreutils git lowdown

--- a/.github/workflows/continuous-build-netbsd.yml
+++ b/.github/workflows/continuous-build-netbsd.yml
@@ -42,11 +42,11 @@ jobs:
         uses: vmactions/netbsd-vm@v1
 
         with:
-          release: '10.0'
+          release: '10.1'
           usesh: true
           prepare: |
             PATH="/usr/pkg/sbin:/usr/pkg/bin:$PATH"
-            PKG_PATH="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/amd64/10.0/All/"
+            PKG_PATH="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/amd64/10.1/All/"
             export PATH PKG_PATH
             /usr/sbin/pkg_add pkgin
             pkgin -y install gmake gcc10 coreutils git


### PR DESCRIPTION
- Bump FreeBSD version to the latest supported `14.2`
- Bump NetBSD version to the latest supported `10.1`

Release notes can be found here: 
- https://www.freebsd.org/releases/
- https://www.netbsd.org/releases/formal-10/NetBSD-10.1.html