### PR TITLE
Change color of 'tab' in options menu for parity

### DIFF
--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -1314,7 +1314,7 @@ static int optionsMenu(const string& key) {
 			height = min(Term::height - 7, max_items * 2 + 4);
 			if (height % 2 != 0) height--;
 			bg 	= Draw::banner_gen(y, 0, true)
-				+ Draw::createBox(x, y + 6, 78, height, Theme::c("hi_fg"), true, Theme::c("hi_fg") + "tab" + Theme::c("main_fg") + Symbols::right)
+				+ Draw::createBox(x, y + 6, 78, height, Theme::c("hi_fg"), true, fmt::format("{}tab{}", Theme::c("hi_fg"), Theme::c("main_fg")) + Symbols::right)
 				+ Mv::to(y+8, x) + Theme::c("hi_fg") + Symbols::div_left + Theme::c("div_line") + Symbols::h_line * 29
 				+ Symbols::div_up + Symbols::h_line * (78 - 32) + Theme::c("hi_fg") + Symbols::div_right
 				+ Mv::to(y+6+height - 1, x+30) + Symbols::div_down + Theme::c("div_line");


### PR DESCRIPTION
This PR changes the color of the word "tab" in the top left corner of the options menu. This is to keep parity with other keyboard shortcut "indicators", which are highlighted in blue to let the user know that pressing that key will do an action.
Also note that the arrow intersecting the box symbols is a quirk of my font, and this change did not cause that. :)

Before change:
<img width="691" height="845" alt="image" src="https://github.com/user-attachments/assets/08f54a85-eb2f-45cb-8885-786956589b3c" />


After change:
<img width="691" height="845" alt="image" src="https://github.com/user-attachments/assets/054e1bf4-d2f8-488f-92bc-e9f28f523f20" />
