### PR TITLE
include/fmt/core.h: fix building with clang-20

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2709,7 +2709,7 @@ template <typename Char, typename... Args> class basic_format_string {
   template <typename S,
             FMT_ENABLE_IF(
                 std::is_convertible<const S&, basic_string_view<Char>>::value)>
-  FMT_CONSTEVAL FMT_INLINE basic_format_string(const S& s) : str_(s) {
+  FMT_CONSTEXPR FMT_INLINE basic_format_string(const S& s) : str_(s) {
     static_assert(
         detail::count<
             (std::is_base_of<detail::view, remove_reference_t<Args>>::value &&


### PR DESCRIPTION
During compilation with clang-20 we receive an error

```bash
include/fmt/format-inl.h:1380:28: error: call to consteval function 'fmt::basic_format_string<char, unsigned int &>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression
 1380 |       out = format_to(out, FMT_STRING("{:08x}"), value);
```

This is due to incompliance of **consteval**-ness of all the call stack up to the target

I think that **constexpr** would do here