### PR TITLE
Update obsolete egrep call

### DIFF
--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -586,7 +586,7 @@ namespace Mem {
 		// this code is for ZFS mounts
 		for (const auto &poolName : Mem::zpools) {
 			char sysCtl[1024];
-			snprintf(sysCtl, sizeof(sysCtl), "sysctl kstat.zfs.%s.dataset | egrep \'dataset_name|nread|nwritten\'", poolName.c_str());
+			snprintf(sysCtl, sizeof(sysCtl), "sysctl kstat.zfs.%s.dataset | grep -E \'dataset_name|nread|nwritten\'", poolName.c_str());
 			PipeWrapper f = PipeWrapper(sysCtl, "r");
 			if (f()) {
 				char buf[512];


### PR DESCRIPTION
The call that grabs zfs mount information uses egrep, which complains about being obsolete to stdout.

This commit does as the warning says, and updates the call to use grep -E instead.

As far as I've tested, this works to remove the warning.

(should fix https://github.com/aristocratos/btop/issues/1016)