### PR TITLE
feat: add --themes-dir flag

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -910,6 +910,12 @@ static auto configure_tty_mode(std::optional<bool> force_tty) {
 		}
 	}
 
+	//? Set custom themes directory from command line if provided
+	if (cli.themes_dir.has_value()) {
+		Theme::custom_theme_dir = cli.themes_dir.value();
+		Logger::info("Using custom themes directory: " + Theme::custom_theme_dir.string());
+	}
+
 	//? Config init
 	init_config(cli.low_color, cli.filter);
 

--- a/src/btop_cli.cpp
+++ b/src/btop_cli.cpp
@@ -142,6 +142,24 @@ namespace Cli {
 				}
 				continue;
 			}
+			if (arg == "--themes-dir") {
+				// This flag requires an argument.
+				if (++it == args.end()) {
+					error("Themes directory requires an argument");
+					return std::unexpected { 1 };
+				}
+
+				auto arg = *it;
+				auto themes_dir = stdfs::path { arg };
+
+				if (not stdfs::is_directory(themes_dir)) {
+					error("Themes directory does not exist or is not a directory");
+					return std::unexpected { 1 };
+				}
+
+				cli.themes_dir = std::make_optional(themes_dir);
+				continue;
+			}
 			if (arg == "-u" || arg == "--update") {
 				// This flag requires an argument.
 				if (++it == args.end()) {
@@ -183,6 +201,7 @@ namespace Cli {
 			"  {2}-l, --low-color{1}         Disable true color, 256 colors only\n"
 			"  {2}-p, --preset{1} <id>       Start with a preset (0-9)\n"
 			"  {2}-t, --tty{1}               Force tty mode with ANSI graph symbols and 16 colors only\n"
+			"  {2}    --themes-dir{1} <dir>  Path to a custom themes directory\n"
 			"  {2}    --no-tty{1}            Force disable tty mode\n"
 			"  {2}-u, --update{1} <ms>       Set an initial update rate in milliseconds\n"
 			"  {2}-h, --help{1}              Show this help message and exit\n"

--- a/src/btop_cli.hpp
+++ b/src/btop_cli.hpp
@@ -28,6 +28,8 @@ namespace Cli {
 		bool low_color {};
 		// Start with one of the provided presets
 		std::optional<std::uint32_t> preset;
+		// Path to a custom themes directory
+		std::optional<stdfs::path> themes_dir;
 		// The initial refresh rate
 		std::optional<std::uint32_t> updates;
 	};

--- a/src/btop_theme.cpp
+++ b/src/btop_theme.cpp
@@ -41,6 +41,7 @@ namespace Theme {
 
 	fs::path theme_dir;
 	fs::path user_theme_dir;
+	fs::path custom_theme_dir;
 	vector<string> themes;
 	std::unordered_map<string, string> colors;
 	std::unordered_map<string, array<int, 3>> rgbs;
@@ -418,7 +419,8 @@ namespace Theme {
 		themes.push_back("Default");
 		themes.push_back("TTY");
 
-		for (const auto& path : { user_theme_dir, theme_dir } ) {
+		//? Priority: custom_theme_dir -> user_theme_dir -> theme_dir
+		for (const auto& path : { custom_theme_dir, user_theme_dir, theme_dir } ) {
 			if (path.empty()) continue;
 			for (auto& file : fs::directory_iterator(path)) {
 				if (file.path().extension() == ".theme" and access(file.path().c_str(), R_OK) != -1 and not v_contains(themes, file.path().c_str())) {

--- a/src/btop_theme.hpp
+++ b/src/btop_theme.hpp
@@ -31,6 +31,7 @@ using std::vector;
 namespace Theme {
 	extern std::filesystem::path theme_dir;
 	extern std::filesystem::path user_theme_dir;
+	extern std::filesystem::path custom_theme_dir;
 
 	//* Contains "Default" and "TTY" at indices 0 and 1, otherwise full paths to theme files
 	extern vector<string> themes;


### PR DESCRIPTION
## Description

Adds `--themes-dir` command-line option to specify a custom directory for theme files.
When provided, this directory is searched before the default user and system directories.

## Motivation

The current fixed theme search paths don't work well for declarative and immutable system configurations that cannot or prefer not to place files in `$HOME`.

I am working with application wrappers that provide additional resources and configuration without modifying the package itself or writing to user directories. Currently, there's no clean way to provide custom btop themes in these scenarios since themes must be in predefined system or user paths, which would require either rebuilding the package to modify the outpath or impurely placing files in the user's home directory.

With `--themes-dir`, themes can be specified in any directory the user chooses, or bundled alongside the application and referenced directly.

## Changes

- Added `--themes-dir <dir>` CLI option with directory validation
- Custom directory takes priority in theme search order

## Usage

```bash
btop --themes-dir /path/to/custom/themes