### PR TITLE
Ignore incomplete filter regex

### DIFF
--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -432,7 +432,7 @@ namespace Proc {
 	void tree_sort(vector<tree_proc>& proc_vec, const string& sorting,
 				   bool reverse, int& c_index, const int index_max, bool collapsed = false);
 
-	bool matches_filter(const proc_info& proc, const std::string& filter);
+	auto matches_filter(const proc_info& proc, const std::string& filter) -> bool;
 
 	//* Generate process tree list
 	void _tree_gen(proc_info& cur_proc, vector<proc_info>& in_procs, vector<tree_proc>& out_procs,


### PR DESCRIPTION
When a user enters a special regex character that expects a closing character, btop will crash before the user has a chance to enter the closing character. This will now just be ignored and no process will match the filter until the regex is valid again.

Closes: https://github.com/aristocratos/btop/issues/1133