### PR TITLE
fix segfault on musl systems

### DIFF
--- a/src/linux/intel_gpu_top/intel_name_lookup_shim.c
+++ b/src/linux/intel_gpu_top/intel_name_lookup_shim.c
@@ -38,10 +38,10 @@ char* find_intel_gpu_dir() {
                     vendor_id[strcspn(vendor_id, "\n")] = 0;
 
                     if (strcmp(vendor_id, VENDOR_ID) == 0) {
-                        fclose(file);
-                        closedir(dir);
                         // Return the parent directory (i.e., /sys/class/drm/card*)
                         snprintf(path, sizeof(path), "%s/%s", SYSFS_PATH, entry->d_name);
+                        fclose(file);
+                        closedir(dir);
                         return path;
                     }
                 }


### PR DESCRIPTION
When using musl system library, dirent data lost after dir is closed. so path must be generated before closing directory 