### PR TITLE
fix: set no_update and resized to true when show/hide box or preset cycle

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1562,6 +1562,7 @@ namespace Proc {
 	int user_size, thread_size, prog_size, cmd_size, tree_size;
 	int dgraph_x, dgraph_width, d_width, d_x, d_y;
 	bool previous_proc_banner_state = false;
+	atomic<bool> resized (false);
 
 	string box;
 
@@ -2206,8 +2207,10 @@ namespace Draw {
 		Global::overlay.clear();
 		Runner::pause_output = false;
 		Runner::redraw = true;
-		Proc::p_counters.clear();
-		Proc::p_graphs.clear();
+		if (not (Proc::resized or Global::resized)) {
+			Proc::p_counters.clear();
+			Proc::p_graphs.clear();
+		}
 		if (Menu::active) Menu::redraw = true;
 
 		Input::mouse_mappings.clear();

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -254,9 +254,11 @@ namespace Input {
 						return;
 					}
 					Config::current_preset = -1;
+					if (Proc::shown) Proc::resized = true;
 					Draw::calcSizes();
 					Draw::update_clock(true);
-					Runner::run("all", false, true);
+					Proc::resized = false;
+					Runner::run("all", true, true);
 					return;
 				}
 				else if (is_in(key, "p", "P") and Config::preset_list.size() > 1) {
@@ -273,9 +275,11 @@ namespace Input {
 						Config::current_preset = old_preset;
 						return;
 					}
+					if (Proc::shown) Proc::resized = true;
 					Draw::calcSizes();
 					Draw::update_clock(true);
-					Runner::run("all", false, true);
+					Proc::resized = false;
+					Runner::run("all", true, true);
 					return;
 				} else if (is_in(key, "ctrl_r")) {
 					kill(getpid(), SIGUSR2);

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -354,6 +354,7 @@ namespace Proc {
 	extern int selected_pid, start, selected, collapse, expand, filter_found, selected_depth, toggle_children;
 	extern int scroll_pos;
 	extern string selected_name;
+	extern atomic<bool> resized;
 
 	//? Contains the valid sorting options for processes
 	const vector<string> sort_vector = {


### PR DESCRIPTION
Fixes: #1497 

This prevents the graphs from updating overly fast if you hold down the preset cycle keybind or the `1`, `2`, `3`, or `4` keys.

Also if you were to just press them very quickly.

Instead the graphs update at the same rate as they are supposed to based on `update_ms`

The reason for `if(Proc::shown) Proc::resized = true;` is to prevent the clearing out of the process list cpu graphs when changing the preset or showing and hiding a box after setting `no_update` to true.

`no_update` being false allowed the process list graphs to stay visible but the update cycle happens sooner then it should based on the `update_ms` value meaning that the timescale of the graphs isn't consistent.

The use of `Global::resized` in `calcSizes()` means that the proc list graphs dont vanish briefly on a terminal window resize

<details>
<summary><b>Example Video</b></summary>

https://github.com/user-attachments/assets/c2b75f58-b905-43d2-b9ad-7e6a3545105a

</details>


