### PR TITLE
Fix wrong error message and documentation of renamed option `--utf-force` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1499,18 +1499,19 @@ log_level = "DEBUG"
 #### Command line options
 
 ```text
-usage: btop [-h] [-v] [-/+t] [-p <id>] [--force-utf] [--debug]
+Usage: btop [OPTIONS]
 
-optional arguments:
-  -h, --help            show this help message and exit
-  -v, --version         show version info and exit
-  -lc, --low-color      disable truecolor, converts 24-bit colors to 256-color
-  -t, --tty_on          force (ON) tty mode, max 16 colors and tty friendly graph symbols
-  +t, --tty_off         force (OFF) tty mode
-  -p, --preset <id>     start with preset, integer value between 0-9
-  --force-utf           force start even if no UTF-8 locale was detected
-  --debug               start in DEBUG mode: shows microsecond timer for information collect
-                        and screen draw functions and sets loglevel to DEBUG
+Options:
+  -c, --config <file>  Path to a config file
+  -d, --debug          Start in debug mode with additional logs and metrics
+      --force-utf      Override automatic UTF locale detection
+  -l, --low-color      Disable true color, 256 colors only
+  -p, --preset <id>    Start with a preset (0-9)
+  -t, --tty            Force tty mode with ANSI graph symbols and 16 colors only
+      --no-tty         Force disable tty mode
+  -u, --update <ms>    Set an initial update rate in milliseconds
+  -h, --help           Show this help message and exit
+  -V, --version        Show a version message and exit (more with --version)
 ```
 
 ## LICENSE

--- a/README.md
+++ b/README.md
@@ -1499,7 +1499,7 @@ log_level = "DEBUG"
 #### Command line options
 
 ```text
-usage: btop [-h] [-v] [-/+t] [-p <id>] [--utf-force] [--debug]
+usage: btop [-h] [-v] [-/+t] [-p <id>] [--force-utf] [--debug]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -1508,7 +1508,7 @@ optional arguments:
   -t, --tty_on          force (ON) tty mode, max 16 colors and tty friendly graph symbols
   +t, --tty_off         force (OFF) tty mode
   -p, --preset <id>     start with preset, integer value between 0-9
-  --utf-force           force start even if no UTF-8 locale was detected
+  --force-utf           force start even if no UTF-8 locale was detected
   --debug               start in DEBUG mode: shows microsecond timer for information collect
                         and screen draw functions and sets loglevel to DEBUG
 ```

--- a/manpage.md
+++ b/manpage.md
@@ -1,6 +1,6 @@
 % btop(1) | User Commands
 %
-% "January  4 2024"
+% 2025-05-01
 
 # NAME
 
@@ -8,8 +8,9 @@ btop - Resource monitor that shows usage and stats for processor, memory, disks,
 
 # SYNOPSIS
 
-**btop** [**-lc**] [**-t** | **+t**] [**-p** _id_] [**\-\-force-utf**]
-         [**\-\-debug**] [{**-h** | **\-\-help**} | {**-v** | **\-\-version**}]
+**btop** [**-c**] [**-d**] [**-l**] [**-t**] [**-p** _id_] [**-u** _ms_] [**\-\-force-utf**]
+
+**btop** [{**-h** | **\-\-help**} | {**-V** | **\-\-version**}]
 
 # DESCRIPTION
 
@@ -20,28 +21,34 @@ btop - Resource monitor that shows usage and stats for processor, memory, disks,
 The program follows the usual GNU command line syntax, with long options
 starting with two dashes ('-'). A summary of options is included below.
 
-**-lc**, **\-\-low-color**
-:   Disable truecolor, converts 24-bit colors to 256-color.
+**-c**, **\-\-config _file_**
+:   Path to a config file.
 
-**-t**, **\-\-tty_on**
-:   Force (ON) tty mode, max 16 colors and tty-friendly graph symbols.
-
-**+t**, **\-\-tty_off**
-:   Force (OFF) tty mode.
-
-**-p**, **\-\-preset _id_**
-:   Start with preset, integer value between 0-9.
+**-d**, **\-\-debug**
+:   Start in debug mode with additional logs and metrics.
 
 **\-\-force-utf**
 :   Force start even if no UTF-8 locale was detected.
 
