### PR TITLE
Update Ryzen name trimming to skip "H" and "HX"

### DIFF
--- a/src/btop_shared.cpp
+++ b/src/btop_shared.cpp
@@ -43,7 +43,7 @@ namespace Cpu {
 			int tokens = 0;
 			for (auto i = ryz_pos + 1; i < name_vec.size() && tokens < 2; i++) {
 				const std::string& p = name_vec.at(i);
-				if (p != "AI" && p != "PRO")
+				if (p != "AI" && p != "PRO" && p != "H" && p != "HX")
 					tokens++;
 				name += " " + p;
 			}


### PR DESCRIPTION
Update on #1033, plus "H" and "HX" as suffixes.

Zen 5 based AMD mobile processors (Strix Point and Krackan Point) have the [naming scheme](https://en.wikipedia.org/wiki/List_of_AMD_mobile_processors#Strix_Point_and_Krackan_Point_(Zen_5/RDNA3.5/XDNA2_based)) as "Ryzen AI [Tier] (PRO) (H/HX) [Model]", such as "Ryzen AI 9 HX 370" seen on Framework Laptop 13. The "H" suffix appears to be exclusive to the Chinese market.

In the current build, the name trimming would incorrectly counts "H" and "HX" as tokens and omits the model number.

This PR fixes that.

Here are the pictures of the Ryzen 7 H 260 I'm using:

Before:
<img width="337" height="287" alt="Ryzen 7 H 260 before PR" src="https://github.com/user-attachments/assets/28f0f57e-989b-40d2-9833-83febbd52311" />

After:
<img width="337" height="287" alt="Ryzen 7 H 260 after PR" src="https://github.com/user-attachments/assets/5648e9b6-08ea-4b76-afd3-358a24675383" />