### PR TITLE
feat: display CPU power draw & fix GPU+load avg overwriting core info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,6 +334,7 @@ setcap:
 	@printf "\033[1;97mFile: $(DESTDIR)$(PREFIX)/bin/btop\n"
 	@printf "\033[1;92mSetting capabilities...\033[0m\n"
 	@setcap cap_perfmon=+ep $(DESTDIR)$(PREFIX)/bin/btop
+	@setcap cap_dac_read_search=+ep $(DESTDIR)$(PREFIX)/bin/btop
 
 # With 'rm -v' user will see what files (if any) got removed
 uninstall:

--- a/README.md
+++ b/README.md
@@ -1402,6 +1402,9 @@ cpu_bottom = False
 #* Shows the system uptime in the CPU box.
 show_uptime = True
 
+#* Shows the CPU package current power consumption in watts. Requires running `make setcap` or `make setuid` or running with sudo.
+show_cpu_watts = True
+
 #* Show cpu temperature.
 check_temp = True
 

--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -132,6 +132,8 @@ namespace Config {
 
 		{"show_uptime", 		"#* Shows the system uptime in the CPU box."},
 
+		{"show_cpu_watts",		"#* Shows the CPU package current power consumption in watts. Requires running `make setcap` or `make setuid` or running with sudo."},
+
 		{"check_temp", 			"#* Show cpu temperature."},
 
 		{"cpu_sensor", 			"#* Which sensor to use for cpu temperature, use options menu to select from list of available sensors."},
@@ -281,6 +283,7 @@ namespace Config {
 		{"cpu_single_graph", false},
 		{"cpu_bottom", false},
 		{"show_uptime", true},
+		{"show_cpu_watts", true},
 		{"check_temp", true},
 		{"show_coretemp", true},
 		{"show_cpu_freq", true},

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -510,6 +510,13 @@ namespace Menu {
 				"\"/uptime\" in the formatting.",
 				"",
 				"True or False."},
+			{"show_cpu_watts",
+				"Shows the CPU power consumption in watts.",
+				"",
+				"Requires running `make setcap` or",
+				"`make setuid` or running with sudo.",
+				"",
+				"True or False."},
 		},
 	#ifdef GPU_SUPPORT
 		{

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -199,7 +199,7 @@ namespace Gpu {
 namespace Cpu {
 	extern string box;
 	extern int x, y, width, height, min_width, min_height;
-	extern bool shown, redraw, got_sensors, cpu_temp_only, has_battery;
+	extern bool shown, redraw, got_sensors, cpu_temp_only, has_battery, supports_watts;
 	extern string cpuName, cpuHz;
 	extern vector<string> available_fields;
 	extern vector<string> available_sensors;
@@ -223,6 +223,7 @@ namespace Cpu {
 		vector<deque<long long>> temp;
 		long long temp_max = 0;
 		array<double, 3> load_avg;
+		float usage_watts = 0;
 	};
 
 	//* Collect cpu stats and temperatures

--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -78,7 +78,7 @@ namespace Cpu {
 	vector<string> available_fields = {"Auto", "total"};
 	vector<string> available_sensors = {"Auto"};
 	cpu_info current_cpu;
-	bool got_sensors = false, cpu_temp_only = false;
+	bool got_sensors = false, cpu_temp_only = false, supports_watts = false;
 
 	//* Populate found_sensors map
 	bool get_sensors();

--- a/src/netbsd/btop_collect.cpp
+++ b/src/netbsd/btop_collect.cpp
@@ -84,7 +84,7 @@ namespace Cpu {
 	vector<string> available_fields = {"total"};
 	vector<string> available_sensors = {"Auto"};
 	cpu_info current_cpu;
-	bool got_sensors = false, cpu_temp_only = false;
+	bool got_sensors = false, cpu_temp_only = false, supports_watts = false;
 
 	//* Populate found_sensors map
 	bool get_sensors();

--- a/src/openbsd/btop_collect.cpp
+++ b/src/openbsd/btop_collect.cpp
@@ -83,7 +83,7 @@ namespace Cpu {
 	vector<string> available_fields = {"total"};
 	vector<string> available_sensors = {"Auto"};
 	cpu_info current_cpu;
-	bool got_sensors = false, cpu_temp_only = false;
+	bool got_sensors = false, cpu_temp_only = false, supports_watts = false;
 
 	//* Populate found_sensors map
 	bool get_sensors();

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -77,7 +77,7 @@ namespace Cpu {
 	vector<string> available_fields = {"Auto", "total"};
 	vector<string> available_sensors = {"Auto"};
 	cpu_info current_cpu;
-	bool got_sensors = false, cpu_temp_only = false;
+	bool got_sensors = false, cpu_temp_only = false, supports_watts = false;
 	int core_offset = 0;
 
 	//* Populate found_sensors map


### PR DESCRIPTION
This change was based on YuriiShkrobut's initial PR from here: https://github.com/aristocratos/btop/pull/595

Not only adds CPU power draw display, but also fixes missing CPU core information when there are too many cores for btop to display. Previously, the bottom lines were hidden by GPU(s) as well as by the load average.

### Screenshots at min width of 80

Before: (note missing cores 23, 47, and 70 upwards)
<img width="494" height="689" alt="image" src="https://github.com/user-attachments/assets/f0e19ce9-79b0-4d79-a7b1-16caf02e985a" />

After:
<img width="493" height="692" alt="image" src="https://github.com/user-attachments/assets/562cb45a-f4e5-494b-a664-80632a995abd" />

