### PR TITLE
docs: Update "cpu responsive" to "cpu direct" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1340,8 +1340,8 @@ shown_boxes = "proc cpu mem net"
 #* Update time in milliseconds, recommended 2000 ms or above for better sample times for graphs.
 update_ms = 1500
 
-#* Processes sorting, "pid" "program" "arguments" "threads" "user" "memory" "cpu lazy" "cpu responsive",
-#* "cpu lazy" sorts top process over time (easier to follow), "cpu responsive" updates top process directly.
+#* Processes sorting, "pid" "program" "arguments" "threads" "user" "memory" "cpu lazy" "cpu direct",
+#* "cpu lazy" sorts top process over time (easier to follow), "cpu direct" updates top process directly.
 proc_sorting = "cpu lazy"
 
 #* Reverse sorting order, True or False.


### PR DESCRIPTION
"cpu responsive" was renamed to "cpu direct" elsewhere,  but the README.md update was missed.

So fix the README too.

This is a follow-on to #274.