### PR TITLE
Reduce noise in Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,30 +1,29 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG]"
 labels: bug
 
 ---
 
 **Read the README.md and search for similar issues before posting a bug report!**
 
-Any bug that can be solved by just reading the [prerequisites](https://github.com/aristocratos/btop#prerequisites) section of the README will likely be ignored.
+<!-- Any bug that can be solved by just reading the [prerequisites](https://github.com/aristocratos/btop#prerequisites) section of the README will likely be ignored. -->
 
 **Describe the bug**
 
-[A clear and concise description of what the bug is.]
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
 
-[Steps to reproduce the behavior:]
+<!-- Steps to reproduce the behavior. ->
 
 **Expected behavior**
 
-[A clear and concise description of what you expected to happen.]
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Screenshots**
 
-[If applicable, add screenshots to help explain your problem.]
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 **Info (please complete the following information):**
  - btop++ version: `btop --version`
@@ -39,22 +38,22 @@ Any bug that can be solved by just reading the [prerequisites](https://github.co
 
 **Additional context**
 
-Contents of `~/.local/state/btop.log`
+<!-- Contents of `~/.local/state/btop.log` -->
 
-Note: The snap uses: `~/snap/btop/current/.local/state/btop.log`
+<!-- Note: The snap uses: `~/snap/btop/current/.local/state/btop.log` -->
 
-(try running btop with `--debug` flag if btop.log is empty)
+<!-- (try running btop with `--debug` flag if btop.log is empty) -->
 
 **GDB Backtrace**
 
-If btop++ is crashing at start the following steps could be helpful:
+<!-- If btop++ is crashing at start the following steps could be helpful: -->
 
-(Extra helpful if compiled with `make OPTFLAGS="-O0 -g"`)
+<!-- (Extra helpful if compiled with `make OPTFLAGS="-O0 -g"`) -->
 
-1. run (linux): `gdb btop` (macos): `lldb btop`
+<!-- 1. run (linux): `gdb btop` (macos): `lldb btop` -->
 
-2. `r` to run, wait for crash and press enter if prompted, CTRL+L to clear screen if needed.
+<!-- 2. `r` to run, wait for crash and press enter if prompted, CTRL+L to clear screen if needed. -->
 
-3. (gdb): `thread apply all bt` (lldb): `bt all` to get backtrace for all threads
+<!-- 3. (gdb): `thread apply all bt` (lldb): `bt all` to get backtrace for all threads -->
 
-4. Copy and paste the backtrace here:
+<!-- 4. Copy and paste the backtrace here: -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,19 +1,22 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[REQUEST]"
-labels: enhancement
+labels: feature
 
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+
+<!-- A clear and concise description of what you want to happen. -->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
Remove superfluous title prefix and make instructions comments so they don't leak into the final request.

There is also a [config.yml](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) but I have not time to look into that right now.