### PR TITLE
feat(linux): add Intel Xe GPU driver support

### DIFF
--- a/src/linux/intel_gpu_top/intel_gpu_top.h
+++ b/src/linux/intel_gpu_top/intel_gpu_top.h
@@ -92,4 +92,7 @@ char* find_intel_gpu_dir();
 char* get_intel_device_id(const char* vendor_path);
 char *get_intel_device_name(const char *device_id);
 
+const char *find_xe_pmu_device(char *buf, int buflen);
+const char *find_i915_pmu_device(char *buf, int buflen);
+
 #endif


### PR DESCRIPTION
## Summary

Add support for Intel Xe GPU driver (Lunar Lake, etc). #1407 

## Changes

- Add dynamic PMU device discovery (`find_xe_pmu_device`, `find_i915_pmu_device`)
  - Supports both `xe` and `xe_XXXX_XX_XX.X` PMU device names
- Add Xe PMU event constants (`XE_PMU_ENGINE_ACTIVE_TICKS`, etc.)
- Add Xe-specific engine discovery in `discover_engines()`
- Add `pmu_init_xe()` for Xe PMU initialization
- Change hardcoded `"i915"` device to dynamic detection
- Add Xe-specific utilization calculation (`active_ticks / total_ticks`)
- Add power availability check for GPUs without RAPL `energy-gpu`

## Tests

- [x] Tested on Intel Lunar Lake (Core Ultra 5 228V, device ID 0x64A0)
- [x] Build succeeds
- [x] GPU utilization and frequency display correctly
- [ ] i915 systems (no hardware available, but code path unchanged)
