### PR TITLE
Fix: redraw for tree view when changing sorting mode with fully collapsed tree

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1968,7 +1968,7 @@ namespace Proc {
 		}
 
 		out += Fx::reset;
-		while (lc++ < height - 5) out += Mv::to(y+lc+1, x+1) + string(width - 2, ' ');
+		while (lc++ < height - 3) out += Mv::to(y+lc+1, x+1) + string(width - 2, ' ');
 
 		//? Draw scrollbar if needed
 		if (numpids > select_max) {


### PR DESCRIPTION
Fixes: #1308 

This fixes the issue with the tree view leaving 2 lines behind at the bottom when changing the sorting mode with the tree fully collapsed. 

It seems that the code that was putting blank lines after the end of the process list if it was smaller then the box size was off by 2.

I've tested this on Linux and macOS

This is a screenshot of before the change
<img width="435" height="411" alt="Screenshot 2025-10-23 at 4 51 12 PM" src="https://github.com/user-attachments/assets/43cbdc14-f19d-4117-8d9e-ce77dd58d015" />

Here is a video showing it working after the change

https://github.com/user-attachments/assets/1de71478-bfef-4910-a9a4-1d2883a747bc


