### PR TITLE
fix: Skip argv[0] on main

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,5 +5,5 @@
 #include <vector>
 
 auto main(int argc, const char* argv[]) -> int {
-	return btop_main(std::views::counted(argv + 1, argc - 1) | std::ranges::to<std::vector<std::string_view>>());
+	return btop_main(std::views::counted(std::next(argv), argc - 1) | std::ranges::to<std::vector<std::string_view>>());
 }


### PR DESCRIPTION
The recent commit https://github.com/aristocratos/btop/pull/1325 introduced a bug on the cli because `argv[0]` was being passed to `btop_main` args. 

```
./bin/btop
error: Unknown argument './bin/btop'

Usage: btop [OPTIONS]

For more information, try '--help'
```