### PR TITLE
fix: setcap cap_dac_read_search was overriding cap_perfmon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,8 +333,7 @@ setuid:
 setcap:
 	@printf "\033[1;97mFile: $(DESTDIR)$(PREFIX)/bin/btop\n"
 	@printf "\033[1;92mSetting capabilities...\033[0m\n"
-	@setcap cap_perfmon=+ep $(DESTDIR)$(PREFIX)/bin/btop
-	@setcap cap_dac_read_search=+ep $(DESTDIR)$(PREFIX)/bin/btop
+	@setcap "cap_perfmon=+ep cap_dac_read_search=+ep" $(DESTDIR)$(PREFIX)/bin/btop
 
 # With 'rm -v' user will see what files (if any) got removed
 uninstall:


### PR DESCRIPTION
It seems that calling setcap multiple times does not stack capabilities but instead overwrites them. This caused a regression in `cap_perfmon` no longer being active after `make setcap` (due to #1227) which this PR fixes.