### PR TITLE
Fix missing application entry in the snap distribution

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,7 @@ package-repositories:
 apps:
   btop:
     command: usr/local/bin/btop
+    desktop: usr/local/share/applications/btop.desktop
     environment:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
@@ -62,3 +63,11 @@ parts:
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"
+
+    override-build: |
+      snapcraftctl build
+
+      # Patch icon path of the desktop entry
+      # WORKAROUND: Use PNG icon until KDE Plasma can correctly render the SVG one
+      # Bug: https://bugs.kde.org/show_bug.cgi?id=448234
+      sed -i 's|Icon=btop|Icon=/usr/local/share/icons/hicolor/48x48/apps/btop.png|' "${CRAFT_PART_INSTALL}/usr/local/share/applications/btop.desktop"


### PR DESCRIPTION
This patch implements the necessary changes to allow the application desktop entry and icon to appear in the snap distribution user's desktop menu:

<img width="308" height="112" alt="image" src="https://github.com/user-attachments/assets/91f52690-7bb5-4d3c-8721-24a333587a1e" />

The SVG variant of the application is not used as currently it'll not rendered properly in the KDE Plasma desktop environment.

Refer-to: 448234 – Usage of Qt SVG renderer causes some 3rd-party app icons to be mis-rendered <https://bugs.kde.org/show_bug.cgi?id=448234>
Signed-off-by: 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>