### PR TITLE
Set Intel GPU flag when GPU_SUPPORT with STATIC enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,14 @@ ifeq ($(PLATFORM_LC)$(ARCH),linuxx86_64)
 		INTEL_GPU_SUPPORT := true
 	endif
 endif
+
 ifneq ($(GPU_SUPPORT),true)
 	GPU_SUPPORT := false
+endif
+
+ifeq ($(GPU_SUPPORT)$(STATIC),truetrue)
+	GPU_SUPPORT := true
+	INTEL_GPU_SUPPORT := true
 endif
 
 ifeq ($(GPU_SUPPORT),true)


### PR DESCRIPTION
Set Intel GPU flag when GPU_SUPPORT with STATIC enabled

Enable INTEL_GPU_SUPPORT when both STATIC and GPU_SUPPORT is enabled.

Even though NVIDIA and AMD GPUs _(partially)_ requires dynamic linking, Intel GPU does not requires it.