### PR TITLE
themes: load/save by name if possible

### DIFF
--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -34,6 +34,9 @@ tab-size = 4
 #include <iostream>
 #include <unordered_map>
 #include <utility>
+#include <ranges>
+#include <algorithm>
+#include <iterator>
 
 #include <fmt/format.h>
 
@@ -1513,25 +1516,53 @@ static int optionsMenu(const string& key) {
 			}
 			else if (selPred.test(isBrowsable)) {
 				auto& optList = optionsList.at(option).get();
-				int i = v_index(optList, Config::getS(option));
+				int i = -1;
+				if (option == "color_theme") {
+					const auto current_theme = Config::getS(option);
+					const auto it = std::ranges::find_if(optList, [&](const auto& p) {
+						return (p == current_theme or fs::path(p).filename().string() == current_theme);
+					});
+					if (it != optList.end()) i = std::distance(optList.begin(), it);
+					else i = optList.size();
+				}
+				else {
+					i = v_index(optList, Config::getS(option));
+				}
 
 				if ((key == "right" or (vim_keys and key == "l")) and ++i >= (int)optList.size()) i = 0;
 				else if ((key == "left" or (vim_keys and key == "h")) and --i < 0) i = optList.size() - 1;
-				Config::set(option, optList.at(i));
 
-				if (option == "color_theme")
+				if (option == "color_theme") {
+					const auto theme_path = fs::path(optList.at(i));
+					const auto theme_filename = theme_path.filename().string();
+					
+					//? Check if the selected theme is the first one that matches this filename (handling shadowing)
+					const auto first_match = std::ranges::find_if(optList, [&](const string& p) {
+						return fs::path(p).filename().string() == theme_filename;
+					});
+
+					if (first_match != optList.end() and *first_match == optList.at(i))
+						Config::set(option, theme_filename);
+					else
+						Config::set(option, theme_path.string());
+					
 					theme_refresh = true;
-				else if (option == "log_level") {
-					Logger::set_log_level(optList.at(i));
-					Logger::info("Logger set to {}", optList.at(i));
 				}
-				else if (option == "base_10_bitrate") {
-				    recollect = true;
+				else {
+					Config::set(option, optList.at(i));
+
+					if (option == "log_level") {
+						Logger::set_log_level(optList.at(i));
+						Logger::info("Logger set to {}", optList.at(i));
+					}
+					else if (option == "base_10_bitrate") {
+						recollect = true;
+					}
+					else if (is_in(option, "proc_sorting", "cpu_sensor", "show_gpu_info") or option.starts_with("graph_symbol") or option.starts_with("cpu_graph_"))
+						screen_redraw = true;
+					else if (option == "disable_presets" and optList.at(i) != "Off")
+						Config::current_preset.reset();
 				}
-				else if (is_in(option, "proc_sorting", "cpu_sensor", "show_gpu_info") or option.starts_with("graph_symbol") or option.starts_with("cpu_graph_"))
-					screen_redraw = true;
-				else if (option == "disable_presets" and optList.at(i) != "Off")
-					Config::current_preset.reset();
 			}
 			else
 				retval = NoChange;
@@ -1613,11 +1644,31 @@ static int optionsMenu(const string& key) {
 				const auto& option = categories[selected_cat][i][0];
 				const auto& value = (option == "color_theme" ? fs::path(Config::getS("color_theme")).stem().string() : Config::getAsString(option));
 
+				string idx_str;
+				if (c-1 == selected and selPred.test(isBrowsable)) {
+					const auto& optList = optionsList.at(option).get();
+					int idx = 0;
+					if (option == "color_theme") {
+						const auto current_theme = Config::getS(option);
+						const auto current_theme_path = fs::path(current_theme);
+						const auto it = std::ranges::find_if(optList, [&](const string& p) {
+							const auto p_path = fs::path(p);
+							//? Match against full path, filename, stem or legacy absolute path
+							return p == current_theme 
+								or p_path.filename() == current_theme 
+								or p_path.stem() == current_theme
+								or (current_theme_path.is_absolute() and current_theme_path.filename() == p_path.filename());
+						});
+						if (it != optList.end()) idx = std::distance(optList.begin(), it);
+						else idx = optList.size();
+					} else {
+						idx = v_index(optList, value);
+					}
+					idx_str = " " + to_string(idx + 1) + '/' + to_string(optList.size());
+				}
+
 				out += Mv::to(cy++, x + 1) + (c-1 == selected ? Theme::c("selected_bg") + Theme::c("selected_fg") : Theme::c("title"))
-					+ Fx::b + cjust(capitalize(s_replace(option, "_", " "))
-						+ (c-1 == selected and selPred.test(isBrowsable)
-							? ' ' + to_string(v_index(optionsList.at(option).get(), (option == "color_theme" ? Config::getS("color_theme") : value)) + 1) + '/' + to_string(optionsList.at(option).get().size())
-							: ""), 29);
+					+ Fx::b + cjust(capitalize(s_replace(option, "_", " ")) + idx_str, 29);
 				out	+= Mv::to(cy++, x + 1) + (c-1 == selected ? "" : Theme::c("main_fg")) + Fx::ub + "  "
 					+ (c-1 == selected and editing ? cjust(editor(24), 34, true) : cjust(value, 25, true)) + "  ";
 

--- a/src/btop_theme.cpp
+++ b/src/btop_theme.cpp
@@ -19,6 +19,7 @@ tab-size = 4
 #include <cmath>
 #include <fstream>
 #include <unistd.h>
+#include <algorithm>
 
 #include "btop_config.hpp"
 #include "btop_log.hpp"
@@ -440,13 +441,20 @@ namespace Theme {
 			}
 		}
 
+		//? Sort themes alphabetically
+		std::stable_sort(themes.begin() + 2, themes.end(), [](const string& a, const string& b) {
+			return fs::path(a).filename().string() < fs::path(b).filename().string();
+		});
+
 	}
 
 	void setTheme() {
 		const auto& theme = Config::getS("color_theme");
+		const auto theme_cfg_path = fs::path(theme);
 		fs::path theme_path;
 		for (const fs::path p : themes) {
-			if (p == theme or p.stem() == theme or p.filename() == theme) {
+			//? Check for match by full path, filename, stem or legacy absolute path
+			if (p == theme or p.filename() == theme or p.stem() == theme or (theme_cfg_path.is_absolute() and theme_cfg_path.filename() == p.filename())) {
 				theme_path = p;
 				break;
 			}


### PR DESCRIPTION
This fixes #443 and a downstream issue in nixpkgs: https://github.com/NixOS/nixpkgs/issues/460344

Short description of the latter issue: I nixpkgs, different versions of btop are installed under different paths. If a user selects a theme and it is saved to the config by its absolute path, that path will be broken after an update.

To solve this, we allow writing the theme name only into the config, and we save the theme by name if possible.

When selecting a theme, we check if it is the first (with respect to the load oder priority: custom > user > system) match for this filename in the list of available themes. If it is, we save it by filename instead of using the full path. If there is another theme with the same name and higher priority, we save using the full path.

This should also be compatible with the previous behavior of being able to load themes by name from $XDG_CONFIG_PATH/btop/themes.