### PR TITLE
align proc_sorting options width in tui

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1676,7 +1676,7 @@ namespace Proc {
 			}
 
 			//? per-core, reverse, tree and sorting
-			const auto& sorting = Config::getS("proc_sorting");
+			const auto& sorting = ljust(Config::getS("proc_sorting"),10);
 			const int sort_len = sorting.size();
 			const int sort_pos = x + width - sort_len - 8;
 


### PR DESCRIPTION
Pr is for aligning the process sorting options in the tui, such that cycling trough the options doesn't move the less/greater symbols.
This helps in making quick switches with the mouse faster.

before:
![image](https://github.com/user-attachments/assets/b8c390cc-6e6e-470b-b533-cadeebfbb781)
after:
![image](https://github.com/user-attachments/assets/42b1d907-04cf-49a8-844c-1ec96ee1b4ab)
