### PR TITLE
feat: respect effective cpus from cgroup

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -855,26 +855,31 @@ namespace Cpu {
 	#endif
 		max_row -= n_gpus_to_show;
 
+		auto is_cpu_enabled = [&cpu](const std::int32_t num) -> bool {
+			return !cpu.active_cpus.has_value() || std::ranges::find(cpu.active_cpus.value(), num) != cpu.active_cpus.value().end();
+		};
+
 		//? Core text and graphs
 		int cx = 0, cy = 1, cc = 0, core_width = (b_column_size == 0 ? 2 : 3);
 		if (Shared::coreCount >= 100) core_width++;
 		for (const auto& n : iota(0, Shared::coreCount)) {
-			out += Mv::to(b_y + cy + 1, b_x + cx + 1) + Theme::c("main_fg") + (Shared::coreCount < 100 ? Fx::b + 'C' + Fx::ub : "")
+			auto enabled = is_cpu_enabled(n);
+			out += Mv::to(b_y + cy + 1, b_x + cx + 1) + Theme::c(enabled ? "main_fg" : "inactive_fg") + (Shared::coreCount < 100 ? Fx::b + 'C' + Fx::ub : "")
 				+ ljust(to_string(n), core_width);
 			if ((b_column_size > 0 or extra_width > 0) and cmp_less(n, core_graphs.size()))
 				out += Theme::c("inactive_fg") + graph_bg * (5 * b_column_size + extra_width) + Mv::l(5 * b_column_size + extra_width)
 					+ core_graphs.at(n)(safeVal(cpu.core_percent, n), data_same or redraw);
 
-			out += Theme::g("cpu").at(clamp(safeVal(cpu.core_percent, n).back(), 0ll, 100ll));
-			out += rjust(to_string(safeVal(cpu.core_percent, n).back()), (b_column_size < 2 ? 3 : 4)) + Theme::c("main_fg") + '%';
+			out += enabled ? Theme::g("cpu").at(clamp(safeVal(cpu.core_percent, n).back(), 0ll, 100ll)) : Theme::c("inactive_fg");
+			out += rjust(to_string(safeVal(cpu.core_percent, n).back()), (b_column_size < 2 ? 3 : 4)) + Theme::c(enabled ? "main_fg" : "inactive_fg") + '%';
 
 			if (show_temps and not hide_cores) {
 				const auto [temp, unit] = celsius_to(safeVal(cpu.temp, n+1).back(), temp_scale);
-				const auto temp_color = Theme::g("temp").at(clamp(safeVal(cpu.temp, n+1).back() * 100 / cpu.temp_max, 0ll, 100ll));
+				const auto temp_color = enabled ? Theme::g("temp").at(clamp(safeVal(cpu.temp, n+1).back() * 100 / cpu.temp_max, 0ll, 100ll)) : Theme::c("inactive_fg");
 				if (b_column_size > 1 and std::cmp_greater_equal(temp_graphs.size(), n))
 					out += ' ' + Theme::c("inactive_fg") + graph_bg * 5 + Mv::l(5)
 						+ temp_graphs.at(n+1)(safeVal(cpu.temp, n+1), data_same or redraw);
-				out += temp_color + rjust(to_string(temp), 4) + Theme::c("main_fg") + unit;
+				out += temp_color + rjust(to_string(temp), 4) + Theme::c(enabled ? "main_fg" : "inactive_fg") + unit;
 			}
 
 			out += Theme::c("div_line") + Symbols::v_line;

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -20,8 +20,10 @@ tab-size = 4
 
 #include <array>
 #include <atomic>
+#include <cstdint>
 #include <deque>
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -224,6 +226,7 @@ namespace Cpu {
 		long long temp_max = 0;
 		array<double, 3> load_avg;
 		float usage_watts = 0;
+		std::optional<std::vector<std::int32_t>> active_cpus;
 	};
 
 	//* Collect cpu stats and temperatures

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -16,23 +16,29 @@ indent = tab
 tab-size = 4
 */
 
+#include <algorithm>
+#include <charconv>
+#include <cmath>
 #include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <iterator>
+#include <numeric>
+#include <optional>
+#include <ranges>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
-#include <fstream>
-#include <ranges>
-#include <cmath>
-#include <unistd.h>
-#include <numeric>
-#include <sys/statvfs.h>
-#include <netdb.h>
+#include <utility>
+
+#include <arpa/inet.h> // for inet_ntop()
+#include <dlfcn.h>
 #include <ifaddrs.h>
 #include <net/if.h>
-#include <arpa/inet.h> // for inet_ntop()
-#include <filesystem>
-#include <future>
-#include <dlfcn.h>
-#include <utility>
+#include <netdb.h>
+#include <sys/statvfs.h>
+#include <unistd.h>
 
 #if defined(RSMI_STATIC)
 	#include <rocm_smi/rocm_smi.h>
@@ -990,6 +996,51 @@ namespace Cpu {
 		return watts;
 	}
 
+	static auto to_int(std::string_view view) -> std::uint32_t {
+		std::uint32_t value {};
+		std::from_chars(view.data(), view.data() + view.size(), value);
+		return value;
+	}
+
+	static auto detect_active_cpus() -> std::vector<std::int32_t> {
+	    auto stream = std::ifstream { "/sys/fs/cgroup/cpuset.cpus.effective" };
+	    auto buf = std::string { std::istreambuf_iterator<char> { stream }, {} };
+
+	    if (buf.empty()) {
+	        auto result = std::vector<std::int32_t>(Shared::coreCount);
+	        std::iota(result.begin(), result.end(), Shared::coreCount);
+	        return result;
+	    }
+
+	    auto active_cpus = buf | std::views::split(',') | std::views::transform([](auto&& expr) {
+	                           // Officially only in C++23
+	                           // auto view = std::string_view { expr.begin(), expr.end() };
+	                           auto view =
+	                               std::string_view(&*expr.begin(), std::ranges::distance(expr.begin(), expr.end()));
+	                           auto dash = view.find('-');
+
+	                           if (dash == std::string_view::npos) {
+	                               // Single CPU, return iota of single element
+	                               auto value = to_int(view);
+	                               return std::views::iota(value, value + 1);
+	                           }
+
+	                           // Create views before and after '-'
+	                           auto low_view = view.substr(0, dash);
+	                           auto high_view = view.substr(dash + 1);
+
+	                           auto low = to_int(low_view);
+	                           auto high = to_int(high_view);
+	                           return std::views::iota(low, high + 1);
+	                       }) |
+	                       std::views::join;
+
+	    // Collect the view into a vector. C++20 way of `std::ranges::to`.
+	    auto result = std::vector<std::int32_t> {};
+	    std::ranges::copy(active_cpus, std::back_inserter(result));
+	    return result;
+	}
+
 	auto collect(bool no_update) -> cpu_info& {
 		if (Runner::stopping or (no_update and not current_cpu.cpu_percent.at("total").empty())) return current_cpu;
 		auto& cpu = current_cpu;
@@ -1129,6 +1180,8 @@ namespace Cpu {
 
 		if (Config::getB("show_cpu_watts") and supports_watts)
 			current_cpu.usage_watts = get_cpuConsumptionWatts();
+
+		cpu.active_cpus = std::make_optional(detect_active_cpus());
 
 		return cpu;
 	}


### PR DESCRIPTION
Parse `/sys/fs/cgroup/cpuset.cpus.effective` and highlight only active cpus with color in cpu widget.

Closes: https://github.com/aristocratos/btop/issues/1151