### PR TITLE
Fix incorrect list item paragraph indentation in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,21 +257,21 @@ See [GPU compatibility](#gpu-compatibility) section for more about compiling wit
 
  * **NVIDIA**
 
-If you have an NVIDIA GPU you must use an official NVIDIA driver, both the closed-source and open-source ones have been verified to work.
+   If you have an NVIDIA GPU you must use an official NVIDIA driver, both the closed-source and open-source ones have been verified to work.
 
-In addition to that you must also have the nvidia-ml dynamic library installed, which should be included with the driver package of your distribution.
+   In addition to that you must also have the nvidia-ml dynamic library installed, which should be included with the driver package of your distribution.
 
  * **AMD**
 
-If you have an AMD GPU `rocm_smi_lib` is required, which may or may not be packaged for your distribution.
+   If you have an AMD GPU `rocm_smi_lib` is required, which may or may not be packaged for your distribution.
 
  * **INTEL**
 
-Requires a working C compiler if compiling from source - tested with GCC12 and Clang16.
+   Requires a working C compiler if compiling from source - tested with GCC12 and Clang16.
 
-Also requires the user to have permission to read from SYSFS.
+   Also requires the user to have permission to read from SYSFS.
 
-Can be set with `make setcap` (preferred) or `make setuid` or by running btop with `sudo` or equivalent.
+   Can be set with `make setcap` (preferred) or `make setuid` or by running btop with `sudo` or equivalent.
 
 ### **Notice (Text rendering issues)**
 


### PR DESCRIPTION
Refer to the following screenshots for the addressed problem(BEFORE/AFTER):

<div><img width="250" height="auto" alt="before" title="before" src="https://github.com/user-attachments/assets/a816f00a-4559-449a-8eae-62aaeab1e605" />&nbsp;&nbsp;&nbsp;&nbsp;<img width="250" height="auto" alt="after" title="after" src="https://github.com/user-attachments/assets/07d8dfdf-12dd-41d2-b0d7-15537ff4f5d7" /></div>