-**\-\-debug**
-:   Start in DEBUG mode: shows microsecond timer for information collect and screen draw functions and sets loglevel to DEBUG.
+**-l**, **\-\-low-color**
+:   Disable true color, 256 colors only.
+
+**-p**, **\-\-preset _id_**
+:   Start with a preset (0-9).
+
+**-t**, **\-\-tty-on**
+:   Force tty mode with ANSI graph symbols and 16 colors only.
+
+**\-\-tty-off**
+:   Force disable tty mode.
+
+**-u**, **\-\-update _ms_**
+:   Set an initial update rate in milliseconds.
 
 **-h**, **\-\-help**
 :   Show summary of options.
 
-**-v**, **\-\-version**
+**-V**, **\-\-version**
 :   Show version of program.
 
 # BUGS

--- a/manpage.md
+++ b/manpage.md
@@ -8,7 +8,7 @@ btop - Resource monitor that shows usage and stats for processor, memory, disks,
 
 # SYNOPSIS
 
-**btop** [**-lc**] [**-t** | **+t**] [**-p** _id_] [**\-\-utf-force**]
+**btop** [**-lc**] [**-t** | **+t**] [**-p** _id_] [**\-\-force-utf**]
          [**\-\-debug**] [{**-h** | **\-\-help**} | {**-v** | **\-\-version**}]
 
 # DESCRIPTION
@@ -32,7 +32,7 @@ starting with two dashes ('-'). A summary of options is included below.
 **-p**, **\-\-preset _id_**
 :   Start with preset, integer value between 0-9.
 
-**\-\-utf-force**
+**\-\-force-utf**
 :   Force start even if no UTF-8 locale was detected.
 
 **\-\-debug**

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -100,7 +100,6 @@ namespace Global {
 	atomic<bool> thread_exception (false);
 
 	bool debug{};
-	bool utf_force{};
 
 	uint64_t start_time;
 
@@ -823,6 +822,8 @@ int main(const int argc, const char** argv) {
 		}
 	}
 
+	Global::debug = cli.debug;
+
 	{
 		const auto config_dir = Config::get_config_dir();
 		if (config_dir.has_value()) {
@@ -930,9 +931,9 @@ int main(const int argc, const char** argv) {
 			}
 		}
 	#else
-		if (found.empty() and Global::utf_force)
+		if (found.empty() and cli.force_utf) {
 			Logger::warning("No UTF-8 locale detected! Forcing start with --utf-force argument.");
-		else if (found.empty()) {
+		} else if (found.empty()) {
 			Global::exit_error_msg = "No UTF-8 locale detected!\nUse --utf-force argument to force start if you're sure your terminal can handle it.";
 			clean_quit(1);
 		}

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -932,9 +932,9 @@ int main(const int argc, const char** argv) {
 		}
 	#else
 		if (found.empty() and cli.force_utf) {
-			Logger::warning("No UTF-8 locale detected! Forcing start with --utf-force argument.");
+			Logger::warning("No UTF-8 locale detected! Forcing start with --force-utf argument.");
 		} else if (found.empty()) {
-			Global::exit_error_msg = "No UTF-8 locale detected!\nUse --utf-force argument to force start if you're sure your terminal can handle it.";
+			Global::exit_error_msg = "No UTF-8 locale detected!\nUse --force-utf argument to force start if you're sure your terminal can handle it.";
 			clean_quit(1);
 		}
 	#endif

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -99,7 +99,6 @@ namespace Global {
 	string exit_error_msg;
 	atomic<bool> thread_exception (false);
 
-	bool debuginit{};
 	bool debug{};
 	bool utf_force{};
 

--- a/src/btop_cli.cpp
+++ b/src/btop_cli.cpp
@@ -83,7 +83,7 @@ namespace Cli {
 				cli.force_tty = std::make_optional(true);
 				continue;
 			}
-			if (arg == "-T" || arg == "--no-tty") {
+			if (arg == "--no-tty") {
 				if (cli.force_tty.has_value()) {
 					error("tty mode can't be set twice");
 					return OrRetCode { 1 };


### PR DESCRIPTION
The content of `btop --help` gives a wrong name to the `--force-utf` option, by still mentioning the previous version of this CLI argument, `--utf-force`. 

This PR fixes the different occurrences of this problem.

Closes: https://github.com/aristocratos/btop/issues/1119