### PR TITLE
fix: cpu per-thread totals not reaching 100%

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -1102,7 +1102,7 @@ namespace Cpu {
 					//? Calculate values for totals from first line of stat
 					if (i == 0) {
 						const long long calc_totals = max(1ll, totals - cpu_old.at("totals"));
-						const long long calc_idles = max(1ll, idles - cpu_old.at("idles"));
+						const long long calc_idles = max(0ll, idles - cpu_old.at("idles"));
 						cpu_old.at("totals") = totals;
 						cpu_old.at("idles") = idles;
 
@@ -1133,7 +1133,7 @@ namespace Cpu {
 							cpu.core_percent.emplace_back();
 						}
 						const long long calc_totals = max(1ll, totals - core_old_totals.at(i-1));
-						const long long calc_idles = max(1ll, idles - core_old_idles.at(i-1));
+						const long long calc_idles = max(0ll, idles - core_old_idles.at(i-1));
 						core_old_totals.at(i-1) = totals;
 						core_old_idles.at(i-1) = idles;
 


### PR DESCRIPTION
Fixes #1142 

The bug was introduced by https://github.com/aristocratos/btop/commit/684fbeb583c1e8e1ef5475f2963e968f4fb47fa9. This PR fixes it while still staying robust against divisions by 0.