### PR TITLE
Fixed typo in toggling boxes error message

### DIFF
--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -1004,7 +1004,7 @@ namespace Menu {
 		if (redraw) {
 			vector<string> cont_vec {
 				Fx::b + Theme::g("used")[100] + "Error:" + Theme::c("main_fg") + Fx::ub,
-				"Terminal size to small to" + Fx::reset,
+				"Terminal size too small to" + Fx::reset,
 				"display menu or box!" + Fx::reset };
 
 			messageBox = Menu::msgBox{45, 0, cont_vec, "error"};


### PR DESCRIPTION
A recent update added more user-facing messages, this fixes a typo in a common one