### PR TITLE
Add encode and decode meters on Nvidia GPUs

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1049,9 +1049,9 @@ namespace Gpu {
 		bool drawnEncDec = gpu.supported_functions.encoder_utilization and gpu.supported_functions.decoder_utilization;
 		if (drawnEncDec) {
 			out += Mv::to(b_y + 3, b_x +1) + Theme::c("main_fg") + Fx::b + "ENC " + enc_meter(gpu.encoder_utilization)
-				+ Theme::g("cpu").at(clamp(gpu.encoder_utilization, 0ll, 100ll)) + rjust(to_string(gpu.encoder_utilization), 4) + '%'
-				+ Theme::c("div_line") + Symbols::v_line + Theme::c("main_fg")
-				+ Fx::b + "DEC " + enc_meter(gpu.decoder_utilization) + Theme::g("cpu").at(clamp(gpu.decoder_utilization, 0ll, 100ll)) + rjust(to_string(gpu.decoder_utilization), 4) + '%';
+				+ Theme::g("cpu").at(clamp(gpu.encoder_utilization, 0ll, 100ll)) + rjust(to_string(gpu.encoder_utilization), 4) + Theme::c("main_fg") + '%'
+				+ Theme::c("div_line") + Symbols::v_line + Theme::c("main_fg") + Fx::b + "DEC " + enc_meter(gpu.decoder_utilization)
+				+ Theme::g("cpu").at(clamp(gpu.decoder_utilization, 0ll, 100ll)) + rjust(to_string(gpu.decoder_utilization), 4) + Theme::c("main_fg") + '%';
 		}
 
 		if (gpu.supported_functions.mem_total or gpu.supported_functions.mem_used) {

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1046,7 +1046,8 @@ namespace Gpu {
 		}
 
 		//? Encode and Decode meters
-		if (gpu.supported_functions.encoder_utilization and gpu.supported_functions.decoder_utilization) {
+		bool drawnEncDec = gpu.supported_functions.encoder_utilization and gpu.supported_functions.decoder_utilization;
+		if (drawnEncDec) {
 			out += Mv::to(b_y + 3, b_x +1) + Theme::c("main_fg") + Fx::b + "ENC " + enc_meter(gpu.encoder_utilization)
 				+ Theme::g("cpu").at(clamp(gpu.encoder_utilization, 0ll, 100ll)) + rjust(to_string(gpu.encoder_utilization), 4) + '%'
 				+ Theme::c("div_line") + Symbols::v_line + Theme::c("main_fg")
@@ -1054,7 +1055,7 @@ namespace Gpu {
 		}
 
 		if (gpu.supported_functions.mem_total or gpu.supported_functions.mem_used) {
-			out += Mv::to(b_y + 4, b_x);
+			out += Mv::to(b_y + (drawnEncDec ? 4 : 3), b_x);
 			if (gpu.supported_functions.mem_total and gpu.supported_functions.mem_used) {
 				string used_memory_string = floating_humanizer(gpu.mem_used);
 
@@ -1079,7 +1080,7 @@ namespace Gpu {
 				//? Memory clock speed
 				if (gpu.supported_functions.mem_clock) {
 					string clock_speed_string = to_string(gpu.mem_clock_speed);
-					out += Mv::to(b_y + 4, b_x + b_width/2 - 11) + Theme::c("div_line") + Symbols::h_line*(5-clock_speed_string.size())
+					out += Mv::to(b_y + (drawnEncDec ? 4 : 3), b_x + b_width/2 - 11) + Theme::c("div_line") + Symbols::h_line*(5-clock_speed_string.size())
 						+ Symbols::title_left + Fx::b + Theme::c("title") + clock_speed_string + " MHz" + Fx::ub + Theme::c("div_line") + Symbols::title_right;
 				}
 			} else {

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -947,6 +947,7 @@ namespace Gpu {
 	vector<Draw::Graph> mem_used_graph_vec = {}, mem_util_graph_vec = {};
 	vector<Draw::Meter> gpu_meter_vec = {};
 	vector<Draw::Meter> pwr_meter_vec = {};
+	vector<Draw::Meter> enc_meter_vec = {};
 	vector<string> box = {};
 
     string draw(const gpu_info& gpu, unsigned long index, bool force_redraw, bool data_same) {
@@ -964,6 +965,7 @@ namespace Gpu {
 		auto& mem_util_graph = mem_util_graph_vec[index];
 		auto& gpu_meter = gpu_meter_vec[index];
 		auto& pwr_meter = pwr_meter_vec[index];
+		auto& enc_meter = enc_meter_vec[index];
 
 		if (force_redraw) redraw[index] = true;
         bool show_temps = gpu.supported_functions.temp_info and (Config::getB("check_temp"));
@@ -1002,6 +1004,8 @@ namespace Gpu {
 				mem_util_graph = Draw::Graph{b_width/2 - 1, 2, "free", gpu.mem_utilization_percent, graph_symbol, 0, 0, 100, 4}; // offset so the graph isn't empty at 0-5% utilization
 			if (gpu.supported_functions.mem_used and gpu.supported_functions.mem_total)
 				mem_used_graph = Draw::Graph{b_width/2 - 2, 2 + 2*(gpu.supported_functions.mem_utilization), "used", safeVal(gpu.gpu_percent, "gpu-vram-totals"s), graph_symbol};
+			if (gpu.supported_functions.encoder_utilization)
+				enc_meter = Draw::Meter{b_width/2 - 10, "cpu"};
 		}
 
 
@@ -1041,8 +1045,16 @@ namespace Gpu {
 				out += std::string(" P-state: ") + (gpu.pwr_state > 9 ? "" : " ") + 'P' + Theme::g("cached").at(clamp(gpu.pwr_state, 0ll, 100ll)) + to_string(gpu.pwr_state);
 		}
 
+		//? Encode and Decode meters
+		if (gpu.supported_functions.encoder_utilization and gpu.supported_functions.decoder_utilization) {
+			out += Mv::to(b_y + 3, b_x +1) + Theme::c("main_fg") + Fx::b + "ENC " + enc_meter(gpu.encoder_utilization)
+				+ Theme::g("cpu").at(clamp(gpu.encoder_utilization, 0ll, 100ll)) + rjust(to_string(gpu.encoder_utilization), 4) + '%'
+				+ Theme::c("div_line") + Symbols::v_line + Theme::c("main_fg")
+				+ Fx::b + "DEC " + enc_meter(gpu.decoder_utilization) + Theme::g("cpu").at(clamp(gpu.decoder_utilization, 0ll, 100ll)) + rjust(to_string(gpu.decoder_utilization), 4) + '%';
+		}
+
 		if (gpu.supported_functions.mem_total or gpu.supported_functions.mem_used) {
-			out += Mv::to(b_y + 3, b_x);
+			out += Mv::to(b_y + 4, b_x);
 			if (gpu.supported_functions.mem_total and gpu.supported_functions.mem_used) {
 				string used_memory_string = floating_humanizer(gpu.mem_used);
 
@@ -1067,7 +1079,7 @@ namespace Gpu {
 				//? Memory clock speed
 				if (gpu.supported_functions.mem_clock) {
 					string clock_speed_string = to_string(gpu.mem_clock_speed);
-					out += Mv::to(b_y + 3, b_x + b_width/2 - 11) + Theme::c("div_line") + Symbols::h_line*(5-clock_speed_string.size())
+					out += Mv::to(b_y + 4, b_x + b_width/2 - 11) + Theme::c("div_line") + Symbols::h_line*(5-clock_speed_string.size())
 						+ Symbols::title_left + Fx::b + Theme::c("title") + clock_speed_string + " MHz" + Fx::ub + Theme::c("div_line") + Symbols::title_right;
 				}
 			} else {
@@ -2100,6 +2112,7 @@ namespace Draw {
 			mem_used_graph_vec.resize(shown); mem_util_graph_vec.resize(shown);
 			gpu_meter_vec.resize(shown);
 			pwr_meter_vec.resize(shown);
+			enc_meter_vec.resize(shown);
 			redraw.resize(shown);
 			for (auto i = 0; i < shown; ++i) {
 				redraw[i] = true;
@@ -2120,7 +2133,7 @@ namespace Draw {
 				box[i] = createBox(x_vec[i], y_vec[i], width, height, Theme::c("cpu_box"), true, std::string("gpu") + (char)(shown_panels[i]+'0'), "", (shown_panels[i]+5)%10); // TODO gpu_box
 
 				b_height_vec[i] = 2 + gpu_b_height_offsets[shown_panels[i]];
-				b_width = clamp(width/2, min_width, 64);
+				b_width = clamp(width/2, min_width, 65);
 
 				//? Main statistics box
 				b_x_vec[i] = x_vec[i] + width - b_width - 1;

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -139,7 +139,9 @@ namespace Gpu {
 				 temp_info = true,
 				 mem_total = true,
 				 mem_used = true,
-				 pcie_txrx = true;
+				 pcie_txrx = true,
+				 encoder_utilization = true,
+				 decoder_utilization = true;
 	};
 
 	//* Per-device container for GPU info
@@ -165,6 +167,9 @@ namespace Gpu {
 
 		long long pcie_tx = 0; // KB/s
 		long long pcie_rx = 0;
+
+		long long encoder_utilization = 0;
+		long long decoder_utilization = 0;
 
 		gpu_info_supported supported_functions;
 

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -1466,6 +1466,10 @@ namespace Gpu {
         			if (result != RSMI_STATUS_SUCCESS)
     					Logger::warning("ROCm SMI: Failed to get maximum GPU temperature, defaulting to 110°C");
     				else gpus_slice[i].temp_max = (long long)temp_max;
+
+					//? Disable encoder and decoder utilisation on AMD
+					gpus_slice[i].supported_functions.encoder_utilization = false;
+					gpus_slice[i].supported_functions.decoder_utilization = false;
     			}
 
 				//? GPU utilization
@@ -1697,7 +1701,9 @@ namespace Gpu {
 					.temp_info = false,
 					.mem_total = false,
 					.mem_used = false,
-					.pcie_txrx = false
+					.pcie_txrx = false,
+					.encoder_utilization = false,
+					.decoder_utilization = false
 				};
 
 				gpus_slice->pwr_max_usage = 10'000; //? 10W

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -308,6 +308,7 @@ namespace Shared {
 			for (size_t i = 0; i < gpu_b_height_offsets.size(); ++i)
 				gpu_b_height_offsets[i] = gpus[i].supported_functions.gpu_utilization
 					   + gpus[i].supported_functions.pwr_usage
+					   + (gpus[i].supported_functions.encoder_utilization or gpus[i].supported_functions.decoder_utilization)
 					   + (gpus[i].supported_functions.mem_total or gpus[i].supported_functions.mem_used)
 						* (1 + 2*(gpus[i].supported_functions.mem_total and gpus[i].supported_functions.mem_used) + 2*gpus[i].supported_functions.mem_utilization);
 		}
@@ -1117,7 +1118,7 @@ namespace Gpu {
     				result = nvmlDeviceGetHandleByIndex(i, devices.data() + i);
         			if (result != NVML_SUCCESS) {
     					Logger::warning(std::string("NVML: Failed to get device handle: ") + nvmlErrorString(result));
-    					gpus[i].supported_functions = {false, false, false, false, false, false, false, false};
+						gpus[i].supported_functions = {false, false, false, false, false, false, false, false, false, false};
     					continue;
         			}
 


### PR DESCRIPTION
Initially requested in #977 

![image](https://github.com/user-attachments/assets/56308619-09dd-489c-8133-c62d0496e6c1)

Unfortunately it doesn't appear to be possible using ROCm SMI to retrieve separate metrics for encode and decode; using `rsmi_dev_activity_metric_get` with `activity_metric_type = RSMI_ACTIVITY_MM` *should* give some indication of the VCN's utilisation, but on my system (RX 6600) the value returned is always 0. (See test program below).

AMD SMI (the successor to ROCm SMI) returns VCN activity as part of its device metrics, however notes in the source indicate that measuring encode utilisation is not yet supported on Navi GPUs, and testing this with the amd-smi python script seems to confirm that. Additionally, decode utilisation seemingly always reports zero.

```
$ /opt/rocm/bin/amd-smi monitor -nd
GPU   ENC%   DEC%    VCLOCK    DCLOCK
  0    N/A    0 %     0 MHz     0 MHz
```

I tested whether nvtop could measure encode and decode utilisation on my AMD GPU, and it can do both. Seemingly, they sum the per-process encoder/decoder utilisation reported through sysfs for all GPU processes. There doesn't seem to be an equivalent way to achieve this using ROCm SMI, as you can only get PIDs for KFD(?) processes. I'm not sure what the criteria for a KFD process is, but ffmpeg does not appear to meet them.

I do not have access to an Intel GPU and so did not investigate implementing this for Intel GPUs.

```cpp
#include <chrono>
#include <iostream>
#include <thread>
#include "rocm_smi/rocm_smi.h"

int main() {
    rsmi_status_t ret;
    uint32_t num_devices;
    uint16_t dev_id;

    ret = rsmi_init(0);
    if (ret != RSMI_STATUS_SUCCESS) {
        std::cout << "ERROR rsmi init failed" << std::endl;
        return 1;
    }
    ret = rsmi_num_monitor_devices(&num_devices);
    if (ret != RSMI_STATUS_SUCCESS) {
        std::cout << "ERROR get num devices failed" << std::endl;
    }

    for (int i = 0; i < num_devices; ++i) {
        ret = rsmi_dev_id_get(i, &dev_id);
        if (ret != RSMI_STATUS_SUCCESS) {
            std::cout << "ERROR failed to get device id for device " << i << std::endl;
            continue;
        }

        char name[128];
        ret = rsmi_dev_name_get(i, name, 128);
        if (ret != RSMI_STATUS_SUCCESS) {
            std::cout << "ERROR failed to get device name for device " << i << std::endl;
            continue;
        }

        while (true) {
            rsmi_activity_metric_counter_t metric_couter;
            ret = rsmi_dev_activity_metric_get(i, RSMI_ACTIVITY_MM, &metric_couter);
            if (ret != RSMI_STATUS_SUCCESS) {
                std::cout << "ERROR failed to get device metrics MM" << std::endl;
                break;
            }
            std::cout << name << ": " << metric_couter.average_mm_activity << std::endl;
            std::this_thread::sleep_for(std::chrono::milliseconds(100));
        }
    }

    ret = rsmi_shut_down();

    return 0;
}
```