### PR TITLE
Update clock with preset change or show/hide box

### DIFF
--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -255,6 +255,7 @@ namespace Input {
 					}
 					Config::current_preset = -1;
 					Draw::calcSizes();
+					Draw::update_clock(true);
 					Runner::run("all", false, true);
 					return;
 				}
@@ -273,6 +274,7 @@ namespace Input {
 						return;
 					}
 					Draw::calcSizes();
+					Draw::update_clock(true);
 					Runner::run("all", false, true);
 					return;
 				} else if (is_in(key, "ctrl_r")) {


### PR DESCRIPTION
Fixes: #1490 

This change updates the clock when the presets are cycled or a box is opened or closed. 

This prevents the clock from vanishing briefly while cycling the presets or opening the cpu box.

of some relevence the code in `btop.cpp` for when the Terminal resizes also have `Draw::update_clock(true)` called after `Draw::calcSizes()` and as expected the clock doesn't vanish when you resize the terminal window

```
if (Global::resized) {
	Draw::calcSizes();
	Draw::update_clock(true);
	Global::resized = false;
	if (Menu::active) Menu::process();
	else Runner::run("all", true, true);
	atomic_wait_for(Runner::active, true, 1000);
}
```