### PR TITLE
refactor: use `fmt::format` like interface for logger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(libbtop OBJECT
   src/btop_config.cpp
   src/btop_draw.cpp
   src/btop_input.cpp
+  src/btop_log.cpp
   src/btop_menu.cpp
   src/btop_shared.cpp
   src/btop_theme.cpp

--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -30,6 +30,7 @@ tab-size = 4
 #include <sys/statvfs.h>
 
 #include "btop_config.hpp"
+#include "btop_log.hpp"
 #include "btop_shared.hpp"
 #include "btop_tools.hpp"
 

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -26,15 +26,16 @@ tab-size = 4
 #include <string_view>
 #include <utility>
 
-#include "btop_draw.hpp"
-#include "btop_config.hpp"
-#include "btop_theme.hpp"
-#include "btop_shared.hpp"
-#include "btop_tools.hpp"
-#include "btop_input.hpp"
-#include "btop_menu.hpp"
 #include <fmt/format.h>
 
+#include "btop_config.hpp"
+#include "btop_draw.hpp"
+#include "btop_input.hpp"
+#include "btop_log.hpp"
+#include "btop_menu.hpp"
+#include "btop_shared.hpp"
+#include "btop_theme.hpp"
+#include "btop_tools.hpp"
 
 using std::array;
 using std::clamp;
@@ -229,7 +230,7 @@ namespace Draw {
 				c_upos = ulen(first);
 			}
 			catch (const std::exception& e) {
-				Logger::error("In TextEdit::operator() : " + string{e.what()});
+				Logger::error("In TextEdit::operator() : {}", e.what());
 				return "";
 			}
 		}

--- a/src/btop_log.cpp
+++ b/src/btop_log.cpp
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "btop_log.hpp"
+
+#include "btop_shared.hpp"
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <ios>
+#include <iterator>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+#include <fmt/base.h>
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+#include <fmt/std.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+namespace Logger {
+	namespace {
+		constexpr auto ONE_MEGABYTE = 1024 << 10;
+
+		struct State {
+			std::mutex lock {};
+			std::once_flag print_header;
+			Level level = Level::ERROR;
+			std::optional<fs::path> path {};
+		};
+
+		[[nodiscard]] auto get_state() -> State& {
+			static State state;
+			return state;
+		}
+
+		auto rotate_log_file(fs::path& path) {
+			std::error_code errc {};
+			if (fs::exists(path, errc) && !errc && fs::file_size(path, errc) > ONE_MEGABYTE && !errc) {
+				auto old_path = path;
+				old_path += ".1";
+				if (fs::exists(old_path, errc) && !errc) {
+					fs::remove(old_path, errc);
+				}
+				if (!errc) {
+					fs::rename(path, old_path, errc);
+				}
+			}
+			return !errc;
+		}
+
+		class DropPrivilegeGuard {
+		private:
+			uid_t saved_euid {};
+
+		public:
+			DropPrivilegeGuard() {
+				saved_euid = geteuid();
+				auto real_uid = getuid();
+				if (saved_euid != real_uid && seteuid(real_uid) != 0) {
+					throw std::runtime_error(
+						fmt::format("Failed to drop privileges to write log file: {}", strerror(errno))
+					);
+				}
+			}
+
+			~DropPrivilegeGuard() noexcept {
+				if (saved_euid != geteuid()) {
+					// Silently drop error status.
+					seteuid(saved_euid);
+				}
+			}
+
+			DropPrivilegeGuard(const DropPrivilegeGuard&) = delete;
+			DropPrivilegeGuard& operator=(const DropPrivilegeGuard&) = delete;
+		};
+	} // namespace
+
+	void init(const fs::path& path) {
+		auto& state = get_state();
+		std::lock_guard guard { state.lock };
+		state.path = std::make_optional(path);
+	}
+
+	void set_log_level(Level level) {
+		auto& state = get_state();
+		std::lock_guard guard { state.lock };
+		state.level = level;
+	}
+
+	void set_log_level(const std::string_view level) {
+		auto& state = get_state();
+		auto it = std::ranges::find(log_levels, level);
+		if (it != log_levels.end()) {
+			std::lock_guard guard { state.lock };
+			state.level = static_cast<Level>(std::distance(log_levels.begin(), it));
+		}
+	}
+
+	namespace detail {
+		[[nodiscard]] auto is_enabled(Level level) -> bool {
+			auto& state = get_state();
+			return state.level >= level && state.path.has_value();
+		}
+
+		void log_write(Level level, const std::string_view msg) {
+			auto& state = get_state();
+
+			auto guard = std::lock_guard { state.lock };
+
+			if (!is_enabled(level) || !state.path.has_value()) {
+				return;
+			}
+
+			std::string buffer {};
+			std::call_once(state.print_header, [&buffer]() {
+				fmt::format_to(std::back_inserter(buffer), "\n===> btop++ v{}\n", Global::Version);
+			});
+			auto now = std::chrono::system_clock::now();
+			auto seconds = std::chrono::time_point_cast<std::chrono::seconds>(now);
+			fmt::format_to(
+				std::back_inserter(buffer),
+				"{:%F (%T)} | {}: {}\n",
+				seconds,
+				log_levels.at(std::to_underlying(level)),
+				msg
+			);
+
+			DropPrivilegeGuard privilege_guard {};
+
+			auto& path = state.path.value();
+			if (!rotate_log_file(path)) {
+				return;
+			}
+
+			auto file = std::ofstream { path, std::ios::app };
+			if (!file.is_open()) {
+				return;
+			}
+			file << buffer;
+		}
+	} // namespace detail
+
+} // namespace Logger

