### PR TITLE
Fix CPU frequency detection for LoongArch CPUs

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -637,7 +637,7 @@ namespace Cpu {
 				if (cpufreq.good()) {
 					while (cpufreq.ignore(SSmax, '\n')) {
 						// peek is caps sensitive so it was skipping 'CPU MHz'. This aims to fix it.
-						if (cpufreq.peek() == 'c' or 'C') {
+						if (cpufreq.peek() == 'c' || cpufreq.peek() == 'C') {
 							cpufreq.ignore(SSmax, ' ');
 							if (cpufreq.peek() == 'M') {
 								cpufreq.ignore(SSmax, ':');


### PR DESCRIPTION
As mentioned in #1281, CPU frequency detection doesn't work on LoongArch systems because cpufreq.peek() is case sensitive and couldn't find **CPU MHz**. This PR improves the fallback `/proc/cpuinfo`. 

**Changes:**
- Modified `get_cpuHz()` function in `src/linux/btop_collect.cpp` to lines 576
- Added support for "CPU MHz" field in addition to "cpu MHz"
- Tested on Loongson 3A6000 system

**Testing:**
- CPU frequency now displays correctly on LoongArch
<img width="2522" height="1284" alt="Screenshot_20251005_012546" src="https://github.com/user-attachments/assets/d89953e2-807f-4926-9144-98220d2b4748" />

Fixes #1281
