### PR TITLE
Fix hide and info buttons

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1776,7 +1776,8 @@ namespace Proc {
 			int mouse_x = x + 14;
 			out += Mv::to(y + height - 1, x + 1) + title_left_down + Fx::b + hi_color + Symbols::up + Theme::c("title") + " select " + down_button + Fx::ub + title_right_down
 				+ title_left_down + Fx::b + t_color + "info " + hi_color + Symbols::enter + Fx::ub + title_right_down;
-				if (selected > 0) Input::mouse_mappings["enter"] = {y + height - 1, mouse_x, 1, 6};
+				if (selected > 0) Input::mouse_mappings["info_enter"] = {y + height - 1, mouse_x, 1, 6};
+				else Input::mouse_mappings.erase("info_enter");
 				mouse_x += 8;
 			if (width > 60) {
 				out += title_left_down + Fx::b + hi_color + 't' + t_color + "erminate" + Fx::ub + title_right_down;
@@ -2042,6 +2043,7 @@ namespace Proc {
 				greyed_out ? "" : Theme::c("hi_fg"), Symbols::enter,
 				Fx::ub, Theme::c("proc_box"), Symbols::title_right);
 			if (not greyed_out) Input::mouse_mappings["enter"] = {d_y, d_x + d_width - 9, 1, 6};
+			else Input::mouse_mappings.erase("enter");
 		}
 
 		if (selected == 0 and selected_pid != 0) {

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -403,7 +403,7 @@ namespace Input {
 					else
 						keep_going = true;
 				}
-				else if (key == "enter") {
+				else if (is_in(key, "enter", "info_enter")) {
 					if (Config::getI("proc_selected") == 0 and not Config::getB("show_detailed")) {
 						return;
 					}


### PR DESCRIPTION
Fixes: #1428 

This is my fault from when I made a change to allow the hide button to not be greyed out when the detailed view item was selected in the list.

I didn't realize that this deactivated the info button on the bottom bar from operating at the same time that the hide button in the detailed view is enabled.

to fix this I have adding an additinal mouse mapping called "info_enter". If there is another way to have 2 mouse mappings for the same key that is preferrable to this I can do that instead.

Additionally I didn't realize that to disable a mouse mapping you have to 'erase' it so the hide button was continuing to act as a button even when greyed out if at any point the detailed view process was selected while detailed view was open.