### PR TITLE
Fix: tty theme for pause banner

### DIFF
--- a/src/btop_theme.cpp
+++ b/src/btop_theme.cpp
@@ -135,7 +135,7 @@ namespace Theme {
 		{ "process_start", "\x1b[32m" },
 		{ "process_mid", "\x1b[33m" },
 		{ "process_end", "\x1b[31m" },
-		{ "proc_pause_bg", "\x1b[31m" }
+		{ "proc_pause_bg", "\x1b[41m" },
 	};
 
 	namespace {


### PR DESCRIPTION
was accidently using ansi foreground color instead of background color for banner

Fixes: #1333 