### PR TITLE
Fix auto-detection of CPU temp on Ampere boards

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -445,7 +445,7 @@ namespace Cpu {
 
 						found_sensors[sensor_name] = Sensor { fs::path(basepath + "input"), temp, crit };
 
-						if (not got_cpu and (label.starts_with("Package id") or label.starts_with("Tdie"))) {
+						if (not got_cpu and (label.starts_with("Package id") or label.starts_with("Tdie") or label.starts_with("SoC Temperature"))) {
 							got_cpu = true;
 							cpu_sensor = sensor_name;
 						}


### PR DESCRIPTION
Ampere boards use the APM X-Gene Hardware Monitoring driver. The label the driver returns is "Soc Temperature" which the current code doesn't detect. Fix that by adding a special case for it. This prevents it from using the "CPU Power" sensor and reporting the CPU tempature as over 8000C (which is the power reported in mW).