### PR TITLE
Fix MacOS tree-mode + aggregate memory/thread scaling issue

### DIFF
--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1236,6 +1236,11 @@ namespace Proc {
 						cpu_t = pti.pti_total_user + pti.pti_total_system;
 
 						if (new_proc.cpu_t == 0) new_proc.cpu_t = cpu_t;
+					} else {
+						// Reset memory value if process info cannot be accessed (bad permissions or zombie processes)
+						new_proc.threads = 0;
+						new_proc.mem = 0;
+						cpu_t = new_proc.cpu_t;
 					}
 
 					//? Process cpu usage since last update

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1229,7 +1229,7 @@ namespace Proc {
 					new_proc.state = kproc.kp_proc.p_stat;
 
 					//? Get threads, mem and cpu usage
-					struct proc_taskinfo pti;
+					struct proc_taskinfo pti{};
 					if (sizeof(pti) == proc_pidinfo(new_proc.pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti))) {
 						new_proc.threads = pti.pti_threadnum;
 						new_proc.mem = pti.pti_resident_size;


### PR DESCRIPTION
Fixes issue where using "Proc tree" and "Proc aggregate" on MacOS without running btop as root lets the memory and thread counts scale infinitely.

# Before:
<img width="717" alt="image" src="https://github.com/user-attachments/assets/df861223-530e-461a-8f6e-f0755c156627" />

# After:
non-root:
<img width="629" alt="image" src="https://github.com/user-attachments/assets/4b4bb7ed-4374-4af0-bcea-a0deea769803" />
root:
<img width="633" alt="image" src="https://github.com/user-attachments/assets/c5deb19d-b44b-43ed-96ae-9c7f46c4fa91" />

