### PR TITLE
Add ability to view core frequencies for Linux

### DIFF
--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -155,7 +155,8 @@ namespace Config {
 
 		{"show_cpu_freq", 		"#* Show CPU frequency."},
 	#ifdef __linux__
-		{"freq_mode",				"#* How to calculate CPU frequency, available values: \"first\", \"range\", \"lowest\", \"highest\" and \"average\"."},
+		{"show_cores_freq",     "#* Show each CPU core frequence."},
+		{"freq_mode",			"#* How to calculate CPU frequency, available values: \"first\", \"range\", \"lowest\", \"highest\" and \"average\"."},
 	#endif
 		{"clock_format", 		"#* Draw a clock at top of screen, formatting according to strftime, empty string to disable.\n"
 								"#* Special formatting: /host = hostname | /user = username | /uptime = system uptime"},
@@ -298,6 +299,7 @@ namespace Config {
 		{"check_temp", true},
 		{"show_coretemp", true},
 		{"show_cpu_freq", true},
+		{"show_cores_freq", false },
 		{"background_update", true},
 		{"mem_graphs", true},
 		{"mem_below_net", false},

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -887,8 +887,7 @@ namespace Cpu {
 			out += enabled ? Theme::g("cpu").at(clamp(safeVal(cpu.core_percent, n).back(), 0ll, 100ll)) : Theme::c("inactive_fg");
 			out += rjust(to_string(safeVal(cpu.core_percent, n).back()), (b_column_size < 2 ? 3 : 4)) + Theme::c(enabled ? "main_fg" : "inactive_fg") + '%';
 
-			if (not hide_cores)
-			{
+			if (not hide_cores) {
 			#if __linux__
 				// Preventing anyone using unsupported OS from manually setting this option to On
 				if (show_cores_freq) {

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -524,6 +524,11 @@ namespace Menu {
 				"Highest, the highest frequency.",
 				"",
 				"Average, sum and divide."},
+			{"show_cores_freq",
+				"Show each CPU core frequency.",
+				"",
+				"Can cause slowdowns on systems with many",
+				"cores and certain kernel versions."},
 		#endif
 			{"custom_cpu_name",
 				"Custom cpu model name in cpu percentage box.",

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -525,7 +525,7 @@ namespace Menu {
 				"",
 				"Average, sum and divide."},
 			{"show_cores_freq",
-				"Show each CPU core frequency.",
+				"Show each CPU core frequency next to core utilization.",
 				"",
 				"Can cause slowdowns on systems with many",
 				"cores and certain kernel versions."},

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -224,6 +224,7 @@ namespace Cpu {
 		};
 		vector<deque<long long>> core_percent;
 		vector<deque<long long>> temp;
+		vector<string> core_freq;
 		long long temp_max = 0;
 		array<double, 3> load_avg;
 		float usage_watts = 0;

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -689,13 +689,10 @@ namespace Cpu {
 		return cpuhz;
 	}
 
-	vector<string> get_cpu_coresHz()
-	{
-		try
-		{
+	vector<string> get_cpu_coresHz() {
+		try {
 			vector<double> frequencies;
-			for (auto it = core_freq.begin(); it != Cpu::core_freq.end(); )
-			{
+			for (auto it = core_freq.begin(); it != Cpu::core_freq.end();) {
 				if (it->empty()) {
 					it = core_freq.erase(it);
 					continue;

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -723,7 +723,7 @@ namespace Cpu {
 			}
 		}
 		catch (const std::exception& e) {
-			Logger::warning("get_cpu_coresHz() : " + string{e.what()});
+			Logger::warning(fmt::format("get_cpu_coresHz() : {}", e.what()));
 			return vector<string>{};
 		}
 

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -701,7 +701,8 @@ namespace Cpu {
 				double core_hz = stod(readfile(*it, "0.0")) / 1000;
 				if (core_hz <= 1 or core_hz >= 999999999) {
 					Logger::warning("get_cpuHZ() : Failed to read /sys/devices/system/cpu/cpufreq/policy");
-					frequencies.push_back(0.0);
+					// Pushing -1.0 to signalize no frequency have been obtained
+					frequencies.push_back(-1.0);
 				}
 				else {
 					frequencies.push_back(core_hz);
@@ -711,9 +712,8 @@ namespace Cpu {
 
 			if (not frequencies.empty()) {
 				vector<string> formated_frequencies;
-				for (auto& freq : frequencies)
-				{
-					formated_frequencies.push_back(freq == 0.0 ? "" : normalize_frequency(freq));
+				for (auto& freq : frequencies) {
+					formated_frequencies.push_back(freq == -1.0 ? "N/A" : normalize_frequency(freq));
 				}
 
 				return formated_frequencies;
@@ -1215,8 +1215,7 @@ namespace Cpu {
 
 		cpu.active_cpus = std::make_optional(detect_active_cpus());
 
-		if (Config::getB("show_cores_freq") and not cpu_coreHz.empty())
-		{
+		if (Config::getB("show_cores_freq") and not cpu_coreHz.empty()) {
 			cpu.core_freq = cpu_coreHz;
 		}
 
@@ -3282,7 +3281,7 @@ namespace Proc {
 				}
 				toggle_children = -1;
 			}
-			
+
 			if (auto find_pid = (collapse != -1 ? collapse : expand); find_pid != -1) {
 				auto collapser = rng::find(current_procs, find_pid, &proc_info::pid);
 				if (collapser != current_procs.end()) {

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -691,7 +691,7 @@ namespace Cpu {
 
 	vector<string> get_cpu_coresHz() {
 		try {
-			vector<double> frequencies;
+			vector<std::optional<double>> frequencies;
 			for (auto it = core_freq.begin(); it != Cpu::core_freq.end();) {
 				if (it->empty()) {
 					it = core_freq.erase(it);
@@ -701,11 +701,10 @@ namespace Cpu {
 				double core_hz = stod(readfile(*it, "0.0")) / 1000;
 				if (core_hz <= 1 or core_hz >= 999999999) {
 					Logger::warning("get_cpuHZ() : Failed to read /sys/devices/system/cpu/cpufreq/policy");
-					// Pushing -1.0 to signalize no frequency have been obtained
-					frequencies.push_back(-1.0);
+					frequencies.emplace_back(std::nullopt);
 				}
 				else {
-					frequencies.push_back(core_hz);
+					frequencies.emplace_back(core_hz);
 				}
 				++it;
 			}
@@ -713,7 +712,7 @@ namespace Cpu {
 			if (not frequencies.empty()) {
 				vector<string> formated_frequencies;
 				for (auto& freq : frequencies) {
-					formated_frequencies.push_back(freq == -1.0 ? "N/A" : normalize_frequency(freq));
+					formated_frequencies.push_back(not freq.has_value() ? "N/A" : normalize_frequency(freq.value()));
 				}
 
 				return formated_frequencies;


### PR DESCRIPTION
Add ability to view core frequencies on Linux. CPU cores frequencies are hidden for each OS but Linux to prevent unsupported functionality from being activated on other platforms.
<img width="1599" height="232" alt="image" src="https://github.com/user-attachments/assets/3be9c6a0-eeda-4703-bf3c-2d96e4eb2488" />

Added config update from settings, removed some of the magic numbers in core column width calculation.
In case when failed to get core frequency, zero is populated so we can track it and show **N/A** for a moment.