### PR TITLE
ci: enable manual triggering of cmake workflows

### DIFF
--- a/.github/workflows/cmake-freebsd.yml
+++ b/.github/workflows/cmake-freebsd.yml
@@ -1,6 +1,7 @@
 name: FreeBSD CMake
 
 on:
+  workflow_dispatch:
   push:
     branches: main
     tags-ignore: '*.*'

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -1,6 +1,7 @@
 name: Linux CMake
 
 on:
+  workflow_dispatch:
   push:
     branches: main
     tags-ignore: '*.*'

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -1,6 +1,7 @@
 name: macOS CMake
 
 on:
+  workflow_dispatch:
   push:
     branches: main
     tags-ignore: '*.*'

--- a/.github/workflows/cmake-netbsd.yml
+++ b/.github/workflows/cmake-netbsd.yml
@@ -1,6 +1,7 @@
 name: NetBSD CMake
 
 on:
+  workflow_dispatch:
   push:
     branches: main
     tags-ignore: '*.*'

--- a/.github/workflows/cmake-openbsd.yml
+++ b/.github/workflows/cmake-openbsd.yml
@@ -1,6 +1,7 @@
 name: OpenBSD CMake
 
 on:
+  workflow_dispatch:
   push:
     branches: main
     tags-ignore: '*.*'


### PR DESCRIPTION
It's enabled for make-based workflows, it's always nice to have, and I could've used it recently.