### PR TITLE
feat: Add process renicing functionality

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1662,11 +1662,14 @@ namespace Proc {
 				}
 				out += title_left + hi_color + Fx::b + (vim_keys ? 'K' : 'k') + t_color + "ill" + Fx::ub + title_right
 					+ title_left + hi_color + Fx::b + 's' + t_color + "ignals" + Fx::ub + title_right
+					+ title_left + hi_color + Fx::b + 'N' + t_color + "ice" + Fx::ub + title_right
 					+ Mv::to(d_y, d_x + d_width - 10) + title_left + t_color + Fx::b + hide + Symbols::enter + Fx::ub + title_right;
 				if (alive and selected == 0) {
 					Input::mouse_mappings["k"] = {d_y, mouse_x, 1, 4};
 					mouse_x += 6;
 					Input::mouse_mappings["s"] = {d_y, mouse_x, 1, 7};
+				    mouse_x += 9;
+					Input::mouse_mappings["N"] = {d_y, mouse_x, 1, 5};
 				}
 				if (selected == 0) Input::mouse_mappings["enter"] = {d_y, d_x + d_width - 9, 1, 6};
 
@@ -1760,6 +1763,9 @@ namespace Proc {
 			}
 			out += title_left_down + Fx::b + hi_color + 's' + t_color + "ignals" + Fx::ub + title_right_down;
 			if (selected > 0) Input::mouse_mappings["s"] = {y + height - 1, mouse_x, 1, 7};
+		    mouse_x += 9;
+		    out += title_left_down + Fx::b + hi_color + 'N' + t_color + "ice" + Fx::ub + title_right_down;
+		    if (selected > 0) Input::mouse_mappings["N"] = {y + height -1, mouse_x, 1, 5};
 
 			//? Labels for fields in list
 			if (not proc_tree)

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -421,6 +421,12 @@ namespace Input {
 					Menu::show(Menu::Menus::SignalChoose);
 					return;
 				}
