### PR TITLE
Add command line option to set an inital filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1497,16 +1497,17 @@ log_level = "DEBUG"
 Usage: btop [OPTIONS]
 
 Options:
-  -c, --config <file>  Path to a config file
-  -d, --debug          Start in debug mode with additional logs and metrics
-      --force-utf      Override automatic UTF locale detection
-  -l, --low-color      Disable true color, 256 colors only
-  -p, --preset <id>    Start with a preset (0-9)
-  -t, --tty            Force tty mode with ANSI graph symbols and 16 colors only
-      --no-tty         Force disable tty mode
-  -u, --update <ms>    Set an initial update rate in milliseconds
-  -h, --help           Show this help message and exit
-  -V, --version        Show a version message and exit (more with --version)
+  -c, --config <file>     Path to a config file
+  -d, --debug             Start in debug mode with additional logs and metrics
+  -f, --filter <filter>   Set an initial process filter
+      --force-utf         Override automatic UTF locale detection
+  -l, --low-color         Disable true color, 256 colors only
+  -p, --preset <id>       Start with a preset (0-9)
+  -t, --tty               Force tty mode with ANSI graph symbols and 16 colors only
+      --no-tty            Force disable tty mode
+  -u, --update <ms>       Set an initial update rate in milliseconds
+  -h, --help              Show this help message and exit
+  -V, --version           Show a version message and exit (more with --version)
 ```
 
 ## LICENSE

--- a/manpage.md
+++ b/manpage.md
@@ -27,6 +27,9 @@ starting with two dashes ('-'). A summary of options is included below.
 **-d**, **\-\-debug**
 :   Start in debug mode with additional logs and metrics.
 
+**-f**, **\-\-filter _filter_**
+:   Set an initial process filter.
+
 **\-\-force-utf**
 :   Force start even if no UTF-8 locale was detected.
 

--- a/src/btop_cli.cpp
+++ b/src/btop_cli.cpp
@@ -110,6 +110,17 @@ namespace Cli {
 				cli.config_file = std::make_optional(config_file);
 				continue;
 			}
+			if (arg == "-f" || arg == "--filter") {
+				// This flag requires an argument.
+				if (++it == args.end()) {
+					error("Filter requires an argument");
+					return OrRetCode { 1 };
+				}
+
+				auto arg = *it;
+				cli.filter = std::make_optional(arg);
+				continue;
+			}
 			if (arg == "-p" || arg == "--preset") {
 				// This flag requires an argument.
 				if (++it == args.end()) {
@@ -158,16 +169,17 @@ namespace Cli {
 	void help() noexcept {
 		fmt::print(
 				"{0}Options:{1}\n"
-				"  {2}-c, --config {1}<file>  Path to a config file\n"
-				"  {2}-d, --debug{1}          Start in debug mode with additional logs and metrics\n"
-				"  {2}    --force-utf{1}      Override automatic UTF locale detection\n"
-				"  {2}-l, --low-color{1}      Disable true color, 256 colors only\n"
-				"  {2}-p, --preset {1}<id>    Start with a preset (0-9)\n"
-				"  {2}-t, --tty{1}            Force tty mode with ANSI graph symbols and 16 colors only\n"
-				"  {2}    --no-tty{1}         Force disable tty mode\n"
-				"  {2}-u, --update {1}<ms>    Set an initial update rate in milliseconds\n"
-				"  {2}-h, --help{1}           Show this help message and exit\n"
-				"  {2}-V, --version{1}        Show a version message and exit (more with --version)\n",
+				"  {2}-c, --config{1} <file>     Path to a config file\n"
+				"  {2}-d, --debug{1}             Start in debug mode with additional logs and metrics\n"
+				"  {2}-f, --filter{1} <filter>   Set an initial process filter\n"
+				"  {2}    --force-utf{1}         Override automatic UTF locale detection\n"
+				"  {2}-l, --low-color{1}         Disable true color, 256 colors only\n"
+				"  {2}-p, --preset{1} <id>       Start with a preset (0-9)\n"
+				"  {2}-t, --tty{1}               Force tty mode with ANSI graph symbols and 16 colors only\n"
+				"  {2}    --no-tty{1}            Force disable tty mode\n"
+				"  {2}-u, --update{1} <ms>       Set an initial update rate in milliseconds\n"
+				"  {2}-h, --help{1}              Show this help message and exit\n"
+				"  {2}-V, --version{1}           Show a version message and exit (more with --version)\n",
 				BOLD_UNDERLINE, RESET, BOLD
 		);
 	}

--- a/src/btop_cli.hpp
+++ b/src/btop_cli.hpp
@@ -18,6 +18,8 @@ namespace Cli {
 		std::optional<stdfs::path> config_file;
 		// Enable debug mode with additional logs and metrics
 		bool debug {};
+		// Set an initial process filter.
+		std::optional<std::string> filter;
 		// Only use ANSI supported graph symbols and colors
 		std::optional<bool> force_tty;
 		// Use UTF-8 locale even if not detected


### PR DESCRIPTION
This will spawn btop with a filter already set, which can be edited and also deleted as usual.

Beware that the filter will ALWAYS also match btop itself, since the --filter flag on the command line will be matched.

Closes: https://github.com/aristocratos/btop/issues/883