### PR TITLE
Add Intel NPU utilization

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -333,6 +333,8 @@ void clean_quit(int sig) {
 #ifdef GPU_SUPPORT
 	Gpu::Nvml::shutdown();
 	Gpu::Rsmi::shutdown();
+	Gpu::Intel::shutdown();
+	Gpu::IntelNPU::shutdown();
 #endif
 
 	Config::write();

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -874,7 +874,7 @@ namespace Cpu {
 			for (unsigned long i = 0; i < gpus.size(); ++i) {
 				if (gpu_auto and v_contains(Gpu::shown_panels, i))
 					continue;
-				out += Mv::to(b_y + ++cy, b_x + 1) + Theme::c("main_fg") + Fx::b + "GPU";
+				out += Mv::to(b_y + ++cy, b_x + 1) + Theme::c("main_fg") + Fx::b + gpus[i].get_device_type();
 				if (gpus.size() > 1) out += rjust(to_string(i), 1 + (gpus.size() > 9));
 				if (gpus[i].supported_functions.gpu_utilization) {
 					out += ' ';
@@ -1006,7 +1006,7 @@ namespace Gpu {
 			if (not single_graph)
 				out += Mv::to(y + graph_up_height + 1, x + 1) + graph_lower(safeVal(gpu.gpu_percent, "gpu-totals"s), (data_same or redraw[index]));
 
-			out += Mv::to(b_y + 1, b_x + 1) + Theme::c("main_fg") + Fx::b + "GPU " + gpu_meter(safeVal(gpu.gpu_percent, "gpu-totals"s).back())
+			out += Mv::to(b_y + 1, b_x + 1) + Theme::c("main_fg") + Fx::b + gpu.get_device_type() + " " + gpu_meter(safeVal(gpu.gpu_percent, "gpu-totals"s).back())
 				+ Theme::g("cpu").at(clamp(safeVal(gpu.gpu_percent, "gpu-totals"s).back(), 0ll, 100ll)) + rjust(to_string(safeVal(gpu.gpu_percent, "gpu-totals"s).back()), 5) + Theme::c("main_fg") + '%';
 
 			//? Temperature graph, I assume the device supports utilization if it supports temperature
@@ -1066,11 +1066,11 @@ namespace Gpu {
 			} else {
 				out += Theme::c("main_fg") + Mv::r(1);
 				if (gpu.supported_functions.mem_total)
-					out += "VRAM total:" + rjust(floating_humanizer(gpu.mem_total), b_width/(1 + gpu.supported_functions.mem_clock)-14);
-				else out += "VRAM usage:" + rjust(floating_humanizer(gpu.mem_used), b_width/(1 + gpu.supported_functions.mem_clock)-14);
+					out += gpu.get_memory_type() + " total:" + rjust(floating_humanizer(gpu.mem_total), b_width/(1 + gpu.supported_functions.mem_clock)-14);
+				else out += gpu.get_memory_type() + " usage:" + rjust(floating_humanizer(gpu.mem_used, false, 0, false, false), b_width/(1 + gpu.supported_functions.mem_clock)-14);
 
 				if (gpu.supported_functions.mem_clock)
-					out += "   VRAM clock:" + rjust(to_string(gpu.mem_clock_speed) + " Mhz", b_width/2-13);
+					out += "   " + gpu.get_memory_type() + " clock:" + rjust(to_string(gpu.mem_clock_speed) + " Mhz", b_width/2-13);
 			}
 		}
 
@@ -2106,7 +2106,7 @@ namespace Draw {
 
 				height += (height+Cpu::height == Term::height-1);
 				x_vec[i] = 1; y_vec[i] = 1 + i*height + (not Config::getB("cpu_bottom"))*Cpu::shown*Cpu::height;
-				box[i] = createBox(x_vec[i], y_vec[i], width, height, Theme::c("cpu_box"), true, std::string("gpu") + (char)(shown_panels[i]+'0'), "", (shown_panels[i]+5)%10); // TODO gpu_box
+				box[i] = createBox(x_vec[i], y_vec[i], width, height, Theme::c("cpu_box"), true, std::string("xpu") + (char)(shown_panels[i]+'0'), "", (shown_panels[i]+5)%10); // TODO gpu_box
 
 				b_height_vec[i] = 2 + gpu_b_height_offsets[shown_panels[i]];
 				b_width = clamp(width/2, min_width, 64);

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -44,6 +44,7 @@ using std::deque;
 using std::string;
 using std::tuple;
 using std::vector;
+using std::string_view;
 
 using namespace std::literals; // for operator""s
 
@@ -130,15 +131,16 @@ namespace Gpu {
 	//* Container for supported Gpu::*::collect() functions
 	struct gpu_info_supported {
 		bool gpu_utilization = true,
-		   	 mem_utilization = true,
-				 gpu_clock = true,
-				 mem_clock = true,
-				 pwr_usage = true,
-				 pwr_state = true,
-				 temp_info = true,
-				 mem_total = true,
-				 mem_used = true,
-				 pcie_txrx = true;
+		mem_utilization = true,
+		gpu_clock = true,
+		mem_clock = true,
+		pwr_usage = true,
+		pwr_state = true,
+		temp_info = true,
+		mem_total = true,
+		mem_used = true,
+		pcie_txrx = true,
+		is_npu_device = true;
 	};
 
 	//* Per-device container for GPU info
@@ -167,6 +169,19 @@ namespace Gpu {
 
 		gpu_info_supported supported_functions;
 
+		string get_device_label() const {
+			return supported_functions.is_npu_device ? "npu" : "gpu";
+		}
+
+		string get_device_type() const {
+			return supported_functions.is_npu_device ? "NPU" : "GPU";
+		}
+
+		string get_memory_type() const {
+			// TODO: This should be set per device - GPU may use RAM and discrete NPU may have VRAM.
+			return supported_functions.is_npu_device ? "RAM" : "VRAM";
+		}
+
 		// vector<proc_info> graphics_processes = {}; // TODO
 		// vector<proc_info> compute_processes = {};
 	};
@@ -175,6 +190,14 @@ namespace Gpu {
 		extern bool shutdown();
 	}
 	namespace Rsmi {
+		extern bool shutdown();
+	}
+
+	namespace Intel {
+		extern bool shutdown();
+	}
+
+	namespace IntelNPU {
 		extern bool shutdown();
 	}
 


### PR DESCRIPTION
Hello,

This commit adds proof of concept support for the Intel NPU inference accelerator [^1][^2][^3]
that is present in Meteor and Lunar Lake CPUs.

I emphasize that this is a PoC implementation to show that NPU device implementation may reuse GPU codebase.
These two are asynchronous coprocessors that expose similar statistics (utilization, VRAM/RAM memory, clocks, power stats).

For now, the NPU device is added into vector<gpus> and based on `is_npu_device` info to generate distinct strings for GPU/NPU at the drawing stage.

To make a complete implementation there are a couple of ways I see and I am not sure which is appropriate:

1. Continue the current way but filter NPU devices from gpu-average etc.
2. Duplicate or maybe alias gpu_info into npu_info, create separate container for vector<npu_info> and reuse drawing functions,
   keeping `is_npu_device` in `supported_functions` to get the device string in a drawing.
3. Duplicate fully gpu_info and drawing utilities.

I think that the second option seems to be the most optimal and I would ask for some guidance.

[^1]: NPU explained: https://intel.github.io/intel-npu-acceleration-library/npu.html
[^2]: Linux driver sources path: `root/drivers/accel/ivpu/`
[^3]: NPU UMD sources: https://github.com/intel/linux-npu-driver
