### PR TITLE
Lock/unlock config to avoid infinite recursion when exiting process filtering with down arrow

### DIFF
--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -288,6 +288,8 @@ namespace Input {
 						Config::set("proc_filtering", false);
 						old_filter.clear();
 						if(key == "down"){
+							Config::unlock();
+							Config::lock();
 							process("down");
 							return;
 						}


### PR DESCRIPTION
This is a potential fix for #996. This doesn't seem like a great solution, but seems to be enough to fix the issue.
