### PR TITLE
improved fix for metric updates during view change

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -1067,6 +1067,7 @@ static auto configure_tty_mode(std::optional<bool> force_tty) {
 		Config::set_boxes("cpu mem net proc");
 		Config::set("shown_boxes", "cpu mem net proc"s);
 	}
+	Config::set_seen_boxes(Config::getS("shown_boxes"));
 
 	//? Update list of available themes and generate the selected theme
 	Theme::updateThemes();
@@ -1163,7 +1164,7 @@ static auto configure_tty_mode(std::optional<bool> force_tty) {
 
 			//? Trigger secondary thread to redraw if terminal has been resized
 			if (Global::resized) {
-				Draw::calcSizes();
+				Draw::calcSizes(false);
 				Draw::update_clock(true);
 				Global::resized = false;
 				if (Menu::active) Menu::process();

--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -440,7 +440,9 @@ namespace Config {
 
 	vector<string> available_batteries = {"Auto"};
 
+	bool did_proc_graph_symbol_change = false;
 	vector<string> current_boxes;
+	vector<string> seen_boxes;
 	vector<string> preset_list = {"cpu:0:default,mem:0:default,net:0:default,proc:0:default"};
 	int current_preset = -1;
 
@@ -509,6 +511,8 @@ namespace Config {
 			if (vals.at(0).starts_with("gpu")) {
 				set("graph_symbol_gpu", vals.at(2));
 			} else {
+				if (vals.at(0) == "proc" and getS("graph_symbol_proc") != vals.at(2))
+					did_proc_graph_symbol_change = true;
 				set(strings.find("graph_symbol_" + vals.at(0))->first, vals.at(2));
 			}
 		}
@@ -684,6 +688,20 @@ namespace Config {
 		}
 
 		locked = false;
+	}
+
+	// Add boxes to seen_boxes if they haven't been seen before
+	bool set_seen_boxes(const string& boxes) {
+		auto new_boxes = ssplit(boxes);
+		bool were_new_boxes_seen = false;
+		
+		for (auto& box : new_boxes) {
+			if (not v_contains(seen_boxes, box)) {
+				seen_boxes.push_back(box);
+				were_new_boxes_seen = true;
+			}
+		}
+		return were_new_boxes_seen;
 	}
 
 	bool set_boxes(const string& boxes) {

--- a/src/btop_config.hpp
+++ b/src/btop_config.hpp
@@ -62,11 +62,15 @@ namespace Config {
 	extern vector<string> available_batteries;
 	extern int current_preset;
 
+	extern bool did_proc_graph_symbol_change;
 	extern bool write_new;
 
 	constexpr int ONE_DAY_MILLIS = 1000 * 60 * 60 * 24;
 
 	[[nodiscard]] std::optional<std::filesystem::path> get_config_dir() noexcept;
+
+	// Add boxes to seen_boxes if they haven't been seen before
+	bool set_seen_boxes(const string& boxes);
 
 	//* Check if string only contains space separated valid names for boxes and set current_boxes
 	bool set_boxes(const string& boxes);

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1562,7 +1562,6 @@ namespace Proc {
 	int user_size, thread_size, prog_size, cmd_size, tree_size;
 	int dgraph_x, dgraph_width, d_width, d_x, d_y;
 	bool previous_proc_banner_state = false;
-	atomic<bool> resized (false);
 
 	string box;
 
@@ -2190,7 +2189,7 @@ namespace Proc {
 }
 
 namespace Draw {
-	void calcSizes() {
+	void calcSizes(const bool clear_proc_graphs) {
 		atomic_wait(Runner::active);
 		Config::unlock();
 		auto boxes = Config::getS("shown_boxes");
@@ -2207,7 +2206,7 @@ namespace Draw {
 		Global::overlay.clear();
 		Runner::pause_output = false;
 		Runner::redraw = true;
-		if (not (Proc::resized or Global::resized)) {
+		if (clear_proc_graphs) {
 			Proc::p_counters.clear();
 			Proc::p_graphs.clear();
 		}

--- a/src/btop_draw.hpp
+++ b/src/btop_draw.hpp
@@ -131,7 +131,7 @@ namespace Draw {
 	};
 
 	//* Calculate sizes of boxes, draw outlines and save to enabled boxes namespaces
-	void calcSizes();
+	void calcSizes(const bool clear_proc_graphs = true);
 }
 
 namespace Proc {

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -254,9 +254,11 @@ namespace Input {
 						return;
 					}
 					Config::current_preset = -1;
-					Draw::calcSizes();
+					Draw::calcSizes(!Proc::shown);
 					Draw::update_clock(true);
-					Runner::run("all", false, true);
+					if (Config::set_seen_boxes(boxes.at(intKey)))
+						Runner::run(boxes.at(intKey), false, false);
+					Runner::run("all", true, true);
 					return;
 				}
 				else if (is_in(key, "p", "P") and Config::preset_list.size() > 1) {
@@ -273,9 +275,14 @@ namespace Input {
 						Config::current_preset = old_preset;
 						return;
 					}
-					Draw::calcSizes();
+					Draw::calcSizes(!Proc::shown or Config::did_proc_graph_symbol_change);
+					Config::did_proc_graph_symbol_change = false;
 					Draw::update_clock(true);
-					Runner::run("all", false, true);
+					for (const auto& box : Config::current_boxes) {
+						if (Config::set_seen_boxes(box))
+							Runner::run(box, false, false);
+					}
+					Runner::run("all", true, true);
 					return;
 				} else if (is_in(key, "ctrl_r")) {
 					kill(getpid(), SIGUSR2);

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -354,7 +354,6 @@ namespace Proc {
 	extern int selected_pid, start, selected, collapse, expand, filter_found, selected_depth, toggle_children;
 	extern int scroll_pos;
 	extern string selected_name;
-	extern atomic<bool> resized;
 
 	//? Contains the valid sorting options for processes
 	const vector<string> sort_vector = {


### PR DESCRIPTION
Fixes: #1498 #1500

This PR is a better version of the previous fix that had to be reverted for the fast metric updates when show/hiding box and cycling presets.

The previous fix had an issue where if the box had not been viewed since opening btop then it would not populate all the data and the box could take longer then it should to open.

This new fix prevents that by keeping track of the boxes that have been seen since btop started. 

It also removes the global `Proc::resized` variable that was used in `Draw::calcSizes` and replaces it with a boolean argument for `Draw::calcSizes` that default to `true` if it is not included. I think this is cleaner.

<b>What this fixes:</b>
- Rapidly opening and closing a box or cycling the presets will not cause the metrics to update
- If a box has not previously been opened since btop was started then a metric update is triggered for that box when it is shown
  - <b>This prevents the issue caused by the old fix.</b>
  - It does this by running `Runner::run()` for each newly seen box with `no_update` set to false and `redraw` set to false
- If boxes are shown or hidden and the proc box is already visible. The proc cpu graphs do not briefly vanish.
  - likewise when the Terminal window is resized this does the same thing.
- Not clearing proc graphs if the proc box is still shown breaks the graphs when cycling presets if the graph symbol changes. This now clears the proc graphs if cycling presets and the proc graph symbol changes to prevent that.

<b>What this does not fix:</b>
- Toggling options rapidly in the menu continues to update metrics too fast
  - I am still working out the best solution for this.
- If the proc box was previously shown but is not shown now and then is toggled on the proc graphs do not immediately appear.
  - This happens because if the proc box is hidden then the proc graphs clear like before but when it is shown again they need time to update. 
  - I don't have a good solution for this yet.
  - I need to look more into how those graphs work to prevent it.

<details><summary><b>Example Video (Shows fix for newly opened boxes)</b></summary>

https://github.com/user-attachments/assets/18c5dc89-441a-4fbf-a183-a749bab57521

</details>