### PR TITLE
Fix: Tree sort unstable when filtered

### DIFF
--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -1326,7 +1326,7 @@ namespace Proc {
 			}
 
 			//? Final sort based on tree index
-			rng::sort(current_procs, rng::less{}, & proc_info::tree_index);
+			rng::stable_sort(current_procs, rng::less {}, &proc_info::tree_index);
 
 			//? Move current selection/view to the selected process when collapsing/expanding in the tree
 			if (locate_selection) {

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -3279,7 +3279,7 @@ namespace Proc {
 			}
 
 			//? Final sort based on tree index
-			rng::sort(current_procs, rng::less{}, & proc_info::tree_index);
+			rng::stable_sort(current_procs, rng::less {}, &proc_info::tree_index);
 
 			//? Move current selection/view to the selected process when collapsing/expanding in the tree
 			if (locate_selection) {

--- a/src/netbsd/btop_collect.cpp
+++ b/src/netbsd/btop_collect.cpp
@@ -1389,7 +1389,7 @@ namespace Proc {
 			}
 
 			//? Final sort based on tree index
-			rng::sort(current_procs, rng::less{}, & proc_info::tree_index);
+			rng::stable_sort(current_procs, rng::less {}, &proc_info::tree_index);
 
 			//? Move current selection/view to the selected process when collapsing/expanding in the tree
 			if (locate_selection) {

--- a/src/openbsd/btop_collect.cpp
+++ b/src/openbsd/btop_collect.cpp
@@ -1264,7 +1264,7 @@ namespace Proc {
 			}
 
 			//? Final sort based on tree index
-			rng::sort(current_procs, rng::less{}, & proc_info::tree_index);
+			rng::stable_sort(current_procs, rng::less {}, &proc_info::tree_index);
 
 			//? Move current selection/view to the selected process when collapsing/expanding in the tree
 			if (locate_selection) {

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1402,7 +1402,7 @@ namespace Proc {
 			}
 
 			//? Final sort based on tree index
-			rng::sort(current_procs, rng::less{}, & proc_info::tree_index);
+			rng::stable_sort(current_procs, rng::less {}, &proc_info::tree_index);
 
 			//? Move current selection/view to the selected process when collapsing/expanding in the tree
 			if (locate_selection) {


### PR DESCRIPTION
Fixes: #1327 

I managed to figure it out!

changed final tree index `sort` to `stable_sort` and this seems to have fixed the issue.

It doesn't seem to have adversely affected the unfiltered tree sorting in any way. But it has fixed the issue of a filtered tree sort moving the last result up to the top and back to the bottom for `name`, `command`, and `user` sorting modes and for all modes with pause enabled

Video example of fix

https://github.com/user-attachments/assets/70cc93a9-0a48-4698-9bbc-bb1a85b36131


