### PR TITLE
fix: metric updates with preset cycle, show/hide box, and menu toggle

### DIFF
--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -1303,7 +1303,6 @@ static int optionsMenu(const string& key) {
 			Theme::updateThemes();
 		}
 		int retval = Changed;
-		bool recollect{};
 		bool screen_redraw{};
 		bool theme_refresh{};
 
@@ -1464,9 +1463,6 @@ static int optionsMenu(const string& key) {
 				else if (option == "background_update") {
 					Runner::pause_output = false;
 				}
-				else if (option == "base_10_sizes") {
-					recollect = true;
-				}
 				else if (option == "save_config_on_exit" and not Config::getB("save_config_on_exit")) {
 					const bool old_write_new = Config::write_new;
 					Config::write_new = true;
@@ -1493,7 +1489,7 @@ static int optionsMenu(const string& key) {
 					Logger::info("Logger set to {}", optList.at(i));
 				}
 				else if (option == "base_10_bitrate") {
-				    recollect = true;
+				    screen_redraw = true;
 				}
 				else if (is_in(option, "proc_sorting", "cpu_sensor", "show_gpu_info") or option.starts_with("graph_symbol") or option.starts_with("cpu_graph_"))
 					screen_redraw = true;
@@ -1629,10 +1625,6 @@ static int optionsMenu(const string& key) {
 			Draw::calcSizes();
 			Global::overlay = std::move(overlay_bkp);
 			Global::clock = std::move(clock_bkp);
-			recollect = true;
-		}
-		if (recollect) {
-			Runner::run("all", false, true);
 			retval = NoChange;
 		}
 


### PR DESCRIPTION
Fixes: #1500

Similar to PR #1498 but also will fix the issue caused by #1498 that I somehow missed. 

I screwed up. I thought my fix for the fast metric update with preset cycle and show/hide box worked. but I forgot to take into account launching btop with the box hidden. I could have sworn I tested this but now testing again I must not have.

Working on fix now however if I can't figure one out I guess this will turn into a revert PR my apologies

toggling options in the menu causes metrics to update. if you toggle options quickly it updates the graphs overly fast. 

There is only one option in the menu that requires a collection update and that appears to be the one for the process list cpu graph symbol. I missed this before so my earlier change needs to be modified.

This rapid update issue also exists for expanding and collapsing the tree in the process list however it only updates the process list and detailed view graph overly fast so its not as huge an issue. Also I haven't figured out a way to solve this one yet as the code that handles the tree collapse and expand is inside the collect code so collect needs to be called for it to happen. 