### PR TITLE
Bump version of deprecated upload-artifact step for bsd

### DIFF
--- a/.github/workflows/continuous-build-freebsd.yml
+++ b/.github/workflows/continuous-build-freebsd.yml
@@ -56,8 +56,8 @@ jobs:
             mv bin/btop bin/btop-"$COMPILER"-"$GIT_HASH"
             ls -alh bin
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: btop-x86_64-freebsd-14
+          name: btop-x86_64-freebsd-14-${{ matrix.compiler }}
           path: 'bin/*'
           if-no-files-found: error

--- a/.github/workflows/continuous-build-netbsd.yml
+++ b/.github/workflows/continuous-build-netbsd.yml
@@ -57,7 +57,7 @@ jobs:
             mv bin/btop bin/btop-GCC10-"$GIT_HASH"
             ls -alh bin
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: btop-x86_64-netbsd-9.3
           path: 'bin/*'


### PR DESCRIPTION
`actions/upload-artifact@v3` was still used in netbsd & freebsd but is dropped from January 30th:
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Also fix artifact upload name collision for FreeBSD.