### PR TITLE
Added a setting which disables the help and menu

### DIFF
--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -50,6 +50,7 @@ namespace Config {
 	bool write_new;
 
 	const vector<array<string, 2>> descriptions = {
+		{"disable_help", "#* Disable menu and help. For the true minimalist!"},
 		{"color_theme", 		"#* Name of a btop++/bpytop/bashtop formatted \".theme\" file, \"Default\" and \"TTY\" for builtin themes.\n"
 								"#* Themes should be placed in \"../share/btop/themes\" relative to binary or \"$HOME/.config/btop/themes\""},
 
@@ -263,6 +264,7 @@ namespace Config {
 	std::unordered_map<std::string_view, string> stringsTmp;
 
 	std::unordered_map<std::string_view, bool> bools = {
+		{"disable_help", false},
 		{"theme_background", true},
 		{"truecolor", true},
 		{"rounded_corners", true},

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -213,15 +213,16 @@ namespace Input {
 			auto kill_key = (vim_keys ? "K" : "k");
 			//? Global input actions
 			if (not filtering) {
+                          auto disable_help = Config::getB("disable_help");
 				bool keep_going = false;
 				if (key == "q") {
 					clean_quit(0);
 				}
-				else if (is_in(key, "escape", "m")) {
+				else if (is_in(key, "escape", "m") && ! disable_help) {
 					Menu::show(Menu::Menus::Main);
 					return;
 				}
-				else if (is_in(key, "F1", "?", help_key)) {
+				else if (is_in(key, "F1", "?", help_key)  && ! disable_help) {
 					Menu::show(Menu::Menus::Help);
 					return;
 				}

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -213,7 +213,7 @@ namespace Input {
 			auto kill_key = (vim_keys ? "K" : "k");
 			//? Global input actions
 			if (not filtering) {
-                          auto disable_help = Config::getB("disable_help");
+				auto disable_help = Config::getB("disable_help");
 				bool keep_going = false;
 				if (key == "q") {
 					clean_quit(0);


### PR DESCRIPTION
This patch introduces a setting that allows users to disable the in-app help and menu, promoting direct editing of the configuration file instead. The motivation behind this feature is to streamline the interface for advanced users who prefer minimalism and already have familiarity with btop's options. By removing the menu and help overlay, it reduces visual clutter. This is particularly useful in environments where clean, distraction-free monitoring is preferred, such as tiling window managers.