### PR TITLE
revert: bad fix for metric updates show/hide box/presets

### DIFF
--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -254,11 +254,9 @@ namespace Input {
 						return;
 					}
 					Config::current_preset = -1;
-					if (Proc::shown) Proc::resized = true;
 					Draw::calcSizes();
 					Draw::update_clock(true);
-					Proc::resized = false;
-					Runner::run("all", true, true);
+					Runner::run("all", false, true);
 					return;
 				}
 				else if (is_in(key, "p", "P") and Config::preset_list.size() > 1) {
@@ -275,11 +273,9 @@ namespace Input {
 						Config::current_preset = old_preset;
 						return;
 					}
-					if (Proc::shown) Proc::resized = true;
 					Draw::calcSizes();
 					Draw::update_clock(true);
-					Proc::resized = false;
-					Runner::run("all", true, true);
+					Runner::run("all", false, true);
 					return;
 				} else if (is_in(key, "ctrl_r")) {
 					kill(getpid(), SIGUSR2);


### PR DESCRIPTION
Fixes: #1500

Edit: If you don't mind waiting a day or so to merge this I will try to figure out an actual fix before then. I have an idea but need some rest before I try implementing it.

I screwed up. I thought my fix for the fast metric update with preset cycle and show/hide box worked. but I forgot to take into account launching btop with a box hidden. I could have sworn I tested this but now testing again I must not have.

if btop is launched with for example the cpu box hidden. the first time it is shown (by pressing 1) the box doesn't show up correctly immediately.

This PR reverts the bad parts that were changed. Once again. Very sorry about this.

I'm sure there is a way to solve this issue though so I will keep at it. It is more complicated then I had thought though. I definitely have to come up with a completely different approach. Something that can update the box if it needs to but doesn't update it when it already has data

I left in the `Proc::resized and Global::resized` bit in `Draw::calcSizes` because that part is useful and does fix the terminal window resizing causing the proc cpu graphs to disappear briefly. And it will also be used by the variable width proc box pr if it is merged