--- a/src/btop_log.hpp
+++ b/src/btop_log.hpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+#include <fmt/std.h>
+
+namespace Logger {
+	enum class Level : std::uint8_t {
+		DISABLED = 0,
+		ERROR = 1,
+		WARNING = 2,
+		INFO = 3,
+		DEBUG = 4,
+	};
+
+	const std::vector<std::string> log_levels { "DISABLED", "ERROR", "WARNING", "INFO", "DEBUG" };
+
+	namespace detail {
+		auto is_enabled(Level level) -> bool;
+
+		void log_write(Level level, const std::string_view msg);
+	} // namespace detail
+
+	void init(const std::filesystem::path& path);
+
+	void set_log_level(Level level);
+
+	void set_log_level(const std::string_view level);
+
+	template<typename... T>
+	inline void error(fmt::format_string<T...> fmt, T&&... args) {
+		// Check if log level is enabled before allocating string.
+		if (detail::is_enabled(Level::ERROR)) {
+			detail::log_write(Level::ERROR, fmt::format(fmt, std::forward<T>(args)...));
+		}
+	}
+
+	template<typename... T>
+	inline void warning(fmt::format_string<T...> fmt, T&&... args) {
+		// Check if log level is enabled before allocating string.
+		if (detail::is_enabled(Level::WARNING)) {
+			detail::log_write(Level::WARNING, fmt::format(fmt, std::forward<T>(args)...));
+		}
+	}
+
+	template<typename... T>
+	inline void info(fmt::format_string<T...> fmt, T&&... args) {
+		// Check if log level is enabled before allocating string.
+		if (detail::is_enabled(Level::INFO)) {
+			detail::log_write(Level::INFO, fmt::format(fmt, std::forward<T>(args)...));
+		}
+	}
+
+	template<typename... T>
+	inline void debug(fmt::format_string<T...> fmt, T&&... args) {
+		// Check if log level is enabled before allocating string.
+		if (detail::is_enabled(Level::DEBUG)) {
+			detail::log_write(Level::DEBUG, fmt::format(fmt, std::forward<T>(args)...));
+		}
+	}
+} // namespace Logger

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -20,6 +20,7 @@ tab-size = 4
 
 #include "btop_config.hpp"
 #include "btop_draw.hpp"
+#include "btop_log.hpp"
 #include "btop_shared.hpp"
 #include "btop_theme.hpp"
 #include "btop_tools.hpp"
@@ -1447,8 +1448,8 @@ static int optionsMenu(const string& key) {
 				if (option == "color_theme")
 					theme_refresh = true;
 				else if (option == "log_level") {
-					Logger::set(optList.at(i));
-					Logger::info("Logger set to " + optList.at(i));
+					Logger::set_log_level(optList.at(i));
+					Logger::info("Logger set to {}", optList.at(i));
 				}
 				else if (option == "base_10_bitrate") {
 				    recollect = true;

--- a/src/btop_theme.cpp
+++ b/src/btop_theme.cpp
@@ -20,9 +20,10 @@ tab-size = 4
 #include <fstream>
 #include <unistd.h>
 
-#include "btop_tools.hpp"
 #include "btop_config.hpp"
+#include "btop_log.hpp"
 #include "btop_theme.hpp"
+#include "btop_tools.hpp"
 
 using std::round;
 using std::stoi;
@@ -158,7 +159,7 @@ namespace Theme {
 			hexa.erase(0, 1);
 			for (auto& c : hexa) {
 				if (not isxdigit(c)) {
-					Logger::error("Invalid hex value: " + hexa);
+					Logger::error("Invalid hex value: {}", hexa);
 					return "";
 				}
 			}
@@ -186,9 +187,9 @@ namespace Theme {
 						to_string(stoi(hexa.substr(4, 2), nullptr, 16)) + "m";
 				}
 			}
-			else Logger::error("Invalid size of hex value: " + hexa);
+			else Logger::error("Invalid size of hex value: {}", hexa);
 		}
-		else Logger::error("Hex value missing: " + hexa);
+		else Logger::error("Hex value missing: {}", hexa);
 		return "";
 	}
 
