### PR TITLE
Fix: humanized units shortening

### DIFF
--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -463,16 +463,20 @@ namespace Tools {
 		}
 
 		if (shorten) {
-			auto f_pos = out.find(".");
-			if (f_pos == 1 and out.size() > 3) {
+			auto has_sep = out.find(".") != string::npos;
+			if (has_sep) {
 				out = fmt::format("{:.1f}", stod(out));
 			}
-			else if (f_pos != string::npos) {
-				out = fmt::format("{:.0f}", stod(out));
-			}
 			if (out.size() > 3) {
-				out = fmt::format("{:d}.0", out[0] - '0');
-				start++;
+				// if out is of the form xy.z
+				if (has_sep) {
+					out = fmt::format("{:.0f}", stod(out));
+				}
+				// if out is of the form xyzw (only when not using base 10)
+				else {
+					out = fmt::format("{:d}.0", out[0] - '0');
+					start++;
+				}
 			}
 			out.push_back(units[start][0]);
 		}

--- a/src/btop_tools.hpp
+++ b/src/btop_tools.hpp
@@ -349,9 +349,9 @@ namespace Tools {
 	string sec_to_dhms(size_t seconds, bool no_days = false, bool no_seconds = false);
 
 	//* Scales up in steps of 1024 to highest positive value unit and returns string with unit suffixed
-	//* bit=True or defaults to bytes
+	//* bit=true or defaults to bytes
 	//* start=int to set 1024 multiplier starting unit
-	//* short=True always returns 0 decimals and shortens unit to 1 character
+	//* shorten=true shortens value to at most 3 characters and shortens unit to 1 character
 	string floating_humanizer(uint64_t value, bool shorten = false, size_t start = 0, bool bit = false, bool per_second = false);
 
 	//* Add std::string operator * : Repeat string <str> <n> number of times


### PR DESCRIPTION
Fixes #1371 
First commit removes some unreachable code. (Please let me know if  this should be split off into its own PR).
Second commit fixes the formatting issue. It correctly shortens `9.99` to `10` without bumping up the unit, and preserves the shortening of other numbers as before.