### PR TITLE
Improved cpu idle ticks calculation

### DIFF
--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -436,8 +436,13 @@ namespace Cpu {
 
 				//? Calculate cpu total for each core
 				if (i > Shared::coreCount) break;
-				const long long calc_totals = max(0ll, totals - core_old_totals.at(i));
-				const long long calc_idles = max(0ll, idles - core_old_idles.at(i));
+				long long calc_totals = max(0ll, totals - core_old_totals.at(i));
+				long long calc_idles = max(0ll, idles - core_old_idles.at(i));
+				if (calc_totals == 0) {
+					//? No changes for this core, simulate 1 idle
+					calc_totals = 1;
+					calc_idles = 1;
+				}
 				core_old_totals.at(i) = totals;
 				core_old_idles.at(i) = idles;
 
@@ -453,8 +458,13 @@ namespace Cpu {
 
 		}
 
-		const long long calc_totals = max(1ll, global_totals - cpu_old.at("totals"));
-		const long long calc_idles = max(1ll, global_idles - cpu_old.at("idles"));
+		long long calc_totals = max(0ll, global_totals - cpu_old.at("totals"));
+		long long calc_idles = max(0ll, global_idles - cpu_old.at("idles"));
+		if (calc_totals == 0) {
+			//? No changes, simulate 1 idle
+			calc_totals = 1;
+			calc_idles = 1;
+		}
 
 		//? Populate cpu.cpu_percent with all fields from syscall
 		for (int ii = 0; const auto &val : times_summed) {

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -951,8 +951,13 @@ namespace Cpu {
 
 					//? Calculate values for totals from first line of stat
 					if (i == 0) {
-						const long long calc_totals = max(1ll, totals - cpu_old.at("totals"));
-						const long long calc_idles = max(1ll, idles - cpu_old.at("idles"));
+						long long calc_totals = max(0ll, totals - cpu_old.at("totals"));
+						long long calc_idles = max(0ll, idles - cpu_old.at("idles"));
+						if (calc_totals == 0) {
+							//? No changes in stat, simulate 1 idle
+							calc_totals = 1;
+							calc_idles = 1;
+						}
 						cpu_old.at("totals") = totals;
 						cpu_old.at("idles") = idles;
 
@@ -982,8 +987,13 @@ namespace Cpu {
 							core_old_idles.push_back(0);
 							cpu.core_percent.emplace_back();
 						}
-						const long long calc_totals = max(0ll, totals - core_old_totals.at(i-1));
-						const long long calc_idles = max(0ll, idles - core_old_idles.at(i-1));
+						long long calc_totals = max(0ll, totals - core_old_totals.at(i-1));
+						long long calc_idles = max(0ll, idles - core_old_idles.at(i-1));
+						if (calc_totals == 0) {
+							//? No changes in stat for this core, simulate 1 idle
+							calc_totals = 1;
+							calc_idles = 1;
+						}
 						core_old_totals.at(i-1) = totals;
 						core_old_idles.at(i-1) = idles;
 

--- a/src/netbsd/btop_collect.cpp
+++ b/src/netbsd/btop_collect.cpp
@@ -601,8 +601,13 @@ namespace Cpu {
 
 				//? Calculate cpu total for each core
 				if (i > Shared::coreCount) break;
-				const long long calc_totals = max(0ll, totals - core_old_totals.at(i));
-				const long long calc_idles = max(0ll, idles - core_old_idles.at(i));
+				long long calc_totals = max(0ll, totals - core_old_totals.at(i));
+				long long calc_idles = max(0ll, idles - core_old_idles.at(i));
+				if (calc_totals == 0) {
+					//? No changes for this core, simulate 1 idle
+					calc_totals = 1;
+					calc_idles = 1;
+				}
 				core_old_totals.at(i) = totals;
 				core_old_idles.at(i) = idles;
 
@@ -618,8 +623,13 @@ namespace Cpu {
 
 		}
 
-		const long long calc_totals = max(1ll, global_totals - cpu_old.at("totals"));
-		const long long calc_idles = max(1ll, global_idles - cpu_old.at("idles"));
+		long long calc_totals = max(0ll, global_totals - cpu_old.at("totals"));
+		long long calc_idles = max(0ll, global_idles - cpu_old.at("idles"));
+		if (calc_totals == 0) {
+			//? No changes, simulate 1 idle
+			calc_totals = 1;
+			calc_idles = 1;
+		}
 
 		//? Populate cpu.cpu_percent with all fields from syscall
 		for (int ii = 0; const auto &val : times_summed) {

--- a/src/openbsd/btop_collect.cpp
+++ b/src/openbsd/btop_collect.cpp
@@ -452,8 +452,13 @@ namespace Cpu {
 
 				//? Calculate cpu total for each core
 				if (i > Shared::coreCount) break;
-				const long long calc_totals = max(0ll, totals - core_old_totals.at(i));
-				const long long calc_idles = max(0ll, idles - core_old_idles.at(i));
+				long long calc_totals = max(0ll, totals - core_old_totals.at(i));
+				long long calc_idles = max(0ll, idles - core_old_idles.at(i));
+				if (calc_totals == 0) {
+					//? No changes for this core, simulate 1 idle
+					calc_totals = 1;
+					calc_idles = 1;
+				}
 				core_old_totals.at(i) = totals;
 				core_old_idles.at(i) = idles;
 
@@ -469,8 +474,13 @@ namespace Cpu {
 
 		}
 
-		const long long calc_totals = max(1ll, global_totals - cpu_old.at("totals"));
-		const long long calc_idles = max(1ll, global_idles - cpu_old.at("idles"));
+		long long calc_totals = max(0ll, global_totals - cpu_old.at("totals"));
+		long long calc_idles = max(0ll, global_idles - cpu_old.at("idles"));
+		if (calc_totals == 0) {
+			//? No changes, simulate 1 idle
+			calc_totals = 1;
+			calc_idles = 1;
+		}
 
 		//? Populate cpu.cpu_percent with all fields from syscall
 		for (int ii = 0; const auto &val : times_summed) {

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -494,8 +494,13 @@ namespace Cpu {
 
 				//? Calculate cpu total for each core
 				if (i > Shared::coreCount) break;
-				const long long calc_totals = max(0ll, totals - core_old_totals.at(i));
-				const long long calc_idles = max(0ll, idles - core_old_idles.at(i));
+				long long calc_totals = max(0ll, totals - core_old_totals.at(i));
+				long long calc_idles = max(0ll, idles - core_old_idles.at(i));
+				if (calc_totals == 0) {
+					//? No changes for this core, simulate 1 idle
+					calc_totals = 1;
+					calc_idles = 1;
+				}
 				core_old_totals.at(i) = totals;
 				core_old_idles.at(i) = idles;
 
@@ -510,8 +515,13 @@ namespace Cpu {
 			}
 		}
 
-		const long long calc_totals = max(1ll, global_totals - cpu_old.at("totals"));
-		const long long calc_idles = max(1ll, global_idles - cpu_old.at("idles"));
+		long long calc_totals = max(0ll, global_totals - cpu_old.at("totals"));
+		long long calc_idles = max(0ll, global_idles - cpu_old.at("idles"));
+		if (calc_totals == 0) {
+			//? No changes, simulate 1 idle
+			calc_totals = 1;
+			calc_idles = 1;
+		}
 
 		//? Populate cpu.cpu_percent with all fields from syscall
 		for (int ii = 0; const auto &val : times_summed) {


### PR DESCRIPTION
Fixes #970.

Removes the minimum of 1 idle cpu cycle, which caused a total percentage of 99% on low interval times when all cores are 100%.
When there were no changes since the last update, `calc_totals` and `calc_idles` are set to 1 to simulate an idle tick to prevent a divide by zero when calculating the percentage.