### PR TITLE
Themes: Add Catppuccin

### DIFF
--- a/themes/catppuccin_frappe.theme
+++ b/themes/catppuccin_frappe.theme
@@ -1,0 +1,83 @@
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#303446"
+
+# Main text color
+theme[main_fg]="#c6d0f5"
+
+# Title color for boxes
+theme[title]="#c6d0f5"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#8caaee"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#51576d"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#8caaee"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#838ba7"
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="#f2d5cf"
+
+# Background color of the percentage meters
+theme[meter_bg]="#51576d"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#f2d5cf"
+
+# CPU, Memory, Network, Proc box outline colors
+theme[cpu_box]="#ca9ee6" #Mauve
+theme[mem_box]="#a6d189" #Green
+theme[net_box]="#ea999c" #Maroon
+theme[proc_box]="#8caaee" #Blue
+
+# Box divider line and small boxes line color
+theme[div_line]="#737994"
+
+# Temperature graph color (Green -> Yellow -> Red)
+theme[temp_start]="#a6d189"
+theme[temp_mid]="#e5c890"
+theme[temp_end]="#e78284"
+
+# CPU graph colors (Teal -> Lavender)
+theme[cpu_start]="#81c8be"
+theme[cpu_mid]="#85c1dc"
+theme[cpu_end]="#babbf1"
+
+# Mem/Disk free meter (Mauve -> Lavender -> Blue)
+theme[free_start]="#ca9ee6"
+theme[free_mid]="#babbf1"
+theme[free_end]="#8caaee"
+
+# Mem/Disk cached meter (Sapphire -> Lavender)
+theme[cached_start]="#85c1dc"
+theme[cached_mid]="#8caaee"
+theme[cached_end]="#babbf1"
+
+# Mem/Disk available meter (Peach -> Red)
+theme[available_start]="#ef9f76"
+theme[available_mid]="#ea999c"
+theme[available_end]="#e78284"
+
+# Mem/Disk used meter (Green -> Sky)
+theme[used_start]="#a6d189"
+theme[used_mid]="#81c8be"
+theme[used_end]="#99d1db"
+
+# Download graph colors (Peach -> Red)
+theme[download_start]="#ef9f76"
+theme[download_mid]="#ea999c"
+theme[download_end]="#e78284"
+
+# Upload graph colors (Green -> Sky)
+theme[upload_start]="#a6d189"
+theme[upload_mid]="#81c8be"
+theme[upload_end]="#99d1db"
+
+# Process box color gradient for threads, mem and cpu usage (Sapphire -> Mauve)
+theme[process_start]="#85c1dc"
+theme[process_mid]="#babbf1"
+theme[process_end]="#ca9ee6"

--- a/themes/catppuccin_latte.theme
+++ b/themes/catppuccin_latte.theme
@@ -1,0 +1,83 @@
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#eff1f5"
+
+# Main text color
+theme[main_fg]="#4c4f69"
+
+# Title color for boxes
+theme[title]="#4c4f69"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#1e66f5"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#bcc0cc"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#1e66f5"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#8c8fa1"
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="#dc8a78"
+
+# Background color of the percentage meters
+theme[meter_bg]="#bcc0cc"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#dc8a78"
+
+# CPU, Memory, Network, Proc box outline colors
+theme[cpu_box]="#8839ef" #Mauve
+theme[mem_box]="#40a02b" #Green
+theme[net_box]="#e64553" #Maroon
+theme[proc_box]="#1e66f5" #Blue
+
+# Box divider line and small boxes line color
+theme[div_line]="#9ca0b0"
+
+# Temperature graph color (Green -> Yellow -> Red)
+theme[temp_start]="#40a02b"
+theme[temp_mid]="#df8e1d"
+theme[temp_end]="#d20f39"
+
+# CPU graph colors (Teal -> Lavender)
+theme[cpu_start]="#179299"
+theme[cpu_mid]="#209fb5"
+theme[cpu_end]="#7287fd"
+
+# Mem/Disk free meter (Mauve -> Lavender -> Blue)
+theme[free_start]="#8839ef"
+theme[free_mid]="#7287fd"
+theme[free_end]="#1e66f5"
+
+# Mem/Disk cached meter (Sapphire -> Lavender)
+theme[cached_start]="#209fb5"
+theme[cached_mid]="#1e66f5"
+theme[cached_end]="#7287fd"
+
+# Mem/Disk available meter (Peach -> Red)
+theme[available_start]="#fe640b"
+theme[available_mid]="#e64553"
+theme[available_end]="#d20f39"
+
+# Mem/Disk used meter (Green -> Sky)
+theme[used_start]="#40a02b"
+theme[used_mid]="#179299"
+theme[used_end]="#04a5e5"
+
+# Download graph colors (Peach -> Red)
+theme[download_start]="#fe640b"
+theme[download_mid]="#e64553"
+theme[download_end]="#d20f39"
+
+# Upload graph colors (Green -> Sky)
+theme[upload_start]="#40a02b"
+theme[upload_mid]="#179299"
+theme[upload_end]="#04a5e5"
+
+# Process box color gradient for threads, mem and cpu usage (Sapphire -> Mauve)
+theme[process_start]="#209fb5"
+theme[process_mid]="#7287fd"
+theme[process_end]="#8839ef"

