### PR TITLE
Feat: Preset disabling options

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -191,7 +191,7 @@ void term_resize(bool force) {
 					if (intKey > 0 and intKey < 5) {
 				#endif
 						const auto& box = all_boxes.at(intKey);
-						Config::current_preset = -1;
+						Config::current_preset.reset();
 						Config::toggle_box(box);
 						boxes = Config::getS("shown_boxes");
 					}
@@ -1104,7 +1104,7 @@ static auto configure_tty_mode(std::optional<bool> force_tty) {
 	Config::presetsValid(Config::getS("presets"));
 	if (cli.preset.has_value()) {
 		Config::current_preset = min(static_cast<std::int32_t>(cli.preset.value()), static_cast<std::int32_t>(Config::preset_list.size() - 1));
-		Config::apply_preset(Config::preset_list.at(Config::current_preset));
+		Config::apply_preset(Config::preset_list.at(Config::current_preset.value()));
 	}
 
 	{

--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -65,6 +65,12 @@ namespace Config {
 		{"force_tty", 			"#* Set to true to force tty mode regardless if a real tty has been detected or not.\n"
 								"#* Will force 16-color mode and TTY theme, set all graph symbols to \"tty\" and swap out other non tty friendly symbols."},
 
+		{"disable_presets",		"#* Option to disable presets. Either the default preset, custom presets, or all presets.\n"
+								"#* \"Off\" All presets are enabled.\n"
+								"#* \"Default\" preset is disabled."
+								"#* \"Custom\" presets are disabled."
+								"#* \"All\" presets are disabled."},
+
 		{"presets",				"#* Define presets for the layout of the boxes. Preset 0 is always all boxes shown with default settings. Max 9 presets.\n"
 								"#* Format: \"box_name:P:G,box_name:P:G\" P=(0 or 1) for alternate positions, G=graph symbol to use for box.\n"
 								"#* Use whitespace \" \" as separator between different presets.\n"
@@ -247,6 +253,7 @@ namespace Config {
 		{"color_theme", "Default"},
 		{"shown_boxes", "cpu mem net proc"},
 		{"graph_symbol", "braille"},
+		{"disable_presets", "Off"},
 		{"presets", "cpu:1:default,proc:0:default cpu:0:default,mem:0:default,net:0:default cpu:0:block,net:0:tty"},
 		{"graph_symbol_cpu", "default"},
 		{"graph_symbol_gpu", "default"},
@@ -442,7 +449,7 @@ namespace Config {
 
 	vector<string> current_boxes;
 	vector<string> preset_list = {"cpu:0:default,mem:0:default,net:0:default,proc:0:default"};
-	int current_preset = -1;
+	std::optional<int> current_preset;
 
 	bool presetsValid(const string& presets) {
 		vector<string> new_presets = {preset_list.at(0)};

--- a/src/btop_config.hpp
+++ b/src/btop_config.hpp
@@ -59,8 +59,9 @@ namespace Config {
     const vector<string> base_10_bitrate_values = { "Auto", "True", "False" };
 	extern vector<string> current_boxes;
 	extern vector<string> preset_list;
+	const vector<string> disable_preset_options = { "Off", "Default", "Custom", "All" };
 	extern vector<string> available_batteries;
-	extern int current_preset;
+	extern std::optional<int> current_preset;
 
 	extern bool write_new;
 

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -594,7 +594,7 @@ namespace Cpu {
 			out += Mv::to(button_y, x + 10) + title_left + Theme::c("hi_fg") + Fx::b + 'm' + Theme::c("title") + "enu" + Fx::ub + title_right;
 			Input::mouse_mappings["m"] = {button_y, x + 11, 1, 4};
 			out += Mv::to(button_y, x + 16) + title_left + Theme::c("hi_fg") + Fx::b + 'p' + Theme::c("title") + "reset "
-				+ (Config::current_preset < 0 ? "*" : to_string(Config::current_preset)) + Fx::ub + title_right;
+				+ (!Config::current_preset.has_value() ? "*" : to_string(Config::current_preset.value())) + Fx::ub + title_right;
 			Input::mouse_mappings["p"] = {button_y, x + 17, 1, 8};
 			const string update = to_string(Config::getI("update_ms")) + "ms";
 			out += Mv::to(button_y, x + width - update.size() - 8) + title_left + Fx::b + Theme::c("hi_fg") + "- " + Theme::c("title") + update

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -263,6 +263,16 @@ namespace Menu {
 				"is accessible while holding shift."},
 			{"disable_mouse",
 				"Disable all mouse events."},
+			{"disable_presets",
+				"Disable the presets.",
+				"",
+				"\"Off\" All presets are enabled.",
+				"",
+				"\"Default\" preset is disabled.",
+				"",
+				"\"Custom\" presets are disabled.",
+				"",
+				"\"All\" presets are disabled."},
 			{"presets",
 				"Define presets for the layout of the boxes.",
 				"",
@@ -1285,6 +1295,7 @@ static int optionsMenu(const string& key) {
 			{"cpu_sensor", std::cref(Cpu::available_sensors)},
 			{"selected_battery", std::cref(Config::available_batteries)},
 	        {"base_10_bitrate", std::cref(Config::base_10_bitrate_values)},
+			{"disable_presets", std::cref(Config::disable_preset_options)},
 		#ifdef GPU_SUPPORT
 			{"show_gpu_info", std::cref(Config::show_gpu_values)},
 			{"graph_symbol_gpu", std::cref(Config::valid_graph_symbols_def)},
@@ -1344,7 +1355,7 @@ static int optionsMenu(const string& key) {
 						screen_redraw = true;
 					else if (is_in(option, "shown_boxes", "presets")) {
 						screen_redraw = true;
-						Config::current_preset = -1;
+						Config::current_preset.reset();
 					}
 					else if (option == "clock_format") {
 						Draw::update_clock(true);
@@ -1497,6 +1508,8 @@ static int optionsMenu(const string& key) {
 				}
 				else if (is_in(option, "proc_sorting", "cpu_sensor", "show_gpu_info") or option.starts_with("graph_symbol") or option.starts_with("cpu_graph_"))
 					screen_redraw = true;
+				else if (option == "disable_presets" and optList.at(i) != "Off")
+					Config::current_preset.reset();
 			}
 			else
 				retval = NoChange;


### PR DESCRIPTION
Closes: #1132

This PR creates a menu option called `disable_presets` that allows the user to disable certain presets.

When the option is set to `Off` none of the presets are disabled. (Default Setting)

When the option is set to `Default` only the default preset is disabled.

When the option is set to `Custom` only the custom presets are disabled.

When the option is set to `All` then all of the presets are disabled.


Launching btop with the `-p [0-9]` flag will still choose the desired preset (ignoring this option)

Additionally this PR refactors `current_preset` using `std::optional` 
- Instead of no preset being `-1` it is now std::nullopt
  - preset can be reset with `Config::current_preset.reset()` instead of `Config::current_preset = -1`



As I see it this PR has several benefits.

- If a user wants to set a specific layout but doesn't want to accidentally mess it up by pressing the `p` key, they can disable all of the presets and pressing `p` will do nothing. This is equivalent to the behaviour of the preset cycling before this PR if the `presets` string was set to `""` and is how you would disable presets if that was your method before.

- If a user wants to set their own default preset then disabling only the default layout makes the first custom preset the defacto default preset. This way they can mess around with the layout (changing box positions or show/hide boxes) and press `p` once (instead of twice) to return to their custom default preset. If they have more presets defined then follow up presses will cycle through them as usual. If it is the only custom preset then further presses of `p` will do nothing and it becomes a custom default preset restore key

- If a user wants to be able to mess around with the layout but then decide that they want to return to the default preset and they also don't want to use the custom presets then disabling only the Custom presets will make a single press of the `p` key change the view to the default layout restoring it from whatever configuration they had put it in and further presses of the `p` key will do nothing. This essentially turns the `p` and `P` keys into a default preset restore key without also having to remove any custom presets that are already defined.

- And of course if the user doesn't care about any of this then having this option set to `Off` keeps the original behavior with the one difference being that if no custom presets are defined (preset string = `""`) then `p` acts as a restore default preset key instead of doing nothing like it did before. This is the default setting.