### PR TITLE
feat: Introduce cpu frequency display modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1429,6 +1429,9 @@ base_10_sizes = False
 #* Show CPU frequency.
 show_cpu_freq = True
 
+#* How to calculate CPU frequency, available values: "first", "range", "lowest", "highest" and "average".
+freq_mode = "first"
+
 #* Draw a clock at top of screen, formatting according to strftime, empty string to disable.
 #* Special formatting: /host = hostname | /user = username | /uptime = system uptime
 clock_format = "%H:%M"

--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -150,7 +150,9 @@ namespace Config {
 		{"base_10_sizes",		"#* Use base 10 for bits/bytes sizes, KB = 1000 instead of KiB = 1024."},
 
 		{"show_cpu_freq", 		"#* Show CPU frequency."},
-
+	#ifdef __linux__
+		{"freq_mode",				"#* How to calculate CPU frequency, available values: \"first\", \"range\", \"lowest\", \"highest\" and \"average\"."},
+	#endif
 		{"clock_format", 		"#* Draw a clock at top of screen, formatting according to strftime, empty string to disable.\n"
 								"#* Special formatting: /host = hostname | /user = username | /uptime = system uptime"},
 
@@ -243,6 +245,9 @@ namespace Config {
 		{"selected_battery", "Auto"},
 		{"cpu_core_map", ""},
 		{"temp_scale", "celsius"},
+	#ifdef __linux__
+		{"freq_mode", "first"},
+	#endif
 		{"clock_format", "%X"},
 		{"custom_cpu_name", ""},
 		{"disks_filter", ""},

--- a/src/btop_config.hpp
+++ b/src/btop_config.hpp
@@ -50,6 +50,9 @@ namespace Config {
 #endif
 		};
 	const vector<string> temp_scales = { "celsius", "fahrenheit", "kelvin", "rankine" };
+#ifdef __linux__
+	const vector<string> freq_modes = { "first", "range", "lowest", "highest", "average" };
+#endif
 #ifdef GPU_SUPPORT
 	const vector<string> show_gpu_values = { "Auto", "On", "Off" };
 #endif

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -812,9 +812,16 @@ namespace Cpu {
 					+ Theme::c("graph_text") + "up" + Mv::r(1) + upstr;
 			}
 
+		#ifdef __linux__
+			const bool freq_range = Config::getS("freq_mode") == "range";
+		#else
+			const bool freq_range = false;
+		#endif
+
 			//? Cpu clock and cpu meter
 			if (Config::getB("show_cpu_freq") and not cpuHz.empty())
-				out += Mv::to(b_y, b_x + b_width - 10) + Fx::ub + Theme::c("div_line") + Symbols::h_line * (7 - cpuHz.size())
+				out += Mv::to(b_y, b_x + b_width - (freq_range ? 20 : 10)) + Fx::ub + Theme::c("div_line")
+					+ Symbols::h_line * ((freq_range ? 17 : 7) - cpuHz.size())
 					+ Symbols::title_left + Fx::b + Theme::c("title") + cpuHz + Fx::ub + Theme::c("div_line") + Symbols::title_right;
 
 		out += Mv::to(b_y + 1, b_x + 1) + Theme::c("main_fg") + Fx::b + "CPU " + cpu_meter(safeVal(cpu.cpu_percent, "total"s).back())
@@ -2117,9 +2124,14 @@ namespace Draw {
 
 			auto& custom = Config::getS("custom_cpu_name");
 			static const bool hasCpuHz = not Cpu::get_cpuHz().empty();
+		#ifdef __linux__
+			static const bool freq_range = Config::getS("freq_mode") == "range";
+		#else
+			static const bool freq_range = false;
+		#endif
 			const string cpu_title = uresize(
 					(custom.empty() ? Cpu::cpuName : custom),
-					b_width - (Config::getB("show_cpu_freq") and hasCpuHz ? 14 : 4)
+					b_width - (Config::getB("show_cpu_freq") and hasCpuHz ? (freq_range ? 24 : 14) : 5)
 			);
 			box += createBox(b_x, b_y, b_width, b_height, "", false, cpu_title);
 		}

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -500,6 +500,22 @@ namespace Menu {
 				"",
 				"Can cause slowdowns on systems with many",
 				"cores and certain kernel versions."},
+		#ifdef __linux__
+			{"freq_mode",
+				"How the CPU frequency will be displayed.",
+				"",
+				"First, get the frequency from the first",
+				"core.",
+				"",
+				"Range, show the lowest and the highest",
+				"frequency.",
+				"",
+				"Lowest, the lowest frequency.",
+				"",
+				"Highest, the highest frequency.",
+				"",
+				"Average, sum and divide."},
+		#endif
 			{"custom_cpu_name",
 				"Custom cpu model name in cpu percentage box.",
 				"",
@@ -1202,6 +1218,9 @@ static int optionsMenu(const string& key) {
 			{"color_theme", std::cref(Theme::themes)},
 			{"log_level", std::cref(Logger::log_levels)},
 			{"temp_scale", std::cref(Config::temp_scales)},
+		#ifdef __linux__
+			{"freq_mode", std::cref(Config::freq_modes)},
+		#endif
 			{"proc_sorting", std::cref(Proc::sort_vector)},
 			{"graph_symbol", std::cref(Config::valid_graph_symbols)},
 			{"graph_symbol_cpu", std::cref(Config::valid_graph_symbols_def)},


### PR DESCRIPTION
This allows for the user to select how the cpu frequency is calculated (relates to #554)

Options are:

 - **first**: The current way. Just fetches the frequency from the first available core;
 - **range**: Display the lowest and highest frequencies;
 - **lowest**: Display the lowest frequency;
 - **highest**: Display the highest frequency;
 - **average**: Sum all the cores frequencies and divides by the number of cores;

I don't have a device with macOS or BSD to test so I'm implementing this feature on Linux only. IF anyone with access to other OSes want to test it please do and comment here.