--- a/themes/catppuccin_macchiato.theme
+++ b/themes/catppuccin_macchiato.theme
@@ -1,0 +1,83 @@
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#24273a"
+
+# Main text color
+theme[main_fg]="#cad3f5"
+
+# Title color for boxes
+theme[title]="#cad3f5"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#8aadf4"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#494d64"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#8aadf4"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#8087a2"
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="#f4dbd6"
+
+# Background color of the percentage meters
+theme[meter_bg]="#494d64"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#f4dbd6"
+
+# CPU, Memory, Network, Proc box outline colors
+theme[cpu_box]="#c6a0f6" #Mauve
+theme[mem_box]="#a6da95" #Green
+theme[net_box]="#ee99a0" #Maroon
+theme[proc_box]="#8aadf4" #Blue
+
+# Box divider line and small boxes line color
+theme[div_line]="#6e738d"
+
+# Temperature graph color (Green -> Yellow -> Red)
+theme[temp_start]="#a6da95"
+theme[temp_mid]="#eed49f"
+theme[temp_end]="#ed8796"
+
+# CPU graph colors (Teal -> Lavender)
+theme[cpu_start]="#8bd5ca"
+theme[cpu_mid]="#7dc4e4"
+theme[cpu_end]="#b7bdf8"
+
+# Mem/Disk free meter (Mauve -> Lavender -> Blue)
+theme[free_start]="#c6a0f6"
+theme[free_mid]="#b7bdf8"
+theme[free_end]="#8aadf4"
+
+# Mem/Disk cached meter (Sapphire -> Lavender)
+theme[cached_start]="#7dc4e4"
+theme[cached_mid]="#8aadf4"
+theme[cached_end]="#b7bdf8"
+
+# Mem/Disk available meter (Peach -> Red)
+theme[available_start]="#f5a97f"
+theme[available_mid]="#ee99a0"
+theme[available_end]="#ed8796"
+
+# Mem/Disk used meter (Green -> Sky)
+theme[used_start]="#a6da95"
+theme[used_mid]="#8bd5ca"
+theme[used_end]="#91d7e3"
+
+# Download graph colors (Peach -> Red)
+theme[download_start]="#f5a97f"
+theme[download_mid]="#ee99a0"
+theme[download_end]="#ed8796"
+
+# Upload graph colors (Green -> Sky)
+theme[upload_start]="#a6da95"
+theme[upload_mid]="#8bd5ca"
+theme[upload_end]="#91d7e3"
+
+# Process box color gradient for threads, mem and cpu usage (Sapphire -> Mauve)
+theme[process_start]="#7dc4e4"
+theme[process_mid]="#b7bdf8"
+theme[process_end]="#c6a0f6"

--- a/themes/catppuccin_mocha.theme
+++ b/themes/catppuccin_mocha.theme
@@ -1,0 +1,83 @@
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#1e1e2e"
+
+# Main text color
+theme[main_fg]="#cdd6f4"
+
+# Title color for boxes
+theme[title]="#cdd6f4"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#89b4fa"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#45475a"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#89b4fa"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#7f849c"
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="#f5e0dc"
+
+# Background color of the percentage meters
+theme[meter_bg]="#45475a"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#f5e0dc"
+
+# CPU, Memory, Network, Proc box outline colors
+theme[cpu_box]="#cba6f7" #Mauve
+theme[mem_box]="#a6e3a1" #Green
+theme[net_box]="#eba0ac" #Maroon
+theme[proc_box]="#89b4fa" #Blue
+
+# Box divider line and small boxes line color
+theme[div_line]="#6c7086"
+
+# Temperature graph color (Green -> Yellow -> Red)
+theme[temp_start]="#a6e3a1"
+theme[temp_mid]="#f9e2af"
+theme[temp_end]="#f38ba8"
+
+# CPU graph colors (Teal -> Lavender)
+theme[cpu_start]="#94e2d5"
+theme[cpu_mid]="#74c7ec"
+theme[cpu_end]="#b4befe"
+
+# Mem/Disk free meter (Mauve -> Lavender -> Blue)
+theme[free_start]="#cba6f7"
+theme[free_mid]="#b4befe"
+theme[free_end]="#89b4fa"
+
+# Mem/Disk cached meter (Sapphire -> Lavender)
+theme[cached_start]="#74c7ec"
+theme[cached_mid]="#89b4fa"
+theme[cached_end]="#b4befe"
+
+# Mem/Disk available meter (Peach -> Red)
+theme[available_start]="#fab387"
+theme[available_mid]="#eba0ac"
+theme[available_end]="#f38ba8"
+
+# Mem/Disk used meter (Green -> Sky)
+theme[used_start]="#a6e3a1"
+theme[used_mid]="#94e2d5"
+theme[used_end]="#89dceb"
+
+# Download graph colors (Peach -> Red)
+theme[download_start]="#fab387"
+theme[download_mid]="#eba0ac"
+theme[download_end]="#f38ba8"
+
+# Upload graph colors (Green -> Sky)
+theme[upload_start]="#a6e3a1"
+theme[upload_mid]="#94e2d5"
+theme[upload_end]="#89dceb"
+
+# Process box color gradient for threads, mem and cpu usage (Sapphire -> Mauve)
+theme[process_start]="#74c7ec"
+theme[process_mid]="#b4befe"
+theme[process_end]="#cba6f7"


### PR DESCRIPTION
I've added the catppuccin themes from [here](https://github.com/catppuccin/btop).
I'm not the author, but I think this is okay to do with the MIT license.
I've added the copyright owner and link to the origin files in the commit messages.