### PR TITLE
btop_collect.cpp: fix regression from a switch to kIOMainPortDefault

### DIFF
--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -65,6 +65,10 @@ tab-size = 4
 #endif
 #include "smc.hpp"
 
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 120000
+#define kIOMainPortDefault kIOMasterPortDefault
+#endif
+
 using std::clamp, std::string_literals::operator""s, std::cmp_equal, std::cmp_less, std::cmp_greater;
 using std::ifstream, std::numeric_limits, std::streamsize, std::round, std::max, std::min;
 namespace fs = std::filesystem;


### PR DESCRIPTION
Fix breakage from https://github.com/aristocratos/btop/commit/85f4f0ec503a24db724300bbea0524ce4d15e795