@@ -257,7 +258,7 @@ namespace Theme {
 					else if (not source.at(name).empty()) {
 						t_rgb = ssplit(source.at(name));
 						if (t_rgb.size() != 3) {
-							Logger::error("Invalid RGB decimal value: \"" + source.at(name) + "\"");
+							Logger::error("Invalid RGB decimal value: \"{}\"", source.at(name));
 						} else {
 							colors[name] = dec_to_color(stoi(t_rgb[0]), stoi(t_rgb[1]), stoi(t_rgb[2]), t_to_256, depth);
 							rgbs[name] = array{stoi(t_rgb[0]), stoi(t_rgb[1]), stoi(t_rgb[2])};
@@ -266,7 +267,7 @@ namespace Theme {
 					}
 				}
 				if (not colors.contains(name) and not is_in(name, "meter_bg", "process_start", "process_mid", "process_end", "graph_text")) {
-					Logger::debug("Missing color value for \"" + name + "\". Using value from default.");
+					Logger::debug("Missing color value for \"{}\". Using value from default.", name);
 					colors[name] = hex_to_color(color, t_to_256, depth);
 					rgbs[name] = hex_to_dec(color);
 				}
@@ -382,7 +383,7 @@ namespace Theme {
 			std::ifstream themefile(filepath);
 			if (themefile.good()) {
 				std::unordered_map<string, string> theme_out;
-				Logger::debug("Loading theme file: " + filename);
+				Logger::debug("Loading theme file: {}", filename);
 				while (not themefile.bad()) {
 					if (themefile.peek() == '#') {
 						themefile.ignore(SSmax, '\n');

--- a/src/btop_tools.hpp
+++ b/src/btop_tools.hpp
@@ -49,8 +49,10 @@ tab-size = 4
 	#endif
 #endif
 
-#include "fmt/core.h"
-#include "fmt/format.h"
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+#include "btop_log.hpp"
 
 using std::array;
 using std::atomic;
@@ -153,47 +155,6 @@ namespace Term {
 
 	//* Restore terminal options
 	void restore();
-}
-
-//* Simple logging implementation
-namespace Logger {
-	const vector<string> log_levels = {
-		"DISABLED",
-		"ERROR",
-		"WARNING",
-		"INFO",
-		"DEBUG",
-	};
-	extern std::optional<std::filesystem::path> logfile;
-
-	enum Level : std::uint8_t {
-		DISABLED = 0,
-		ERROR = 1,
-		WARNING = 2,
-		INFO = 3,
-		DEBUG = 4,
-	};
-
-	//* Set log level, valid arguments: "DISABLED", "ERROR", "WARNING", "INFO" and "DEBUG"
-	void set(const string& level);
-
-	void log_write(const Level level, const std::string_view msg);
-
-	inline void error(const std::string_view msg) {
-		log_write(ERROR, msg);
-	}
-
-	inline void warning(const std::string_view msg) {
-		log_write(WARNING, msg);
-	}
-
-	inline void info(const std::string_view msg) {
-		log_write(INFO, msg);
-	}
-
-	inline void debug(const std::string_view msg) {
-		log_write(DEBUG, msg);
-	}
 }
 
 //? --------------------------------------------------- FUNCTIONS -----------------------------------------------------
@@ -363,7 +324,7 @@ namespace Tools {
 		if (auto it = map.find(key); it != map.end()) {
 			return it->second;
 		} else {
-			Logger::error(fmt::format("safeVal() called with invalid key: [{}] in file: {} on line: {}", key, loc.file_name(), loc.line()));
+			Logger::error("safeVal() called with invalid key: [{}] in file: {} on line: {}", key, loc.file_name(), loc.line());
 			return fallback;
 		}
 	};
@@ -372,7 +333,7 @@ namespace Tools {
 		if (auto it = map.find(key); it != map.end()) {
 			return it->second;
 		} else {
-			Logger::error(fmt::format("safeVal() called with invalid key: [{}] (Compile btop with DEBUG=true for more extensive logging!)", key));
+			Logger::error("safeVal() called with invalid key: [{}] (Compile btop with DEBUG=true for more extensive logging!)", key);
 			return fallback;
 		}
 	};
@@ -384,7 +345,7 @@ namespace Tools {
 		if (index < vec.size()) {
 			return vec[index];
 		} else {
-			Logger::error(fmt::format("safeVal() called with invalid index: [{}] in file: {} on line: {}", index, loc.file_name(), loc.line()));
+			Logger::error("safeVal() called with invalid index: [{}] in file: {} on line: {}", index, loc.file_name(), loc.line());
 			return fallback;
 		}
 	};
@@ -393,7 +354,7 @@ namespace Tools {
 		if (index < vec.size()) {
 			return vec[index];
 		} else {
-			Logger::error(fmt::format("safeVal() called with invalid index: [{}] (Compile btop with DEBUG=true for more extensive logging!)", index));
+			Logger::error("safeVal() called with invalid index: [{}] (Compile btop with DEBUG=true for more extensive logging!)", index);
 			return fallback;
 		}
 	};
@@ -457,7 +418,6 @@ namespace Tools {
 		vector<string> report_buffer{};
 		string name{};
 		bool delayed_report{};
-		Logger::Level log_level = Logger::DEBUG;
 	public:
 		DebugTimer() = default;
 		explicit DebugTimer(string name, bool start = true, bool delayed_report = true);

--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -61,7 +61,10 @@ tab-size = 4
 #include <utility>
 #include <unordered_set>
 
+#include <fmt/format.h>
+
 #include "../btop_config.hpp"
+#include "../btop_log.hpp"
 #include "../btop_shared.hpp"
 #include "../btop_tools.hpp"
 
@@ -413,8 +416,8 @@ namespace Cpu {
 				if (cpu.core_percent.at(i).size() > 40) cpu.core_percent.at(i).pop_front();
 
 			} catch (const std::exception &e) {
-				Logger::error("Cpu::collect() : " + (string)e.what());
-				throw std::runtime_error("collect() : " + (string)e.what());
+				Logger::error("Cpu::collect() : {}", e.what());
+				throw std::runtime_error(fmt::format("collect() : {}", e.what()));
 			}
 
 		}
@@ -517,7 +520,7 @@ namespace Mem {
 			size_t len = 512;
 			if (fgets(poolName, len, poolPipe())) {
 				poolName[strcspn(poolName, "\n")] = 0;
-				Logger::debug("zpool found: " + string(poolName));
+				Logger::debug("zpool found: {}", poolName);
 				Mem::zpools.push_back(std::regex_replace(poolName, toReplace, "%25"));
 			}
 		}
@@ -542,7 +545,7 @@ namespace Mem {
 						devstat_compute_statistics(&d, nullptr, etime, DSM_TOTAL_BYTES_READ, &total_bytes_read, DSM_TOTAL_BYTES_WRITE, &total_bytes_write, DSM_NONE);
 						assign_values(disk, total_bytes_read, total_bytes_write);
 						string mountpoint = mapping.at(disk.dev);
-						Logger::debug("dev " + devStatName + " -> " + mountpoint  + " read=" + std::to_string(total_bytes_read) + " write=" + std::to_string(total_bytes_write));
+						Logger::debug("dev {} -> {} read={} write={}", devStatName, mountpoint, total_bytes_read, total_bytes_write);
 					}
 				}
 
@@ -731,7 +734,7 @@ namespace Mem {
 					continue;
 				struct statvfs vfs;
 				if (statvfs(mountpoint.c_str(), &vfs) < 0) {
-					Logger::warning("Failed to get disk/partition stats with statvfs() for: " + mountpoint);
+					Logger::warning("Failed to get disk/partition stats with statvfs() for: {}", mountpoint);
 					continue;
 				}
 				disk.total = vfs.f_blocks * vfs.f_frsize;
@@ -799,7 +802,7 @@ namespace Net {
 			IfAddrsPtr if_addrs {};
 			if (if_addrs.get_status() != 0) {
 				errors++;
-				Logger::error("Net::collect() -> getifaddrs() failed with id " + to_string(if_addrs.get_status()));
+				Logger::error("Net::collect() -> getifaddrs() failed with id {}", if_addrs.get_status());
 				redraw = true;
 				return empty_net;
 			}
@@ -834,7 +837,7 @@ namespace Net {
 							net[iface].ipv4 = ip;
 						} else {
 							int errsv = errno;
-							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface {}, errno: {}", iface, strerror(errsv));
 						}
 					}
 				}
@@ -845,7 +848,7 @@ namespace Net {
 							net[iface].ipv6 = ip;
 						} else {
 							int errsv = errno;
-							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface {}, errno: {}", iface, strerror(errsv));
 						}
 					}
 				}  //else, ignoring family==AF_LINK (see man 3 getifaddrs)

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -40,6 +40,9 @@ tab-size = 4
 #include <sys/statvfs.h>
 #include <unistd.h>
 
+#include <fmt/format.h>
+#include <fmt/std.h>
+
 #if defined(RSMI_STATIC)
 	#include <rocm_smi/rocm_smi.h>
 #endif
@@ -48,8 +51,9 @@ tab-size = 4
 	#include <pwd.h>
 #endif
 
-#include "../btop_shared.hpp"
 #include "../btop_config.hpp"
+#include "../btop_log.hpp"
+#include "../btop_shared.hpp"
 #include "../btop_tools.hpp"
 
 #if defined(GPU_SUPPORT)
@@ -680,7 +684,7 @@ namespace Cpu {
 			if (++failed < 5)
 				return ""s;
 			else {
-				Logger::warning("get_cpuHZ() : " + string{e.what()});
+				Logger::warning("get_cpuHZ() : {}", e.what());
 				return ""s;
 			}
 		}
@@ -1147,7 +1151,7 @@ namespace Cpu {
 
 			//? Notify main thread to redraw screen if we found more cores than previously detected
 			if (cmp_greater(cpu.core_percent.size(), Shared::coreCount)) {
-				Logger::debug("Changing CPU max corecount from " + to_string(Shared::coreCount) + " to " + to_string(cpu.core_percent.size()) + ".");
+				Logger::debug("Changing CPU max corecount from {} to {}.", Shared::coreCount, cpu.core_percent.size());
 				Runner::coreNum_reset = true;
 				Shared::coreCount = cpu.core_percent.size();
 				while (cmp_less(current_cpu.temp.size(), cpu.core_percent.size() + 1)) current_cpu.temp.push_back({0});
@@ -1155,9 +1159,9 @@ namespace Cpu {
 
 		}
 		catch (const std::exception& e) {
-			Logger::debug("Cpu::collect() : " + string{e.what()});
+			Logger::debug("Cpu::collect() : {}", e.what());
 			if (cread.bad()) throw std::runtime_error("Failed to read /proc/stat");
-			else throw std::runtime_error("Cpu::collect() : " + string{e.what()});
+			else throw std::runtime_error(fmt::format("Cpu::collect() : {}", e.what()));
 		}
 
 		if (Config::getB("check_temp") and got_sensors)
@@ -1196,7 +1200,7 @@ namespace Gpu {
 				}
 			}
  			if (!nvml_dl_handle) {
-				Logger::info("Failed to load libnvidia-ml.so, NVIDIA GPUs will not be detected: "s + dlerror());
+				Logger::info("Failed to load libnvidia-ml.so, NVIDIA GPUs will not be detected: {}", dlerror());
  				return false;
  			}
 
@@ -1204,7 +1208,7 @@ namespace Gpu {
 				auto sym = dlsym(nvml_dl_handle, sym_name);
 				auto err = dlerror();
 				if (err != nullptr) {
-					Logger::error(string("NVML: Couldn't find function ") + sym_name + ": " + err);
+					Logger::error("NVML: Couldn't find function {}: {}", sym_name, err);
 					return (void*)nullptr;
 				} else return sym;
 			};
@@ -1234,14 +1238,14 @@ namespace Gpu {
 			//? Function calls
 			nvmlReturn_t result = nvmlInit();
     		if (result != NVML_SUCCESS) {
-    			Logger::debug(std::string("Failed to initialize NVML, NVIDIA GPUs will not be detected: ") + nvmlErrorString(result));
+    			Logger::debug("Failed to initialize NVML, NVIDIA GPUs will not be detected: {}", nvmlErrorString(result));
     			return false;
     		}
 
 			//? Device count
 			result = nvmlDeviceGetCount(&device_count);
     		if (result != NVML_SUCCESS) {
-    			Logger::warning(std::string("NVML: Failed to get device count: ") + nvmlErrorString(result));
+    			Logger::warning("NVML: Failed to get device count: {}", nvmlErrorString(result));
     			return false;
     		}
 
@@ -1265,7 +1269,7 @@ namespace Gpu {
 			if (NVML_SUCCESS == result) {
 				initialized = false;
 				dlclose(nvml_dl_handle);
-			} else Logger::warning(std::string("Failed to shutdown NVML: ") + nvmlErrorString(result));
+			} else Logger::warning("Failed to shutdown NVML: {}", nvmlErrorString(result));
 
 			return !initialized;
 		}
@@ -1282,7 +1286,7 @@ namespace Gpu {
 					//? Device Handle
     				result = nvmlDeviceGetHandleByIndex(i, devices.data() + i);
         			if (result != NVML_SUCCESS) {
-    					Logger::warning(std::string("NVML: Failed to get device handle: ") + nvmlErrorString(result));
+    					Logger::warning("NVML: Failed to get device handle: {}", nvmlErrorString(result));
 						gpus[i].supported_functions = {false, false, false, false, false, false, false, false, false, false};
     					continue;
         			}
@@ -1291,7 +1295,7 @@ namespace Gpu {
 					char name[NVML_DEVICE_NAME_BUFFER_SIZE];
     				result = nvmlDeviceGetName(devices[i], name, NVML_DEVICE_NAME_BUFFER_SIZE);
         			if (result != NVML_SUCCESS)
-    					Logger::warning(std::string("NVML: Failed to get device name: ") + nvmlErrorString(result));
+    					Logger::warning("NVML: Failed to get device name: {}", nvmlErrorString(result));
         			else {
         				gpu_names[i] = string(name);
         				for (const auto& brand : {"NVIDIA", "Nvidia", "(R)", "(TM)"}) {
@@ -1304,7 +1308,7 @@ namespace Gpu {
     				unsigned int max_power;
     				result = nvmlDeviceGetPowerManagementLimit(devices[i], &max_power);
     				if (result != NVML_SUCCESS)
-						Logger::warning(std::string("NVML: Failed to get maximum GPU power draw, defaulting to 225W: ") + nvmlErrorString(result));
+						Logger::warning("NVML: Failed to get maximum GPU power draw, defaulting to 225W: {}", nvmlErrorString(result));
 					else {
 						gpus[i].pwr_max_usage = max_power; // RSMI reports power in microWatts
 						gpu_pwr_total_max += max_power;
@@ -1314,7 +1318,7 @@ namespace Gpu {
 					unsigned int temp_max;
     				result = nvmlDeviceGetTemperatureThreshold(devices[i], NVML_TEMPERATURE_THRESHOLD_SHUTDOWN, &temp_max);
         			if (result != NVML_SUCCESS)
-    					Logger::warning(std::string("NVML: Failed to get maximum GPU temperature, defaulting to 110°C: ") + nvmlErrorString(result));
+    					Logger::warning("NVML: Failed to get maximum GPU temperature, defaulting to 110°C: {}", nvmlErrorString(result));
     				else gpus[i].temp_max = (long long)temp_max;
 				}
 
@@ -1324,7 +1328,7 @@ namespace Gpu {
 						unsigned int tx;
 						nvmlReturn_t result = nvmlDeviceGetPcieThroughput(devices[i], NVML_PCIE_UTIL_TX_BYTES, &tx);
     					if (result != NVML_SUCCESS) {
-							Logger::warning(std::string("NVML: Failed to get PCIe TX throughput: ") + nvmlErrorString(result));
+							Logger::warning("NVML: Failed to get PCIe TX throughput: {}", nvmlErrorString(result));
 							if constexpr(is_init) gpus_slice[i].supported_functions.pcie_txrx = false;
 						} else gpus_slice[i].pcie_tx = (long long)tx;
 					});
@@ -1333,7 +1337,7 @@ namespace Gpu {
 						unsigned int rx;
 						nvmlReturn_t result = nvmlDeviceGetPcieThroughput(devices[i], NVML_PCIE_UTIL_RX_BYTES, &rx);
     					if (result != NVML_SUCCESS) {
-							Logger::warning(std::string("NVML: Failed to get PCIe RX throughput: ") + nvmlErrorString(result));
+							Logger::warning("NVML: Failed to get PCIe RX throughput: {}", nvmlErrorString(result));
 						} else gpus_slice[i].pcie_rx = (long long)rx;
 					});
 				}
@@ -1344,7 +1348,7 @@ namespace Gpu {
 					nvmlUtilization_t utilization;
 					result = nvmlDeviceGetUtilizationRates(devices[i], &utilization);
     				if (result != NVML_SUCCESS) {
-						Logger::warning(std::string("NVML: Failed to get GPU utilization: ") + nvmlErrorString(result));
+						Logger::warning("NVML: Failed to get GPU utilization: {}", nvmlErrorString(result));
 						if constexpr(is_init) gpus_slice[i].supported_functions.gpu_utilization = false;
 						if constexpr(is_init) gpus_slice[i].supported_functions.mem_utilization = false;
     				} else {
@@ -1359,7 +1363,7 @@ namespace Gpu {
 					unsigned int gpu_clock;
 					result = nvmlDeviceGetClockInfo(devices[i], NVML_CLOCK_GRAPHICS, &gpu_clock);
     				if (result != NVML_SUCCESS) {
-						Logger::warning(std::string("NVML: Failed to get GPU clock speed: ") + nvmlErrorString(result));
+						Logger::warning("NVML: Failed to get GPU clock speed: {}", nvmlErrorString(result));
 						if constexpr(is_init) gpus_slice[i].supported_functions.gpu_clock = false;
 					} else gpus_slice[i].gpu_clock_speed = (long long)gpu_clock;
 				}
@@ -1368,7 +1372,7 @@ namespace Gpu {
 					unsigned int mem_clock;
 					result = nvmlDeviceGetClockInfo(devices[i], NVML_CLOCK_MEM, &mem_clock);
     				if (result != NVML_SUCCESS) {
-						Logger::warning(std::string("NVML: Failed to get VRAM clock speed: ") + nvmlErrorString(result));
+						Logger::warning("NVML: Failed to get VRAM clock speed: {}", nvmlErrorString(result));
 						if constexpr(is_init) gpus_slice[i].supported_functions.mem_clock = false;
 					} else gpus_slice[i].mem_clock_speed = (long long)mem_clock;
 				}
@@ -1379,7 +1383,7 @@ namespace Gpu {
     				unsigned int power;
     				result = nvmlDeviceGetPowerUsage(devices[i], &power);
     				if (result != NVML_SUCCESS) {
-						Logger::warning(std::string("NVML: Failed to get GPU power usage: ") + nvmlErrorString(result));
+						Logger::warning("NVML: Failed to get GPU power usage: {}", nvmlErrorString(result));
 						if constexpr(is_init) gpus_slice[i].supported_functions.pwr_usage = false;
     				} else {
     					gpus_slice[i].pwr_usage = (long long)power;
@@ -1393,7 +1397,7 @@ namespace Gpu {
 					nvmlPstates_t pState;
     				result = nvmlDeviceGetPowerState(devices[i], &pState);
     				if (result != NVML_SUCCESS) {
-						Logger::warning(std::string("NVML: Failed to get GPU power state: ") + nvmlErrorString(result));
+						Logger::warning("NVML: Failed to get GPU power state: {}", nvmlErrorString(result));
 						if constexpr(is_init) gpus_slice[i].supported_functions.pwr_state = false;
     				} else gpus_slice[i].pwr_state = static_cast<int>(pState);
     			}
@@ -1405,7 +1409,7 @@ namespace Gpu {
 						unsigned int temp;
 						nvmlReturn_t result = nvmlDeviceGetTemperature(devices[i], NVML_TEMPERATURE_GPU, &temp);
     					if (result != NVML_SUCCESS) {
-							Logger::warning(std::string("NVML: Failed to get GPU temperature: ") + nvmlErrorString(result));
+							Logger::warning("NVML: Failed to get GPU temperature: {}", nvmlErrorString(result));
 							if constexpr(is_init) gpus_slice[i].supported_functions.temp_info = false;
     					} else gpus_slice[i].temp.push_back((long long)temp);
 					}
@@ -1417,7 +1421,7 @@ namespace Gpu {
 					nvmlMemory_t memory;
 					result = nvmlDeviceGetMemoryInfo(devices[i], &memory);
     				if (result != NVML_SUCCESS) {
-						Logger::warning(std::string("NVML: Failed to get VRAM info: ") + nvmlErrorString(result));
+						Logger::warning("NVML: Failed to get VRAM info: {}", nvmlErrorString(result));
 						if constexpr(is_init) gpus_slice[i].supported_functions.mem_total = false;
 						if constexpr(is_init) gpus_slice[i].supported_functions.mem_used = false;
 					} else {
@@ -1437,7 +1441,7 @@ namespace Gpu {
 					unsigned int samplingPeriodUs;
 					result = nvmlDeviceGetEncoderUtilization(devices[i], &utilization, &samplingPeriodUs);
 					if (result != NVML_SUCCESS) {
-						Logger::warning(std::string("NVML: Failed to get encoder utilization: ") + nvmlErrorString(result));
+						Logger::warning("NVML: Failed to get encoder utilization: {}", nvmlErrorString(result));
 						if constexpr(is_init) gpus_slice[i].supported_functions.encoder_utilization = false;
 					} else gpus_slice[i].encoder_utilization = (long long)utilization;
 				}
@@ -1449,7 +1453,7 @@ namespace Gpu {
 					unsigned int samplingPeriodUs;
 					result = nvmlDeviceGetDecoderUtilization(devices[i], &utilization, &samplingPeriodUs);
 					if (result != NVML_SUCCESS) {
-						Logger::warning(std::string("NVML: Failed to get decoder utilization: ") + nvmlErrorString(result));
+						Logger::warning("NVML: Failed to get decoder utilization: {}", nvmlErrorString(result));
 						if constexpr(is_init) gpus_slice[i].supported_functions.decoder_utilization = false;
 					} else gpus_slice[i].decoder_utilization = (long long)utilization;
 				}
@@ -1459,7 +1463,7 @@ namespace Gpu {
     				nvmlProcessInfo_t* proc_info = 0;
     				result = nvmlDeviceGetComputeRunningProcesses_v3(device, &proc_info_len, proc_info);
     				if (result != NVML_SUCCESS) {
-						Logger::warning(std::string("NVML: Failed to get compute processes: ") + nvmlErrorString(result));
+						Logger::warning("NVML: Failed to get compute processes: {}", nvmlErrorString(result));
     				} else {
     					for (unsigned int i = 0; i < proc_info_len; ++i)
     						gpus_slice[i].graphics_processes.push_back({proc_info[i].pid, proc_info[i].usedGpuMemory});
@@ -1505,7 +1509,7 @@ namespace Gpu {
  			}
 
 			if (!rsmi_dl_handle) {
-				Logger::info("Failed to load librocm_smi64.so, AMD GPUs will not be detected: "s + dlerror());
+				Logger::info("Failed to load librocm_smi64.so, AMD GPUs will not be detected: {}", dlerror());
 				return false;
 			}
 
@@ -1513,7 +1517,7 @@ namespace Gpu {
 				auto sym = dlsym(rsmi_dl_handle, sym_name);
 				auto err = dlerror();
 				if (err != nullptr) {
-					Logger::error(string("ROCm SMI: Couldn't find function ") + sym_name + ": " + err);
+					Logger::error("ROCm SMI: Couldn't find function {}: {}", sym_name, err);
 					return (void*)nullptr;
 				} else return sym;
 			};
@@ -2225,7 +2229,7 @@ namespace Mem {
 									} else if (fstype == "zfs") {
 										disks.at(mountpoint).stat = get_zfs_stat_file(dev, zfs_dataset_name_start, zfs_hide_datasets);
 										if (disks.at(mountpoint).stat.empty()) {
-											Logger::debug("Failed to get ZFS stat file for device " + dev);
+											Logger::debug("Failed to get ZFS stat file for device {}", dev);
 										}
 										break;
 									}
@@ -2239,7 +2243,7 @@ namespace Mem {
 								|| (!zfs_hide_datasets && is_directory(disks.at(mountpoint).stat)))) {
 								disks.at(mountpoint).stat = get_zfs_stat_file(dev, zfs_dataset_name_start, zfs_hide_datasets);
 								if (disks.at(mountpoint).stat.empty()) {
-									Logger::debug("Failed to get ZFS stat file for device " + dev);
+									Logger::debug("Failed to get ZFS stat file for device {}", dev);
 								}
 							}
 						}
@@ -2277,7 +2281,7 @@ namespace Mem {
 						auto promise_res = promises_it->second.get();
 						if(promise_res.second != -1){
 							ignore_list.push_back(mountpoint);
-							Logger::warning("Failed to get disk/partition stats for mount \""+ mountpoint + "\" with statvfs error code: " + to_string(promise_res.second) + ". Ignoring...");
+							Logger::warning("Failed to get disk/partition stats for mount \"{}\" with statvfs error code: {}. Ignoring...", mountpoint, promise_res.second);
 							it = disks.erase(it);
 							continue;
 						}
@@ -2412,14 +2416,14 @@ namespace Mem {
 							while (cmp_greater(disk.io_activity.size(), width * 2)) disk.io_activity.pop_front();
 						}
 					} else {
-						Logger::debug("Error in Mem::collect() : when opening " + string{disk.stat});
+						Logger::debug("Error in Mem::collect() : when opening {}", disk.stat);
 					}
 					diskread.close();
 				}
 				old_uptime = uptime;
 			}
 			catch (const std::exception& e) {
-				Logger::warning("Error in Mem::collect() : " + string{e.what()});
+				Logger::warning("Error in Mem::collect() : {}", e.what());
 			}
 		}
 
@@ -2433,7 +2437,7 @@ namespace Mem {
 			if (access(zfs_pool_stat_path.c_str(), R_OK) == 0) {
 				return zfs_pool_stat_path;
 			} else {
-				Logger::debug("Can't access folder: " + zfs_pool_stat_path.string());
+				Logger::debug("Can't access folder: {}", zfs_pool_stat_path);
 				return "";
 			}
 		}
@@ -2465,7 +2469,7 @@ namespace Mem {
 							if (access(file.path().c_str(), R_OK) == 0) {
 								return file.path();
 							} else {
-								Logger::debug("Can't access file: " + file.path().string());
+								Logger::debug("Can't access file: {}", file.path());
 								return "";
 							}
 						}
@@ -2476,7 +2480,7 @@ namespace Mem {
 		}
 		catch (fs::filesystem_error& e) {}
 
-		Logger::debug("Could not read directory: " + zfs_pool_stat_path.string());
+		Logger::debug("Could not read directory: {}", zfs_pool_stat_path);
 		return "";
 	}
 
@@ -2525,7 +2529,7 @@ namespace Mem {
 					// increment read objects counter if no errors were encountered
 					objects_read++;
 				} else {
-					Logger::debug("Could not read file: " + file.path().string());
+					Logger::debug("Could not read file: {}", file.path());
 				}
 				diskread.close();
 			}
@@ -2584,7 +2588,7 @@ namespace Net {
 			IfAddrsPtr if_addrs {};
 			if (if_addrs.get_status() != 0) {
 				errors++;
-				Logger::error("Net::collect() -> getifaddrs() failed with id " + to_string(if_addrs.get_status()));
+				Logger::error("Net::collect() -> getifaddrs() failed with id {}", if_addrs.get_status());
 				redraw = true;
 				return empty_net;
 			}
@@ -2621,7 +2625,7 @@ namespace Net {
 							net[iface].ipv4 = ip;
 						} else {
 							int errsv = errno;
-							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface {}, errno: {}", iface, strerror(errsv));
 						}
 					}
 				}
@@ -2632,7 +2636,7 @@ namespace Net {
 							net[iface].ipv6 = ip;
 						} else {
 							int errsv = errno;
-							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface {}, errno: {}", iface, strerror(errsv));
 						}
 					}
 				} //else, ignoring family==AF_PACKET (see man 3 getifaddrs) which is the first one in the `for` loop.
@@ -3309,6 +3313,6 @@ namespace Tools {
 			catch (const std::invalid_argument&) {}
 			catch (const std::out_of_range&) {}
 		}
-        throw std::runtime_error("Failed to get uptime from " + string{Shared::procPath} + "/uptime");
+        throw std::runtime_error(fmt::format("Failed to get uptime from {}", Shared::procPath / "uptime"));
 	}
 }

--- a/src/netbsd/btop_collect.cpp
+++ b/src/netbsd/btop_collect.cpp
@@ -68,7 +68,10 @@ tab-size = 4
 #include <utility>
 #include <unordered_set>
 
+#include <fmt/format.h>
+
 #include "../btop_config.hpp"
+#include "../btop_log.hpp"
 #include "../btop_shared.hpp"
 #include "../btop_tools.hpp"
 
@@ -232,7 +235,7 @@ namespace Cpu {
 
 		int fd = open(_PATH_SYSMON, O_RDONLY);
 		if (fd == -1) {
-			Logger::warning("failed to open " + string(_PATH_SYSMON));
+			Logger::warning("failed to open {}", _PATH_SYSMON);
 			return got_sensors;
 		}
 
@@ -255,7 +258,7 @@ namespace Cpu {
 		for(const string &sensor : sensors) {
 			fields_array = prop_dictionary_get(prop_dictionary_t(dict), sensor.c_str());
 			if (prop_object_type(fields_array) != PROP_TYPE_ARRAY) {
-				Logger::warning("unknown device " + sensor);
+				Logger::warning("unknown device {}", sensor);
 			} else {
 				Cpu::cpu_sensor = sensor;
 				break;
@@ -281,7 +284,7 @@ namespace Cpu {
 
 		int fd = open(_PATH_SYSMON, O_RDONLY);
 		if (fd == -1) {
-			Logger::warning("failed to open " + string(_PATH_SYSMON));
+			Logger::warning("failed to open {}", _PATH_SYSMON);
 			return;
 		}
 
@@ -302,7 +305,7 @@ namespace Cpu {
 
 		prop_object_t fields_array = prop_dictionary_get(prop_dictionary_t(dict), Cpu::cpu_sensor.c_str());
 		if (prop_object_type(fields_array) != PROP_TYPE_ARRAY) {
-			Logger::warning("unknown device " + Cpu::cpu_sensor);
+			Logger::warning("unknown device {}", Cpu::cpu_sensor);
 			return;
 		}
 
@@ -429,7 +432,7 @@ namespace Cpu {
 
 		int fd = open(_PATH_SYSMON, O_RDONLY);
 		if (fd == -1) {
-			Logger::warning("failed to open " + string(_PATH_SYSMON));
+			Logger::warning("failed to open {}", _PATH_SYSMON);
 			has_battery = false;
 			return {0, 0.0, 0, ""};
 		}
@@ -575,9 +578,9 @@ namespace Cpu {
 				//? Reduce size if there are more values than needed for graph
 				if (cpu.core_percent.at(i).size() > 40) cpu.core_percent.at(i).pop_front();
 
-			} catch (const std::exception &e) {
-				Logger::error("Cpu::collect() : " + (string)e.what());
-				throw std::runtime_error("collect() : " + (string)e.what());
+			} catch (const std::exception& e) {
+				Logger::error("Cpu::collect() : {}", e.what());
+				throw std::runtime_error(fmt::format("collect() : {}", e.what()));
 			}
 
 		}
@@ -824,7 +827,7 @@ namespace Mem {
 					continue;
 				struct statvfs vfs;
 				if (statvfs(mountpoint.c_str(), &vfs) < 0) {
-					Logger::warning("Failed to get disk/partition stats with statvfs() for: " + mountpoint);
+					Logger::warning("Failed to get disk/partition stats with statvfs() for: {}", mountpoint);
 					continue;
 				}
 				disk.total = vfs.f_blocks * vfs.f_frsize;
@@ -892,7 +895,7 @@ namespace Net {
 			IfAddrsPtr if_addrs {};
 			if (if_addrs.get_status() != 0) {
 				errors++;
-				Logger::error("Net::collect() -> getifaddrs() failed with id " + to_string(if_addrs.get_status()));
+				Logger::error("Net::collect() -> getifaddrs() failed with id {}", if_addrs.get_status());
 				redraw = true;
 				return empty_net;
 			}
@@ -927,7 +930,7 @@ namespace Net {
 							net[iface].ipv4 = ip;
 						} else {
 							int errsv = errno;
-							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface {}, errno: {}", iface, strerror(errsv));
 						}
 					}
 				}
@@ -938,7 +941,7 @@ namespace Net {
 							net[iface].ipv6 = ip;
 						} else {
 							int errsv = errno;
-							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface {}, errno: {}", iface, strerror(errsv));
 						}
 					}
 				}  //else, ignoring family==AF_LINK (see man 3 getifaddrs)

--- a/src/openbsd/btop_collect.cpp
+++ b/src/openbsd/btop_collect.cpp
@@ -64,7 +64,10 @@ tab-size = 4
 #include <memory>
 #include <unordered_set>
 
+#include <fmt/format.h>
+
 #include "../btop_config.hpp"
+#include "../btop_log.hpp"
 #include "../btop_shared.hpp"
 #include "../btop_tools.hpp"
 
@@ -435,8 +438,8 @@ namespace Cpu {
 				if (cpu.core_percent.at(i).size() > 40) cpu.core_percent.at(i).pop_front();
 
 			} catch (const std::exception &e) {
-				Logger::error("Cpu::collect() : " + (string)e.what());
-				throw std::runtime_error("collect() : " + (string)e.what());
+				Logger::error("Cpu::collect() : {}", e.what());
+				throw std::runtime_error(fmt::format("collect() : {}", e.what()));
 			}
 
 		}
@@ -689,7 +692,7 @@ namespace Mem {
 					continue;
 				struct statvfs vfs;
 				if (statvfs(mountpoint.c_str(), &vfs) < 0) {
-					Logger::warning("Failed to get disk/partition stats with statvfs() for: " + mountpoint);
+					Logger::warning("Failed to get disk/partition stats with statvfs() for: {}", mountpoint);
 					continue;
 				}
 				disk.total = vfs.f_blocks * vfs.f_frsize;
@@ -757,7 +760,7 @@ namespace Net {
 			IfAddrsPtr if_addrs {};
 			if (if_addrs.get_status() != 0) {
 				errors++;
-				Logger::error("Net::collect() -> getifaddrs() failed with id " + to_string(if_addrs.get_status()));
+				Logger::error("Net::collect() -> getifaddrs() failed with id {}", if_addrs.get_status());
 				redraw = true;
 				return empty_net;
 			}
@@ -792,7 +795,7 @@ namespace Net {
 							net[iface].ipv4 = ip;
 						} else {
 							int errsv = errno;
-							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface {}, errno: {}", iface, strerror(errsv));
 						}
 					}
 				}
@@ -803,7 +806,7 @@ namespace Net {
 							net[iface].ipv6 = ip;
 						} else {
 							int errsv = errno;
-							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface {}, errno: {}", iface, strerror(errsv));
 						}
 					}
 				}  //else, ignoring family==AF_LINK (see man 3 getifaddrs)

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -56,7 +56,10 @@ tab-size = 4
 #include <string>
 #include <unordered_set>
 
+#include <fmt/format.h>
+
 #include "../btop_config.hpp"
+#include "../btop_log.hpp"
 #include "../btop_shared.hpp"
 #include "../btop_tools.hpp"
 
@@ -218,7 +221,7 @@ namespace Cpu {
 	}
 
 	bool get_sensors() {
-		Logger::debug("get_sensors(): show_coretemp=" + std::to_string(Config::getB("show_coretemp")) + " check_temp=" + std::to_string(Config::getB("check_temp")));
+		Logger::debug("get_sensors(): show_coretemp={} check_temp={}", Config::getB("show_coretemp"), Config::getB("check_temp"));
 		got_sensors = false;
 		if (Config::getB("show_coretemp") and Config::getB("check_temp")) {
 #if __MAC_OS_X_VERSION_MIN_REQUIRED > 101504
@@ -252,7 +255,7 @@ namespace Cpu {
 						got_sensors = false;
 					}
 				} catch (std::runtime_error &e) {
-					Logger::debug("SMC not available: " + string(e.what()));
+					Logger::debug("SMC not available: {}", e.what());
 					// ignore, we don't have temp (common in VMs)
 					got_sensors = false;
 				}
@@ -474,8 +477,8 @@ namespace Cpu {
 				if (cpu.core_percent.at(i).size() > 40) cpu.core_percent.at(i).pop_front();
 
 			} catch (const std::exception &e) {
-				Logger::error("Cpu::collect() : " + (string)e.what());
-				throw std::runtime_error("collect() : " + (string)e.what());
+				Logger::error("Cpu::collect() : {}", e.what());
+				throw std::runtime_error(fmt::format("collect() : {}", e.what()));
 			}
 		}
 
@@ -758,7 +761,7 @@ namespace Mem {
 					continue;
 				struct statvfs vfs;
 				if (statvfs(mountpoint.c_str(), &vfs) < 0) {
-					Logger::warning("Failed to get disk/partition stats with statvfs() for: " + mountpoint);
+					Logger::warning("Failed to get disk/partition stats with statvfs() for: {}", mountpoint);
 					continue;
 				}
 				disk.total = vfs.f_blocks * vfs.f_frsize;
@@ -839,7 +842,7 @@ namespace Net {
 			getifaddr_wrapper if_wrap{};
 			if (if_wrap.status != 0) {
 				errors++;
-				Logger::error("Net::collect() -> getifaddrs() failed with id " + to_string(if_wrap.status));
+				Logger::error("Net::collect() -> getifaddrs() failed with id {}", if_wrap.status);
 				redraw = true;
 				return empty_net;
 			}
@@ -872,7 +875,7 @@ namespace Net {
 							net[iface].ipv4 = ip;
 						} else {
 							int errsv = errno;
-							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+							Logger::error("Net::collect() -> Failed to convert IPv4 to string for iface {}, errno: {}", iface, strerror(errsv));
 						}
 					}
 				}
@@ -883,7 +886,7 @@ namespace Net {
 							net[iface].ipv6 = ip;
 						} else {
 							int errsv = errno;
-							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface " + string(iface) + ", errno: " + strerror(errsv));
+							Logger::error("Net::collect() -> Failed to convert IPv6 to string for iface {}, errno: {}", iface, strerror(errsv));
 						}
 					}
 				} // else, ignoring family==AF_LINK (see man 3 getifaddrs)


### PR DESCRIPTION
This will only allocate the log message if a log file exists and the log level is enabled. The interface forwards it's arguments to `fmt::format`. This gets also rid of some global state and hides it in the `btop_log.cpp` translation unit.

Closes: https://github.com/aristocratos/btop/issues/1347