### PR TITLE
add Kanagawa theme

### DIFF
--- a/themes/kanagawa-wave.theme
+++ b/themes/kanagawa-wave.theme
@@ -1,0 +1,86 @@
+# Bashtop Kanagawa-wave (https://github.com/rebelot/kanagawa.nvim) theme
+# By: philikarus
+
+# Main bg
+theme[main_bg]="#16161D"
+
+# Main text color
+theme[main_fg]="#dcd7ba"
+
+# Title color for boxes
+theme[title]="#dcd7ba"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#C34043"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#223249"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#dca561"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#727169"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#7aa89f"
+
+# Cpu box outline color
+theme[cpu_box]="#727169"
+
+# Memory/disks box outline color
+theme[mem_box]="#727169"
+
+# Net up/down box outline color
+theme[net_box]="#727169"
+
+# Processes box outline color
+theme[proc_box]="#727169"
+
+# Box divider line and small boxes line color
+theme[div_line]="#727169"
+
+# Temperature graph colors
+theme[temp_start]="#98BB6C"
+theme[temp_mid]="#DCA561"
+theme[temp_end]="#E82424"
+
+# CPU graph colors
+theme[cpu_start]="#98BB6C"
+theme[cpu_mid]="#DCA561"
+theme[cpu_end]="#E82424"
+
+# Mem/Disk free meter
+theme[free_start]="#E82424"
+theme[free_mid]="#C34043"
+theme[free_end]="#FF5D62"
+
+# Mem/Disk cached meter
+theme[cached_start]="#C0A36E"
+theme[cached_mid]="#DCA561"
+theme[cached_end]="#FF9E3B"
+
+# Mem/Disk available meter
+theme[available_start]="#938AA9"
+theme[available_mid]="#957FBB"
+theme[available_end]="#9CABCA"
+
+# Mem/Disk used meter
+theme[used_start]="#658594"
+theme[used_mid]="#7E9CDB"
+theme[used_end]="#7FB4CA"
+
+# Download graph colors
+theme[download_start]="#7E9CDB"
+theme[download_mid]="#938AA9"
+theme[download_end]="#957FBB"
+
+# Upload graph colors
+theme[upload_start]="#DCA561"
+theme[upload_mid]="#E6C384"
+theme[upload_end]="#E82424"
+
+# Process box color gradient for threads, mem and cpu usage
+theme[process_start]="#98BB6C"
+theme[process_mid]="#DCA561"
+theme[process_end]="#C34043"


### PR DESCRIPTION
Add a theme featuring palettes from the popular Kanagawa theme (https://github.com/rebelot/kanagawa.nvim)
![preview](https://live.staticflickr.com/65535/54314951737_a5a6f4929e_o.png)