### PR TITLE
build(cmake): don't set a default build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,6 @@ include(CMakeDependentOption)
 # Make our Find<Package>.cmake files available
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
-# When the build type is not set we can't fortify
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
This was initially done to aid with fortifying source which required an optimized build. We since removed the logic do to avoid duplicating work of distribtions.

We are also much more likly to call cmake in development so we mostly don't want release builds by default.