### PR TITLE
Fix incorrect positioning and start symbol of second title introduced in 2538d89

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -293,7 +293,7 @@ namespace Draw {
 		}
 		if (not title2.empty()) {
 			out += fmt::format(
-				"{}{}{}{}{}{}{}{}{}", Mv::to(y, x + 2), Symbols::title_left, Fx::b, numbering, Theme::c("title"), title2, Fx::ub,
+				"{}{}{}{}{}{}{}{}{}", Mv::to(y + height - 1, x + 2), Symbols::title_left_down, Fx::b, numbering, Theme::c("title"), title2, Fx::ub,
 				line_color, Symbols::title_right_down
 			);
 		}


### PR DESCRIPTION
This PR reverts the position and starting symbol of the second title, restoring them to their previous values (pre-commit 2538d89ed97bd98b8c092ca73ec75be7db888467),  fixing the overlapping of "upload" and "download" title in the net box.

Closes #1155 