### PR TITLE
Fix: Always collect GPU data when cpu_graph_lower = "Auto"

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -523,7 +523,9 @@ namespace Runner {
 			#ifdef GPU_SUPPORT
 				//? GPU data collection
 				const bool gpu_in_cpu_panel = Gpu::gpu_names.size() > 0 and (
-					Config::getS("cpu_graph_lower").starts_with("gpu-") or Config::getS("cpu_graph_upper").starts_with("gpu-")
+					Config::getS("cpu_graph_lower").starts_with("gpu-")
+					or (Config::getS("cpu_graph_lower") == "Auto")
+					or Config::getS("cpu_graph_upper").starts_with("gpu-")
 					or (Gpu::shown == 0 and Config::getS("show_gpu_info") != "Off")
 				);
 


### PR DESCRIPTION
Fixes: #1368 
Btop sometimes wasn't collecting GPU data when `cpu-graph_lower` option was set to `Auto`, which defaulted to `gpu_totals`.