### PR TITLE
Fix: Exception during Config::unlock() : unordered_map::at when preset cycling

### DIFF
--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -488,7 +488,7 @@ namespace Config {
 			if (vals.at(0).starts_with("gpu")) {
 				set("graph_symbol_gpu", vals.at(2));
 			} else {
-				set("graph_symbol_" + vals.at(0), vals.at(2));
+				set(strings.find("graph_symbol_" + vals.at(0))->first, vals.at(2));
 			}
 		}
 


### PR DESCRIPTION
Fixes: #1010

Switching presets sometimes inserted bad keys in ```Config::stringsTmp```, as temporary ```std::string``` instances were used to make new keys which outlived the original ```string``` objects. Fix by instead using corresponding static duration ```string_view``` instances.

Should now allow holding down `p` to cycle presets indefinitely.