### PR TITLE
Fix: missed changing mouse mapping for hide button

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1693,7 +1693,6 @@ namespace Proc {
 				    mouse_x += 9;
 					Input::mouse_mappings["N"] = {d_y, mouse_x, 1, 5};
 				}
-				if (selected == 0) Input::mouse_mappings["enter"] = {d_y, d_x + d_width - 9, 1, 6};
 
 				//? Labels
 				const int item_fit = floor((double)(d_width - 2) / 10);
@@ -2036,6 +2035,7 @@ namespace Proc {
 				greyed_out ? Theme::c("inactive_fg") : Theme::c("title"), "hide ",
 				greyed_out ? "" : Theme::c("hi_fg"), Symbols::enter,
 				Fx::ub, Theme::c("proc_box"), Symbols::title_right);
+			if (not greyed_out) Input::mouse_mappings["enter"] = {d_y, d_x + d_width - 9, 1, 6};
 		}
 
 		if (selected == 0 and selected_pid != 0) {


### PR DESCRIPTION
I missed the line of code that was mapping the mouse for the hide button.

It now is mapped properly when the detailed view process is selected in the list.

Fixes: #1343 

https://github.com/user-attachments/assets/13bf7d23-c145-442a-b71b-2ec277fc7735

