### PR TITLE
Allows MidnightBSD to build btop using the existing FreeBSD support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ add_executable(btop
 
 if(APPLE)
   target_sources(btop PRIVATE src/osx/btop_collect.cpp src/osx/sensors.cpp src/osx/smc.cpp)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "MidnightBSD")
   target_sources(btop PRIVATE src/freebsd/btop_collect.cpp)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
   target_sources(btop PRIVATE src/openbsd/btop_collect.cpp src/openbsd/sysctlbyname.cpp)
@@ -194,7 +194,7 @@ if(APPLE)
   target_link_libraries(btop
     $<LINK_LIBRARY:FRAMEWORK,CoreFoundation> $<LINK_LIBRARY:FRAMEWORK,IOKit>
   )
-elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "MidnightBSD")
   # Avoid version mismatch for libstdc++ when a specific version of GCC is installed and not the
   # default one since all use the default ones RPATH
   if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ $(error $(shell printf "\033[1;91mERROR: \033[97m$(CXX) can't statically link gl
 		endif
 	endif
 
-	ifeq ($(PLATFORM_LC),$(filter $(PLATFORM_LC),freebsd linux))
+	ifeq ($(PLATFORM_LC),$(filter $(PLATFORM_LC),freebsd linux midnightbsd))
 		override ADDFLAGS += -DSTATIC_BUILD -static
 	else
 		ifeq ($(CXX_IS_CLANG),false)
@@ -128,7 +128,7 @@ ifeq ($(PLATFORM_LC),linux)
 	PLATFORM_DIR := linux
 	THREADS	:= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
 	SU_GROUP := root
-else ifeq ($(PLATFORM_LC),freebsd)
+else ifeq ($(PLATFORM_LC),$(filter $(PLATFORM_LC),freebsd midnightbsd))
 	PLATFORM_DIR := freebsd
 	THREADS	:= $(shell getconf NPROCESSORS_ONLN 2>/dev/null || echo 1)
 	SU_GROUP := wheel

--- a/cmake/Modules/Finddevstat.cmake
+++ b/cmake/Modules/Finddevstat.cmake
@@ -3,7 +3,7 @@
 # Find devstat, the Device Statistics Library
 #
 
-if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "MidnightBSD")
   find_path(devstat_INCLUDE_DIR NAMES devstat.h)
   find_library(devstat_LIBRARY NAMES devstat)
 

--- a/cmake/Modules/Findelf.cmake
+++ b/cmake/Modules/Findelf.cmake
@@ -3,7 +3,7 @@
 # Find libelf, the ELF Access Library
 #
 
-if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "MidnightBSD")
   find_path(elf_INCLUDE_DIR NAMES libelf.h)
   find_library(elf_LIBRARY NAMES elf)
 


### PR DESCRIPTION
Tested with GCC 14 / gmake on MidnightBSD 3.2.2 amd64

(Upstreaming Patch in mports https://github.com/MidnightBSD/mports/commit/cc90a487249395fb6ecdf0ca2b863d82fbfc42fb)