### PR TITLE
Fix: F1 and F2 keys for help and options.

### DIFF
--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -221,11 +221,11 @@ namespace Input {
 					Menu::show(Menu::Menus::Main);
 					return;
 				}
-				else if (is_in(key, "F1", "?", help_key)) {
+				else if (is_in(key, "f1", "?", help_key)) {
 					Menu::show(Menu::Menus::Help);
 					return;
 				}
-				else if (is_in(key, "F2", "o")) {
+				else if (is_in(key, "f2", "o")) {
 					Menu::show(Menu::Menus::Options);
 					return;
 				}


### PR DESCRIPTION
They were comparing to F1 and F2 (uppercase) when the keys were defined as f1 and f2 (lowercase)

Fixes: #1299

Edit:

I fixed this by changing just the 2 lines checking F1 and F2 to f1 and f2. 

It seemed cleaner then changing the definition of all the F keys to uppercase.
The only reason I can think to prefer changing the definitions is that I feel it is pretty common to default to using uppercase F when typing out the F keys and so if another F key is added as a keybinding at some point perhaps this mistake may be made again? In which case perhaps it is better to change all the definitions to uppercase?

Thoughts?

Edit Again:

I decided to see if this issue existed in the btop4win as well and I see that there the check for f1 and f2 does use the lowercase and they are all defined up top as lowercase so I bet Fkeys work fine there.

Since they are lowercase over there I will leave lowercase here as well for consistency
