### PR TITLE
PgDown/PgUp bug fix

### DIFF
--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -1314,10 +1314,12 @@ namespace Menu {
 		else if (pages > 1 and key == "page_down") {
 			if (++page >= pages) page = 0;
 			selected = 0;
+			last_sel = -1;
 		}
 		else if (pages > 1 and key == "page_up") {
 			if (--page < 0) page = pages - 1;
 			selected = 0;
+			last_sel = -1;
 		}
 		else if (key == "tab") {
 			if (++selected_cat >= (int)categories.size()) selected_cat = 0;


### PR DESCRIPTION
Hi there! This fixes the crash when pressing Page Up/Down on the Menu Options Screen by ensuring the last_sel index is reset appropriately.

#1020 