+			    else if (key == "N" and (Config::getB("show_detailed") or Config::getI("selected_pid") > 0)) {
+					atomic_wait(Runner::active);
+				    if (Config::getB("show_detailed") and Config::getI("proc_selected") == 0 and Proc::detailed.status == "Dead") return;
+				    Menu::show(Menu::Menus::Renice);
+				    return;
+			    }
 				else if (is_in(key, "up", "down", "page_up", "page_down", "home", "end") or (vim_keys and is_in(key, "j", "k", "g", "G"))) {
 					proc_mouse_scroll:
 					redraw = false;

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -203,6 +203,7 @@ namespace Menu {
 		{"Selected t", "Terminate selected process with SIGTERM - 15."},
 		{"Selected k", "Kill selected process with SIGKILL - 9."},
 		{"Selected s", "Select or enter signal to send to process."},
+		{"Selected N", "Select new nice value for selected process."},
 		{"", " "},
 		{"", "For bug reporting and project updates, visit:"},
 		{"", "https://github.com/aristocratos/btop"},
@@ -1595,6 +1596,81 @@ static int optionsMenu(const string& key) {
 		return (redraw ? Changed : retval);
 	}
 
+	static int reniceMenu(const string& key) {
+		auto s_pid = (Config::getB("show_detailed") and Config::getI("selected_pid") == 0 ? Config::getI("detailed_pid") : Config::getI("selected_pid"));
+	static Draw::TextEdit editor;
+	static string nice_value;
+	static string message;
+	static bool editing = true;
+
+	if (redraw) {
+		nice_value.clear();
+		editing = true;
+		editor = Draw::TextEdit("", true); // Only allow numbers and hyphen
+		vector<string> cont_vec;
+		message = "Enter new nice value (-20 to 19) for PID " + to_string(s_pid) + ':';
+		cont_vec.push_back(message);
+		messageBox = Menu::msgBox(50, 1, cont_vec, "Renice");
+		Global::overlay = messageBox();
+	}
+		
+		if (editing) {
+			if (is_in(key, "escape")) {
+				editing = false;
+				return Closed;
+			} else if (key == "enter") {
+				nice_value = editor.text;
+				Logger::debug(fmt::format("reniceMenu: editor.text='{}'", editor.text));
+				try {
+					int new_nice = stoi(nice_value);
+					if (new_nice < -20 || new_nice > 19) {
+						message = "Nice value must be between -20 and 19.";
+			        }
+					else {
+						bool result = Proc::set_priority(s_pid, new_nice);
+						Logger::debug(fmt::format("reniceMenu: set_priority returned {}", result));
+						if (result) {
+							message = "Successfully set nice value of PID " + to_string(s_pid) + ".";
+					    }
+						else {
+							Logger::debug(fmt::format("reniceMenu: set_priority failed with errno={}", errno));
+							message = "Failed to set nice value of PID " + to_string(s_pid) + ".";
+						}
+				    }
+				}
+				catch (const std::invalid_argument&) {
+						message = "Invalid nice value.";
+
+				}
+				catch (const std::out_of_range&) {
+						message = "Nice value out of range.";
+				}
+				editing = false;
+				vector<string> cont_vec = {message};
+				messageBox = Menu::msgBox(50, 0, cont_vec, "Renice");
+				Global::overlay = messageBox();
+				return Changed;
+			}
+			else if (not editor.command(key)) {
+				return NoChange;
+			}
+			Global::overlay = messageBox();
+			Global::overlay += Mv::to(messageBox.getY() + 4, messageBox.getX() + 2) + editor(46);
+			return Changed;
+		    }
+
+		    auto ret = messageBox.input(key);
+		    if (ret == msgBox::msgReturn::Ok_Yes or ret == msgBox::No_Esc) {
+			    messageBox.clear();
+			    return Closed;
+		    }
+		    else if (redraw) {
+			    return Changed;
+		    }
+		    return NoChange;
+		
+	}
+
 	//* Add menus here and update enum Menus in header
 	const auto menuFunc = vector{
 		ref(sizeError),
@@ -1603,6 +1679,7 @@ static int optionsMenu(const string& key) {
 		ref(signalReturn),
 		ref(optionsMenu),
 		ref(helpMenu),
+		ref(reniceMenu),
 		ref(mainMenu),
 	};
 	bitset<8> menuMask;

--- a/src/btop_menu.hpp
+++ b/src/btop_menu.hpp
@@ -72,6 +72,8 @@ namespace Menu {
 
 		//? Clears content vector and private strings
 		void clear();
+        int getX() const { return x; }
+        int getY() const { return y; }
 	};
 
 	extern bitset<8> menuMask;
@@ -84,6 +86,7 @@ namespace Menu {
 		SignalReturn,
 		Options,
 		Help,
+	    Renice,
 		Main
 	};
 

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -351,6 +351,7 @@ namespace Proc {
 	extern atomic<int> detailed_pid;
 	extern int selected_pid, start, selected, collapse, expand, filter_found, selected_depth;
 	extern string selected_name;
+	bool set_priority(pid_t pid, int priority);
 
 	//? Contains the valid sorting options for processes
 	const vector<string> sort_vector = {

--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -102,6 +102,15 @@ namespace Cpu {
 	std::unordered_map<int, int> core_mapping;
 }  // namespace Cpu
 
+namespace Proc {
+bool set_priority(pid_t pid, int priority) {
+  if (setpriority(PRIO_PROCESS, pid, priority) == 0) {
+    return true;
+  }
+  return false;
+}
+} // namespace Proc
+
 namespace Mem {
 	double old_uptime;
 	std::vector<string> zpools;

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -31,6 +31,7 @@ tab-size = 4
 #include <arpa/inet.h> // for inet_ntop()
 #include <filesystem>
 #include <future>
+#include <sys/resource.h>
 #include <dlfcn.h>
 #include <utility>
 
@@ -246,6 +247,16 @@ namespace Gpu {
 	}
 #endif
 }
+
+namespace Proc {
+bool set_priority(pid_t pid, int priority) {
+  if (setpriority(PRIO_PROCESS, pid, priority) == 0) {
+    return true;
+  }
+  return false;
+}
+
+} // namespace Proc
 
 namespace Mem {
 	double old_uptime;

--- a/src/netbsd/btop_collect.cpp
+++ b/src/netbsd/btop_collect.cpp
@@ -1087,6 +1087,12 @@ namespace Net {
 }  // namespace Net
 
 namespace Proc {
+bool set_priority(pid_t pid, int priority) {
+  if (setpriority(PRIO_PROCESS, pid, priority) == 0) {
+    return true;
+  }
+  return false;
+}
 
 	vector<proc_info> current_procs;
 	std::unordered_map<string, string> uid_user;

--- a/src/openbsd/btop_collect.cpp
+++ b/src/openbsd/btop_collect.cpp
@@ -944,6 +944,12 @@ namespace Net {
 }  // namespace Net
 
 namespace Proc {
+bool set_priority(pid_t pid, int priority) {
+  if (setpriority(PRIO_PROCESS, pid, priority) == 0) {
+    return true;
+  }
+  return false;
+}
 
 	vector<proc_info> current_procs;
 	std::unordered_map<string, string> uid_user;

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -38,6 +38,7 @@ tab-size = 4
 #include <netdb.h>
 #include <netinet/tcp_fsm.h>
 #include <pwd.h>
+#include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/statvfs.h>
 #include <sys/sysctl.h>
@@ -1025,6 +1026,12 @@ namespace Net {
 }  // namespace Net
 
 namespace Proc {
+bool set_priority(pid_t pid, int priority) {
+  if (setpriority(PRIO_PROCESS, pid, priority) == 0) {
+    return true;
+  }
+  return false;
+}
 
 	vector<proc_info> current_procs;
 	std::unordered_map<string, string> uid_user;


### PR DESCRIPTION
This adds the ability to change the nice value of a process from within btop. A new menu is introduced, accessible by pressing 'N', which allows the user to input a new nice value for the selected process.

Fixes #1245