### PR TITLE
Fix int overflow when using the --update flag

### DIFF
--- a/src/btop_cli.cpp
+++ b/src/btop_cli.cpp
@@ -151,7 +151,7 @@ namespace Cli {
 
 				auto arg = *it;
 				try {
-					auto refresh_rate = std::max(std::stoul(arg.data()), 100UL);
+					auto refresh_rate = std::max(std::stoi(arg.data()), 100);
 					cli.updates = refresh_rate;
 				} catch (std::invalid_argument& e) {
 					error("Update must be a positive number");


### PR DESCRIPTION
Fixes #1354.
Flag value was being cast to unsigned long and then later to int. Also fixes negative value arguments.