### PR TITLE
docs: add entry to man page and README for --themes-dir addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ The user themes directory depends on which environment variables are set:
 The `make install` command places the default themes in `[$PREFIX or /usr/local]/share/btop/themes`.
 User created themes should be placed in the user themes directory.
 
+Use the `--themes-dir` command-line option to specify a custom themes directory.
+When specified, this directory takes priority over the default search paths.
+
 Let me know if you want to contribute with new themes.
 
 ## Support and funding

--- a/manpage.md
+++ b/manpage.md
@@ -8,7 +8,7 @@ btop - Resource monitor that shows usage and stats for processor, memory, disks,
 
 # SYNOPSIS
 
-**btop** [**-c**] [**-d**] [**-l**] [**-t**] [**-p** _id_] [**-u** _ms_] [**\-\-force-utf**]
+**btop** [**-c**] [**-d**] [**-l**] [**-t**] [**-p** _id_] [**-u** _ms_] [**\-\-force-utf**] [**\-\-themes-dir** _dir_]
 
 **btop** [{**-h** | **\-\-help**} | {**-V** | **\-\-version**}]
 
@@ -44,6 +44,9 @@ starting with two dashes ('-'). A summary of options is included below.
 
 **\-\-tty-off**
 :   Force disable tty mode.
+
+**\-\-themes-dir _dir_**
+:   Path to a custom themes directory. When specified, this directory takes priority over the default theme search paths.
 
 **-u**, **\-\-update _ms_**
 :   Set an initial update rate in milliseconds.


### PR DESCRIPTION
Adds documentation updates for the `--themes-dir` flag addition from #1357
- Add man page entry
- Update README.md to include the flag in the themes section