### PR TITLE
Install README in its own subdirectory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,9 +301,10 @@ install:
 	@mkdir -p $(DESTDIR)$(PREFIX)/bin
 	@cp -p $(TARGETDIR)/btop $(DESTDIR)$(PREFIX)/bin/btop
 	@chmod 755 $(DESTDIR)$(PREFIX)/bin/btop
-	@printf "\033[1;92mInstalling doc to: \033[1;97m$(DESTDIR)$(PREFIX)/share/btop\033[0m\n"
+	@printf "\033[1;92mInstalling doc to: \033[1;97m$(DESTDIR)$(PREFIX)/share/doc/btop\033[0m\n"
+	@mkdir -p $(DESTDIR)$(PREFIX)/share/doc/btop
+	@cp -p README.md $(DESTDIR)$(PREFIX)/share/doc/btop
 	@mkdir -p $(DESTDIR)$(PREFIX)/share/btop
-	@cp -p README.md $(DESTDIR)$(PREFIX)/share/btop
 	@printf "\033[1;92mInstalling themes to: \033[1;97m$(DESTDIR)$(PREFIX)/share/btop/themes\033[0m\n"
 	@cp -pr themes $(DESTDIR)$(PREFIX)/share/btop
 	@printf "\033[1;92mInstalling desktop entry to: \033[1;97m$(DESTDIR)$(PREFIX)/share/applications/btop.desktop\033[0m\n"


### PR DESCRIPTION
According to the Linux Standard Base (LSB), README files should be installed in the /usr/share/doc directory. By convention however the README files should not go there 'bare', but in a subdirectory for each program.

Install to $(PREFIX)/share/doc/btop/README.md to comply with this.

To ensure the 'themes' is copied as a full directory and not individual files, create the /usr/share/btop in a separate step as the doc installation step no longer does it.

Ths was originally submitted in https://github.com/aristocratos/btop/pull/715 but that never got finalized and merged.