### PR TITLE
Set CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ ifneq ($(QUIET),true)
 	override QUIET := false
 endif
 
+OLDC := $(CFLAGS)
 OLDCXX := $(CXXFLAGS)
 OLDLD := $(LDFLAGS)
 
@@ -174,6 +175,7 @@ override REQFLAGS   := -std=c++23
 WARNFLAGS			:= -Wall -Wextra -pedantic
 OPTFLAGS			:= -O2 $(LTO)
 LDCXXFLAGS			:= -pthread -DFMT_HEADER_ONLY -D_GLIBCXX_ASSERTIONS -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -D_FILE_OFFSET_BITS=64 $(GOODFLAGS) $(ADDFLAGS)
+override CFLAGS		+= $(OPTFLAGS) $(WARNFLAGS)
 override CXXFLAGS	+= $(REQFLAGS) $(LDCXXFLAGS) $(OPTFLAGS) $(WARNFLAGS)
 override LDFLAGS	+= $(LDCXXFLAGS) $(OPTFLAGS) $(WARNFLAGS)
 INC					:= $(foreach incdir,$(INCDIRS),-isystem $(incdir)) -I$(SRCDIR) -I$(BUILDDIR)
@@ -240,6 +242,7 @@ info:
 	@printf "\033[1;91mWARNFLAGS    \033[1;94m:| \033[0m$(WARNFLAGS)\n"
 	@printf "\033[1;94mOPTFLAGS     \033[1;94m:| \033[0m$(OPTFLAGS)\n"
 	@printf "\033[1;93mLDCXXFLAGS   \033[1;94m:| \033[0m$(LDCXXFLAGS)\n"
+	@printf "\033[1;95mCFLAGS       \033[1;92m+| \033[0;37m\$$(\033[94mOPTFLAGS\033[37m) \$$(\033[91mWARNFLAGS\033[37m) $(OLDC)\n"
 	@printf "\033[1;95mCXXFLAGS     \033[1;92m+| \033[0;37m\$$(\033[92mREQFLAGS\033[37m) \$$(\033[93mLDCXXFLAGS\033[37m) \$$(\033[94mOPTFLAGS\033[37m) \$$(\033[91mWARNFLAGS\033[37m) $(OLDCXX)\n"
 	@printf "\033[1;95mLDFLAGS      \033[1;92m+| \033[0;37m\$$(\033[93mLDCXXFLAGS\033[37m) \$$(\033[94mOPTFLAGS\033[37m) \$$(\033[91mWARNFLAGS\033[37m) $(OLDLD)\n"
 else
@@ -410,8 +413,8 @@ $(BUILDDIR)/%.c.o: $(SRCDIR)/$(PLATFORM_DIR)/intel_gpu_top/%.c | directories
 	@sleep 0.3 2>/dev/null || true
 	@TSTAMP=$$(date +%s 2>/dev/null || echo "0")
 	@$(QUIET) || printf "\033[1;97mCompiling $<\033[0m\n"
-	@$(VERBOSE) || printf "$(CC) $(INC) -c -o $@ $<\n"
-	@$(CC) $(INC) -w -c -o $@ $< || exit 1
+	@$(VERBOSE) || printf "$(CC) $(CFLAGS) $(INC) -c -o $@ $<\n"
+	@$(CC) $(CFLAGS) $(INC) -w -c -o $@ $< || exit 1
 	@printf "\033[1;92m$$($(PROGRESS))$(P)\033[10D\033[5C-> \033[1;37m$@ \033[100D\033[38C\033[1;93m(\033[1;97m$$(du -ah $@ | cut -f1)iB\033[1;93m) \033[92m(\033[97m$$($(DATE_CMD) -d @$$(expr $$($(DATE_CMD) +%s 2>/dev/null || echo "0") - $${TSTAMP} 2>/dev/null) -u +%Mm:%Ss 2>/dev/null | sed 's/^00m://' || echo '')\033[92m)\033[0m\n"
 
 


### PR DESCRIPTION
Set compiler flags for Intel GPU code, such as warnings and optimization flags.