### PR TITLE
feat(osx): Apple silicon P-core/E-core support and monitoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(BTOP_LTO)
 endif()
 
 if(APPLE)
-  target_sources(libbtop PRIVATE src/osx/btop_collect.cpp src/osx/sensors.cpp src/osx/smc.cpp)
+  target_sources(libbtop PRIVATE src/osx/btop_collect.cpp src/osx/sensors.cpp src/osx/smc.cpp src/osx/ioreport.cpp)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "MidnightBSD")
   target_sources(libbtop PRIVATE src/freebsd/btop_collect.cpp)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -531,6 +531,8 @@ namespace Cpu {
 	vector<Draw::Graph> graphs_upper;
 	vector<Draw::Graph> graphs_lower;
 	Draw::Meter cpu_meter;
+#ifdef __APPLE__
+#endif
 	vector<Draw::Meter> gpu_meters;
 	vector<Draw::Graph> core_graphs;
 	vector<Draw::Graph> temp_graphs;
@@ -698,7 +700,6 @@ namespace Cpu {
 			}
 
 			cpu_meter = Draw::Meter{cpu_meter_width, "cpu"};
-
 			if (mid_line) {
 				out += Mv::to(y + graph_up_height + 1, x) + Fx::ub + Theme::c("cpu_box") + Symbols::div_left + Theme::c("div_line")
 					+ Symbols::h_line * (width - b_width - 2) + Symbols::div_right
@@ -834,6 +835,12 @@ namespace Cpu {
 					+ Symbols::h_line * ((freq_range ? 17 : 7) - cpuHz.size())
 					+ Symbols::title_left + Fx::b + Theme::c("title") + cpuHz + Fx::ub + Theme::c("div_line") + Symbols::title_right;
 
+	#ifdef __APPLE__
+		//? Skip default CPU bar if we have P/E cores - we'll draw P-CPU and E-CPU bars in the core section
+		const bool skip_cpu_bar = (Cpu::cpu_core_info.p_cores > 0 and Cpu::cpu_core_info.e_cores > 0);
+		if (not skip_cpu_bar)
+	#endif
+		{
 		out += Mv::to(b_y + 1, b_x + 1) + Theme::c("main_fg") + Fx::b + "CPU " + cpu_meter(safeVal(cpu.cpu_percent, "total"s).back())
 			+ Theme::g("cpu").at(clamp(safeVal(cpu.cpu_percent, "total"s).back(), 0ll, 100ll)) + rjust(to_string(safeVal(cpu.cpu_percent, "total"s).back()), 4) + Theme::c("main_fg") + '%';
 		if (show_temps) {
@@ -850,10 +857,11 @@ namespace Cpu {
 			string cwatts_post = "W";
 
 			max_observed_pwr = max(max_observed_pwr, cpu.usage_watts);
-			out += Theme::g("cached").at(clamp(cpu.usage_watts / max_observed_pwr * 100.0f, 0.0f, 100.0f)) + cwatts + Theme::c("main_fg") + cwatts_post; 
+			out += Theme::g("cached").at(clamp(cpu.usage_watts / max_observed_pwr * 100.0f, 0.0f, 100.0f)) + cwatts + Theme::c("main_fg") + cwatts_post;
 		}
 
 			out += Theme::c("div_line") + Symbols::v_line;
+		}
 		} catch (const std::exception& e) {
 			throw std::runtime_error("graphs, clock, meter : " + string{e.what()});
 		}
@@ -870,12 +878,41 @@ namespace Cpu {
 		};
 
 		//? Core text and graphs
+	#ifdef __APPLE__
+		//? On Apple Silicon, start at row 0 since we skip the default CPU bar
+		const bool pe_layout = (Cpu::cpu_core_info.p_cores > 0 and Cpu::cpu_core_info.e_cores > 0);
+		int cx = 0, cy = (pe_layout ? 0 : 1), cc = 0, core_width = (b_column_size == 0 ? 2 : 3);
+	#else
 		int cx = 0, cy = 1, cc = 0, core_width = (b_column_size == 0 ? 2 : 3);
+	#endif
 		if (Shared::coreCount >= 100) core_width++;
-		for (const auto& n : iota(0, Shared::coreCount)) {
+
+		//? Helper lambda to draw a single core line
+	#ifdef __APPLE__
+		const int p_cores_count = Cpu::cpu_core_info.p_cores;
+		const int e_cores_count = Cpu::cpu_core_info.e_cores;
+		const bool use_pe_labels = (p_cores_count > 0 and e_cores_count > 0);
+	#endif
+
+		auto draw_core = [&](int n) {
 			auto enabled = is_cpu_enabled(n);
+		#ifdef __APPLE__
+			string core_label;
+			if (use_pe_labels) {
+				// On Apple Silicon: E-cores are indices 0 to e_cores-1, P-cores are e_cores to end
+				if (n < e_cores_count) {
+					core_label = "E" + to_string(n);
+				} else {
+					core_label = "P" + to_string(n - e_cores_count);
+				}
+			} else {
+				core_label = (Shared::coreCount < 100 ? "C" : "") + to_string(n);
+			}
+			out += Mv::to(b_y + cy + 1, b_x + cx + 1) + Theme::c(enabled ? "main_fg" : "inactive_fg") + Fx::b + ljust(core_label, core_width + 1) + Fx::ub;
+		#else
 			out += Mv::to(b_y + cy + 1, b_x + cx + 1) + Theme::c(enabled ? "main_fg" : "inactive_fg") + (Shared::coreCount < 100 ? Fx::b + 'C' + Fx::ub : "")
 				+ ljust(to_string(n), core_width);
+		#endif
 			if ((b_column_size > 0 or extra_width > 0) and cmp_less(n, core_graphs.size()))
 				out += Theme::c("inactive_fg") + graph_bg * (5 * b_column_size + extra_width) + Mv::l(5 * b_column_size + extra_width)
 					+ core_graphs.at(n)(safeVal(cpu.core_percent, n), data_same or redraw);
@@ -893,10 +930,107 @@ namespace Cpu {
 			}
 
 			out += Theme::c("div_line") + Symbols::v_line;
+		};
 
-			if ((++cy > ceil((double)Shared::coreCount / b_columns) or cy == max_row) and n != Shared::coreCount - 1) {
-				if (++cc >= b_columns) break;
-				cy = 1; cx = (b_width / b_columns) * cc;
+	#ifdef __APPLE__
+		//? ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+		//? Apple Silicon P/E Core Layout
+		//?
+		//? Apple Silicon chips have Performance (P) and Efficiency (E) cores.
+		//? We display them in separate sections with their own frequency bars:
+		//?   ┌─────────────────────────┐
+		//?   │ P-CPU ■■■■■■■■■ 3.2 GHz │  <- P-core average + frequency
+		//?   │ P0 ▃▅▇ 45% │ P1 ▂▄▆ 32% │  <- Individual P-cores
+		//?   │ E-CPU ■■■■■■■■■ 2.1 GHz │  <- E-core average + frequency
+		//?   │ E0 ▁▃▅ 12% │ E1 ▂▄▆ 18% │  <- Individual E-cores
+		//?   └─────────────────────────┘
+		//?
+		//? Core indices: E-cores are 0 to e_cores-1, P-cores are e_cores to end.
+		//? Frequency is obtained via IOReport framework (sudoless).
+		//? ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+		const int p_cores_total = Cpu::cpu_core_info.p_cores;
+		const int e_cores_total = Cpu::cpu_core_info.e_cores;
+		const bool has_pe_cores = (p_cores_total > 0 and e_cores_total > 0);
+
+		if (has_pe_cores) {
+			const int col_width = b_width / b_columns;
+
+			//? On Apple Silicon: E-cores are indices 0 to e_cores-1, P-cores are e_cores to end
+			//? Calculate P-core and E-core average percentages
+			long long p_sum = 0, e_sum = 0;
+			for (int i = 0; i < e_cores_total and i < (int)cpu.core_percent.size(); ++i) {
+				e_sum += safeVal(cpu.core_percent, i).back();
+			}
+			for (int i = e_cores_total; i < e_cores_total + p_cores_total and i < (int)cpu.core_percent.size(); ++i) {
+				p_sum += safeVal(cpu.core_percent, i).back();
+			}
+			const long long p_avg = p_cores_total > 0 ? p_sum / p_cores_total : 0;
+			const long long e_avg = e_cores_total > 0 ? e_sum / e_cores_total : 0;
+
+			//? P-CPU bar (spans full width of all columns)
+			string p_label = "P-CPU";
+			const int p_freq = Cpu::cpu_core_info.p_freq_mhz;
+			const string p_freq_str = p_freq > 0 ? " " + format_freq(p_freq) : "";
+			//? Total row width = b_width - 1 (content area, box border is separate)
+			//? Content = "P-CPU " (6) + meter + freq_str + border (1) = b_width - 1
+			const int p_freq_width = static_cast<int>(p_freq_str.size());
+			const int p_meter = max(1, b_width - 7 - p_freq_width - 1);
+			out += Mv::to(b_y + cy + 1, b_x + 1) + Theme::c("main_fg") + Fx::b + p_label + Fx::ub + " "
+				+ Draw::Meter{p_meter, "cpu"}(p_avg)
+				+ Theme::g("cpu").at(clamp(p_avg, 0ll, 100ll)) + p_freq_str
+				+ Theme::c("div_line") + Symbols::v_line;
+			cy++;
+
+			//? Draw P-cores (indices e_cores_total to e_cores_total+p_cores_total-1)
+			int p_drawn = 0;
+			const int p_rows = (p_cores_total + b_columns - 1) / b_columns;
+			for (int row = 0; row < p_rows and p_drawn < p_cores_total and cy < max_row; ++row) {
+				for (int col = 0; col < b_columns and p_drawn < p_cores_total; ++col) {
+					cx = col * col_width;
+					draw_core(e_cores_total + p_drawn);
+					p_drawn++;
+				}
+				cy++;
+			}
+
+			//? E-CPU section header bar (spans full width of all columns)
+			if (cy < max_row) {
+				cx = 0;
+				string e_label = "E-CPU";
+				const int e_freq = Cpu::cpu_core_info.e_freq_mhz;
+				const string e_freq_str = e_freq > 0 ? " " + format_freq(e_freq) : "";
+				const int e_freq_width = static_cast<int>(e_freq_str.size());
+				const int e_meter = max(1, b_width - 7 - e_freq_width - 1);
+				out += Mv::to(b_y + cy + 1, b_x + 1) + Theme::c("main_fg") + Fx::b + e_label + Fx::ub + " "
+					+ Draw::Meter{e_meter, "cpu"}(e_avg)
+					+ Theme::g("cpu").at(clamp(e_avg, 0ll, 100ll)) + e_freq_str
+					+ Theme::c("div_line") + Symbols::v_line;
+				cy++;
+			}
+
+			//? Draw E-cores (indices 0 to e_cores_total-1)
+			const int e_rows = (e_cores_total + b_columns - 1) / b_columns;
+			int e_drawn = 0;
+			for (int row = 0; row < e_rows and e_drawn < e_cores_total and cy < max_row; ++row) {
+				for (int col = 0; col < b_columns and e_drawn < e_cores_total; ++col) {
+					cx = col * col_width;
+					draw_core(e_drawn);
+					e_drawn++;
+				}
+				cy++;
+			}
+			cx = 0;
+		} else
+	#endif
+		{
+			//? Standard layout: all cores in columns
+			for (const auto& n : iota(0, Shared::coreCount)) {
+				draw_core(n);
+
+				if ((++cy > ceil((double)Shared::coreCount / b_columns) or cy == max_row) and n != Shared::coreCount - 1) {
+					if (++cc >= b_columns) break;
+					cy = 1; cx = (b_width / b_columns) * cc;
+				}
 			}
 		}
 
@@ -2278,6 +2412,22 @@ namespace Draw {
 		#else
 			b_columns = max(1, (int)ceil((double)(Shared::coreCount + 1) / (height - 5)));
 		#endif
+		#ifdef __APPLE__
+			//? Apple Silicon P/E layout needs extra rows for section headers.
+			//? Adjust columns so both P-core and E-core sections fit vertically.
+			//? Iterative solution is O(max_cores) ≈ O(16), negligible cost.
+			if (Cpu::cpu_core_info.p_cores > 0 and Cpu::cpu_core_info.e_cores > 0) {
+				const int p_cores = Cpu::cpu_core_info.p_cores;
+				const int e_cores = Cpu::cpu_core_info.e_cores;
+				const int available_rows = height - 5 - 2;  // -2 for P-CPU and E-CPU header bars
+				while (b_columns < Shared::coreCount) {
+					int p_rows = (p_cores + b_columns - 1) / b_columns;
+					int e_rows = (e_cores + b_columns - 1) / b_columns;
+					if (p_rows + e_rows <= available_rows) break;
+					b_columns++;
+				}
+			}
+		#endif
 			if (b_columns * (21 + 12 * show_temp) < width - (width / 3)) {
 				b_column_size = 2;
 				b_width =  max(29, (21 + 12 * show_temp) * b_columns - (b_columns - 1));
@@ -2300,6 +2450,22 @@ namespace Draw {
 			b_height = min(height - 2, (int)ceil((double)Shared::coreCount / b_columns) + 4 + gpus_extra_height);
 		#else
 			b_height = min(height - 2, (int)ceil((double)Shared::coreCount / b_columns) + 4);
+		#endif
+		#ifdef __APPLE__
+			//? On Apple Silicon with P/E cores, recalculate b_height based on actual P/E row needs
+			//? P/E layout needs: P-CPU header + P rows + E-CPU header + E rows + base (4)
+			if (Cpu::cpu_core_info.p_cores > 0 and Cpu::cpu_core_info.e_cores > 0) {
+				const int p_cores = Cpu::cpu_core_info.p_cores;
+				const int e_cores = Cpu::cpu_core_info.e_cores;
+				int p_rows = (p_cores + b_columns - 1) / b_columns;
+				int e_rows = (e_cores + b_columns - 1) / b_columns;
+				//? +4 base, +2 for P-CPU and E-CPU headers (we skip default CPU bar, so net +1 from original)
+				int pe_height = p_rows + e_rows + 4 + 1;
+			#ifdef GPU_SUPPORT
+				pe_height += gpus_extra_height;
+			#endif
+				b_height = min(height - 2, pe_height);
+			}
 		#endif
 
 			b_x = x + width - b_width - 1;

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -240,6 +240,19 @@ namespace Cpu {
 
 	auto get_cpuHz() -> string;
 
+#ifdef __APPLE__
+	//* Apple Silicon P-core and E-core information
+	struct core_info {
+		int p_cores = 0;      // Performance cores (perflevel0) - indices e_cores to e_cores+p_cores-1
+		int e_cores = 0;      // Efficiency cores (perflevel1) - indices 0 to e_cores-1
+		int p_freq_mhz = 0;   // Current P-cluster frequency in MHz
+		int e_freq_mhz = 0;   // Current E-cluster frequency in MHz
+	};
+	extern core_info cpu_core_info;
+	auto get_core_info() -> core_info;
+	void update_core_frequencies();  // Update current P/E frequencies via IOReport
+#endif
+
 	//* Get battery info from /sys
 	auto get_battery() -> tuple<int, float, long, string>;
 

--- a/src/btop_tools.hpp
+++ b/src/btop_tools.hpp
@@ -205,6 +205,21 @@ namespace Tools {
 		return str;
 	}
 
+	//* Format CPU frequency: 3 digits max, e.g., "1.9 GHz" or "600 MHz"
+	inline string format_freq(int mhz) {
+		if (mhz <= 0) return "";
+		string str;
+		if (mhz > 999) {
+			str = fmt::format("{:.1f}", mhz / 1000.0);
+			if (str.size() > 3) str.resize(3);
+			if (str.back() == '.') str.pop_back();
+			str += " GHz";
+		} else {
+			str = fmt::format("{} MHz", mhz);
+		}
+		return str;
+	}
+
 	//* Check if vector <vec> contains value <find_val>
 	template <typename T, typename T2>
 	inline bool v_contains(const vector<T>& vec, const T2& find_val) {

--- a/src/osx/ioreport.cpp
+++ b/src/osx/ioreport.cpp
@@ -1,0 +1,394 @@
+/* Copyright 2021 Aristocratos (jakob@qvantnet.com)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+indent = tab
+tab-size = 4
+*/
+
+/* IOReport CPU Frequency Monitoring for Apple Silicon
+
+Provides sudoless CPU frequency monitoring via Apple's IOReport framework.
+Library: /usr/lib/libIOReport.dylib
+
+We use the ECPM/PCPM channels from "CPU Stats" -> "CPU Complex Performance States"
+to get cluster-level frequency data. Frequency tables are read from the pmgr device
+(voltage-states1-sram for E-CPU, voltage-states5-sram for P-CPU).
+
+State names follow "VxPy" pattern where x is voltage level. We parse x and map to
+frequency table index. The mapping is dynamic to handle variations across chip models.
+
+Frequency calculation: weighted average of (residency × frequency) for each state.
+
+*/
+
+#include "ioreport.hpp"
+
+#include <IOKit/IOKitLib.h>
+#include <dlfcn.h>
+#include <cstring>
+#include <mutex>
+#include <vector>
+#include <string>
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 120000
+#define kIOMainPortDefault kIOMasterPortDefault
+#endif
+
+// IOReport types
+struct IOReportSubscription;
+typedef struct IOReportSubscription* IOReportSubscriptionRef;
+typedef CFDictionaryRef IOReportSampleRef;
+
+// IOReport function pointers (loaded dynamically from libIOReport.dylib)
+static CFMutableDictionaryRef (*IOReportCopyChannelsInGroup)(CFStringRef, CFStringRef, uint64_t, uint64_t, uint64_t) = nullptr;
+static IOReportSubscriptionRef (*IOReportCreateSubscription)(void*, CFMutableDictionaryRef, CFMutableDictionaryRef*, uint64_t, CFTypeRef) = nullptr;
+static CFDictionaryRef (*IOReportCreateSamples)(IOReportSubscriptionRef, CFMutableDictionaryRef, CFTypeRef) = nullptr;
+static CFDictionaryRef (*IOReportCreateSamplesDelta)(CFDictionaryRef, CFDictionaryRef, CFTypeRef) = nullptr;
+static CFStringRef (*IOReportChannelGetChannelName)(IOReportSampleRef) = nullptr;
+static int32_t (*IOReportStateGetCount)(IOReportSampleRef) = nullptr;
+static int64_t (*IOReportStateGetResidency)(IOReportSampleRef, int32_t) = nullptr;
+static CFStringRef (*IOReportStateGetNameForIndex)(IOReportSampleRef, int32_t) = nullptr;
+static int (*IOReportChannelGetFormat)(IOReportSampleRef) = nullptr;
+
+// IOReport format types
+enum {
+	kIOReportFormatState = 2
+};
+
+namespace {
+	// Mutex protecting all module state (thread safety for concurrent access)
+	std::mutex g_mutex;
+
+	// Module state
+	bool g_initialized = false;
+	bool g_available = false;
+	void* g_iokit_handle = nullptr;
+	IOReportSubscriptionRef g_subscription = nullptr;
+	CFMutableDictionaryRef g_channels = nullptr;
+	// g_sub_channels is an out-parameter from IOReportCreateSubscription.
+	// Based on observed behavior (similar to powermetrics), caller owns this reference.
+	CFMutableDictionaryRef g_sub_channels = nullptr;
+
+	// Frequency tables from pmgr
+	std::vector<uint32_t> g_ecpu_freqs;
+	std::vector<uint32_t> g_pcpu_freqs;
+
+	// Last sample for delta calculation
+	CFDictionaryRef g_last_sample = nullptr;
+
+	// Helper to convert CFString to std::string
+	std::string cfstring_to_string(CFStringRef str) {
+		if (str == nullptr) return "";
+		const char* cstr = CFStringGetCStringPtr(str, kCFStringEncodingUTF8);
+		if (cstr != nullptr) return std::string(cstr);
+
+		CFIndex length = CFStringGetLength(str);
+		CFIndex max_size = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8) + 1;
+		std::vector<char> buffer(max_size);
+		if (CFStringGetCString(str, buffer.data(), max_size, kCFStringEncodingUTF8)) {
+			return std::string(buffer.data());
+		}
+		return "";
+	}
+
+	// Parse frequency data from voltage-states property
+	void parse_freq_data(CFDataRef data, std::vector<uint32_t>& freqs, uint32_t scale) {
+		if (data == nullptr) return;
+		CFIndex len = CFDataGetLength(data);
+		const uint8_t* bytes = CFDataGetBytePtr(data);
+		int total_entries = static_cast<int>(len / 8);
+
+		freqs.clear();
+		freqs.reserve(total_entries);
+		for (int i = 0; i < total_entries; i++) {
+			uint32_t freq = 0;
+			memcpy(&freq, bytes + (i * 8), 4);
+			uint32_t freq_mhz = freq / scale;
+			// Keep zero entries to preserve voltage state index mapping.
+			freqs.push_back(freq_mhz);
+		}
+	}
+
+	// RAII wrapper for IOObjectRelease
+	struct ScopedIOObject {
+		io_object_t obj;
+		ScopedIOObject(io_object_t o) : obj(o) {}
+		~ScopedIOObject() { if (obj) IOObjectRelease(obj); }
+		ScopedIOObject(const ScopedIOObject&) = delete;
+		ScopedIOObject& operator=(const ScopedIOObject&) = delete;
+	};
+
+	// RAII wrapper for CFRelease
+	struct ScopedCFType {
+		CFTypeRef obj;
+		ScopedCFType(CFTypeRef o) : obj(o) {}
+		~ScopedCFType() { if (obj) CFRelease(obj); }
+		ScopedCFType(const ScopedCFType&) = delete;
+		ScopedCFType& operator=(const ScopedCFType&) = delete;
+		void release() { obj = nullptr; } // Stop managing the object (if ownership transferred)
+	};
+
+	// Load CPU frequency tables from pmgr device
+	bool load_cpu_frequencies() {
+		io_iterator_t iterator = 0;
+		io_object_t entry = 0;
+
+		CFMutableDictionaryRef matching = IOServiceMatching("AppleARMIODevice");
+		if (IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator) != kIOReturnSuccess) {
+			return false;
+		}
+		ScopedIOObject scoped_iter(iterator);
+
+		bool found = false;
+		constexpr uint32_t M4_FREQ_THRESHOLD_HZ = 10'000'000;
+
+		while ((entry = IOIteratorNext(iterator)) != 0) {
+			ScopedIOObject scoped_entry(entry);
+			io_name_t name = {};
+			if (IORegistryEntryGetName(entry, name) != kIOReturnSuccess) {
+				continue;
+			}
+
+			if (strcmp(name, "pmgr") == 0) {
+				CFMutableDictionaryRef properties = nullptr;
+				if (IORegistryEntryCreateCFProperties(entry, &properties, kCFAllocatorDefault, 0) == kIOReturnSuccess) {
+					ScopedCFType scoped_props(properties);
+					// Determine scale based on chip (M4+ uses KHz, earlier uses MHz)
+					// We'll try to detect by checking frequency magnitudes
+					uint32_t scale = 1000000; // Default to MHz (pre-M4)
+
+					CFDataRef e_data = (CFDataRef)CFDictionaryGetValue(properties, CFSTR("voltage-states1-sram"));
+					CFDataRef p_data = (CFDataRef)CFDictionaryGetValue(properties, CFSTR("voltage-states5-sram"));
+
+					// Check if this is M4+ by examining raw frequency values
+					if (e_data != nullptr) {
+						CFIndex len = CFDataGetLength(e_data);
+						if (len >= 8) {
+							const uint8_t* bytes = CFDataGetBytePtr(e_data);
+							uint32_t first_freq = 0;
+							memcpy(&first_freq, bytes, 4);
+							// M4+ uses KHz (values like 912000 for 912 MHz)
+							// M1-M3 uses Hz (values like 600000000 for 600 MHz)
+							if (first_freq < M4_FREQ_THRESHOLD_HZ) {
+								scale = 1000; // M4+ uses KHz
+							}
+						}
+					}
+
+					if (e_data != nullptr) {
+						parse_freq_data(e_data, g_ecpu_freqs, scale);
+					}
+					if (p_data != nullptr) {
+						parse_freq_data(p_data, g_pcpu_freqs, scale);
+					}
+
+					found = not g_ecpu_freqs.empty() and not g_pcpu_freqs.empty();
+				}
+			}
+			if (found) break;
+		}
+		return found;
+	}
+
+	bool load_ioreport_functions() {
+		g_iokit_handle = dlopen("/usr/lib/libIOReport.dylib", RTLD_NOW);
+		if (g_iokit_handle == nullptr) return false;
+
+		#define LOAD_SYM(name) name = (decltype(name))dlsym(g_iokit_handle, #name)
+		LOAD_SYM(IOReportCopyChannelsInGroup);
+		LOAD_SYM(IOReportCreateSubscription);
+		LOAD_SYM(IOReportCreateSamples);
+		LOAD_SYM(IOReportCreateSamplesDelta);
+		LOAD_SYM(IOReportChannelGetChannelName);
+		LOAD_SYM(IOReportStateGetCount);
+		LOAD_SYM(IOReportStateGetResidency);
+		LOAD_SYM(IOReportStateGetNameForIndex);
+		LOAD_SYM(IOReportChannelGetFormat);
+		#undef LOAD_SYM
+
+		return IOReportCopyChannelsInGroup and IOReportCreateSubscription and
+		       IOReportCreateSamples and IOReportCreateSamplesDelta and
+		       IOReportChannelGetChannelName and IOReportChannelGetFormat and
+		       IOReportStateGetCount and IOReportStateGetResidency and
+		       IOReportStateGetNameForIndex;
+	}
+
+	// Initialize IOReport subscription
+	bool init_subscription() {
+		CFMutableDictionaryRef cpu_chan = IOReportCopyChannelsInGroup(CFSTR("CPU Stats"), nullptr, 0, 0, 0);
+		if (cpu_chan == nullptr) return false;
+
+		g_channels = cpu_chan;
+		g_subscription = IOReportCreateSubscription(nullptr, g_channels, &g_sub_channels, 0, nullptr);
+
+		return g_subscription != nullptr;
+	}
+}
+
+namespace IOReport {
+
+	// Internal cleanup (caller must hold g_mutex)
+	static void cleanup_internal() {
+		// Release CF objects first, before closing the library handle
+		if (g_last_sample != nullptr) {
+			CFRelease(g_last_sample);
+			g_last_sample = nullptr;
+		}
+		if (g_channels != nullptr) {
+			CFRelease(g_channels);
+			g_channels = nullptr;
+		}
+		if (g_subscription != nullptr) {
+			CFRelease(g_subscription);
+			g_subscription = nullptr;
+		}
+		if (g_sub_channels != nullptr) {
+			CFRelease(g_sub_channels);
+			g_sub_channels = nullptr;
+		}
+		// Close library handle last, after all CF objects are released
+		if (g_iokit_handle != nullptr) {
+			dlclose(g_iokit_handle);
+			g_iokit_handle = nullptr;
+		}
+		g_initialized = false;
+		g_available = false;
+	}
+
+	bool init() {
+		std::lock_guard<std::mutex> lock(g_mutex);
+		if (g_initialized) return g_available;
+		g_initialized = true;
+
+		// Load IOReport functions
+		if (not load_ioreport_functions()) {
+			cleanup_internal();
+			return false;
+		}
+
+		// Load frequency tables
+		if (not load_cpu_frequencies()) {
+			cleanup_internal();
+			return false;
+		}
+
+		// Initialize subscription
+		if (not init_subscription()) {
+			cleanup_internal();
+			return false;
+		}
+
+		g_available = true;
+		return true;
+	}
+
+	void cleanup() {
+		std::lock_guard<std::mutex> lock(g_mutex);
+		cleanup_internal();
+	}
+
+	bool is_available() {
+		std::lock_guard<std::mutex> lock(g_mutex);
+		return g_available;
+	}
+
+	//? Process a single IOReport channel sample and extract frequency if it's ECPM/PCPM
+	//? Must be called with g_mutex held
+	void process_channel_sample(IOReportSampleRef sample, uint32_t& e_freq, uint32_t& p_freq) {
+		if (IOReportChannelGetFormat and IOReportChannelGetFormat(sample) != kIOReportFormatState)
+			return;
+
+		std::string channel = cfstring_to_string(IOReportChannelGetChannelName(sample));
+		bool is_ecpm = (channel == "ECPM"), is_pcpm = (channel == "PCPM");
+		if (not is_ecpm and not is_pcpm) return;
+
+		const auto& freq_table = is_ecpm ? g_ecpu_freqs : g_pcpu_freqs;
+		if (freq_table.empty()) return;
+
+		int64_t total_residency = 0;
+		double weighted_freq = 0;
+
+		// Calculate weighted average frequency (matches powermetrics "HW active frequency")
+		for (int32_t s = 0; s < IOReportStateGetCount(sample); s++) {
+			int64_t residency = IOReportStateGetResidency(sample, s);
+			if (residency <= 0) continue;
+
+			std::string name = cfstring_to_string(IOReportStateGetNameForIndex(sample, s));
+			if (name.empty() or name[0] != 'V') continue;
+			size_t p_pos = name.find('P');
+			if (p_pos == std::string::npos or p_pos <= 1) continue;
+
+			try {
+				size_t freq_idx = static_cast<size_t>(std::stoi(name.substr(1, p_pos - 1)));
+				if (freq_idx < freq_table.size()) {
+					total_residency += residency;
+					weighted_freq += residency * freq_table[freq_idx];
+				}
+			} catch (const std::invalid_argument&) {
+				// Ignore: state name couldn't be parsed as integer
+			} catch (const std::out_of_range&) {
+				// Ignore: parsed value exceeded int range
+			}
+		}
+
+		if (total_residency > 0) {
+			(is_ecpm ? e_freq : p_freq) = static_cast<uint32_t>(weighted_freq / total_residency);
+		}
+	}
+
+	std::pair<uint32_t, uint32_t> get_cpu_frequencies() {
+		std::lock_guard<std::mutex> lock(g_mutex);
+		if (not g_available) return {0, 0};
+
+		CFDictionaryRef current_sample = IOReportCreateSamples(g_subscription, g_sub_channels, nullptr);
+		if (current_sample == nullptr) return {0, 0};
+
+		// RAII for current_sample
+		ScopedCFType scoped_sample(current_sample);
+
+		uint32_t e_freq = 0, p_freq = 0;
+
+		if (g_last_sample != nullptr) {
+			CFDictionaryRef delta = IOReportCreateSamplesDelta(g_last_sample, current_sample, nullptr);
+			if (delta != nullptr) {
+				ScopedCFType scoped_delta(delta);
+
+				// Manually iterate over IOReport channels (avoids Objective-C blocks for GCC compat)
+				// Validate type before casting to guard against IOReport API changes
+				CFTypeRef channels_ref = CFDictionaryGetValue(delta, CFSTR("IOReportChannels"));
+				if (channels_ref != nullptr and CFGetTypeID(channels_ref) == CFArrayGetTypeID()) {
+					CFArrayRef channels = (CFArrayRef)channels_ref;
+					CFIndex count = CFArrayGetCount(channels);
+					for (CFIndex i = 0; i < count; i++) {
+						IOReportSampleRef sample = (IOReportSampleRef)CFArrayGetValueAtIndex(channels, i);
+						if (sample != nullptr) {
+							process_channel_sample(sample, e_freq, p_freq);
+						}
+					}
+				}
+			}
+
+			// Release last sample as we will replace it with current
+			CFRelease(g_last_sample);
+			g_last_sample = nullptr;
+		}
+
+		// Keep current_sample for next iteration
+		scoped_sample.release(); // Don't release, we store it
+		g_last_sample = current_sample;
+
+		return {e_freq, p_freq};
+	}
+
+}

--- a/src/osx/ioreport.hpp
+++ b/src/osx/ioreport.hpp
@@ -1,0 +1,39 @@
+/* Copyright 2021 Aristocratos (jakob@qvantnet.com)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+indent = tab
+tab-size = 4
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <utility>
+
+namespace IOReport {
+
+	//* Initialize IOReport subscription for CPU stats
+	bool init();
+
+	//* Cleanup IOReport resources
+	void cleanup();
+
+	//* Get current E-cluster and P-cluster frequencies in MHz
+	//* Returns {e_freq_mhz, p_freq_mhz}
+	std::pair<uint32_t, uint32_t> get_cpu_frequencies();
+
+	//* Check if IOReport is available and initialized
+	bool is_available();
+
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,11 @@ add_library(libbtop_test)
 target_include_directories(libbtop_test PUBLIC ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries(libbtop_test libbtop GTest::gtest_main)
 
-add_executable(btop_test tools.cpp)
+set(TEST_SOURCES tools.cpp cpu_box_property_test.cpp)
+if(APPLE)
+  list(APPEND TEST_SOURCES ioreport_test.cpp)
+endif()
+add_executable(btop_test ${TEST_SOURCES})
 target_link_libraries(btop_test libbtop_test)
 
 include(GoogleTest)

--- a/tests/cpu_box_property_test.cpp
+++ b/tests/cpu_box_property_test.cpp
@@ -1,0 +1,575 @@
+/* Copyright 2021 Aristocratos (jakob@qvantnet.com)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+//? ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//? CPU Box Property Tests
+//?
+//? These tests call the ACTUAL Cpu::draw() function with controlled inputs and
+//? validate that the output is a properly formed box. This catches real bugs
+//? in the rendering code - not just a simulator.
+//? ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+#include <gtest/gtest.h>
+
+#include <cctype>
+#include <regex>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "btop_config.hpp"
+#include "btop_draw.hpp"
+#include "btop_shared.hpp"
+#include "btop_theme.hpp"
+#include "btop_tools.hpp"
+
+namespace {
+
+using std::string;
+using std::vector;
+
+//? Helper: Strip ANSI escape codes from a string
+string StripAnsi(const string& input) {
+	static const std::regex ansi_regex("\x1b\\[[0-9;]*[a-zA-Z]");
+	return std::regex_replace(input, ansi_regex, "");
+}
+
+//? Virtual terminal buffer that renders cursor-positioned output to a 2D grid
+class TerminalBuffer {
+	vector<vector<string>> grid;  // 2D grid of UTF-8 characters
+	int cursor_row = 0;
+	int cursor_col = 0;
+	int height_, width_;
+
+public:
+	TerminalBuffer(int height, int width)
+		: grid(height, vector<string>(width, " ")), height_(height), width_(width) {}
+
+	void render(const string& input) {
+		size_t i = 0;
+		while (i < input.size()) {
+			if (input[i] == '\x1b' && i + 1 < input.size() && input[i + 1] == '[') {
+				// Parse ANSI escape sequence
+				size_t j = i + 2;
+				while (j < input.size() && (std::isdigit(input[j]) || input[j] == ';')) j++;
+				if (j < input.size()) {
+					char cmd = input[j];
+					string params = input.substr(i + 2, j - i - 2);
+					handleEscapeSequence(cmd, params);
+				}
+				i = j + 1;
+			} else if (input[i] == '\n') {
+				cursor_row++;
+				cursor_col = 0;
+				i++;
+			} else {
+				// Regular character - determine UTF-8 length
+				unsigned char c = input[i];
+				size_t len = (c < 0x80) ? 1 : (c < 0xE0) ? 2 : (c < 0xF0) ? 3 : 4;
+				if (i + len <= input.size()) {
+					string ch = input.substr(i, len);
+					writeChar(ch);
+				}
+				i += len;
+			}
+		}
+	}
+
+	//? Extract lines from the grid (for use with existing validator)
+	vector<string> extractLines() const {
+		vector<string> lines;
+		for (const auto& row : grid) {
+			string line;
+			for (const auto& ch : row) {
+				line += ch;
+			}
+			// Trim trailing spaces
+			while (!line.empty() && line.back() == ' ') {
+				line.pop_back();
+			}
+			lines.push_back(line);
+		}
+		return lines;
+	}
+
+	//? Debug: dump the grid
+	string dump() const {
+		string out;
+		for (int r = 0; r < height_; r++) {
+			for (int c = 0; c < width_; c++) {
+				out += grid[r][c];
+			}
+			out += "\n";
+		}
+		return out;
+	}
+
+private:
+	void handleEscapeSequence(char cmd, const string& params) {
+		if (cmd == 'f' || cmd == 'H') {
+			// Cursor position: \e[row;colf or \e[row;colH
+			auto sep = params.find(';');
+			if (sep != string::npos) {
+				cursor_row = std::stoi(params.substr(0, sep)) - 1;  // 1-indexed to 0-indexed
+				cursor_col = std::stoi(params.substr(sep + 1)) - 1;
+			} else if (!params.empty()) {
+				cursor_row = std::stoi(params) - 1;
+				cursor_col = 0;
+			}
+		} else if (cmd == 'C') {
+			// Move cursor right
+			int n = params.empty() ? 1 : std::stoi(params);
+			cursor_col += n;
+		} else if (cmd == 'A') {
+			// Move cursor up
+			int n = params.empty() ? 1 : std::stoi(params);
+			cursor_row -= n;
+		} else if (cmd == 'B') {
+			// Move cursor down
+			int n = params.empty() ? 1 : std::stoi(params);
+			cursor_row += n;
+		} else if (cmd == 'D') {
+			// Move cursor left
+			int n = params.empty() ? 1 : std::stoi(params);
+			cursor_col -= n;
+		}
+		// Ignore color codes (m), clear codes (J, K), etc.
+	}
+
+	void writeChar(const string& ch) {
+		if (cursor_row >= 0 && cursor_row < height_ &&
+		    cursor_col >= 0 && cursor_col < width_) {
+			grid[cursor_row][cursor_col] = ch;
+		}
+		cursor_col++;
+	}
+};
+
+//? Helper: Split UTF-8 string into individual characters
+vector<string> Utf8Split(const string& s) {
+	vector<string> chars;
+	for (size_t i = 0; i < s.size();) {
+		unsigned char c = s[i];
+		size_t len = (c < 0x80) ? 1 : (c < 0xE0) ? 2 : (c < 0xF0) ? 3 : 4;
+		if (i + len > s.size()) break;
+		chars.push_back(s.substr(i, len));
+		i += len;
+	}
+	return chars;
+}
+
+//? Box validation result
+struct BoxValidationResult {
+	bool valid = true;
+	string error;
+	int row = -1;
+	int col = -1;
+
+	explicit operator bool() const { return valid; }
+	static BoxValidationResult Ok() { return {}; }
+	static BoxValidationResult Fail(const string& msg, int r = -1, int c = -1) {
+		return {false, msg, r, c};
+	}
+};
+
+//? Validates box structure: corners, edges, consistent width
+class BoxStructureValidator {
+public:
+	BoxValidationResult Validate(const vector<string>& lines) const {
+		if (lines.empty()) return BoxValidationResult::Fail("Empty box");
+
+		// Find the actual box lines (those that start/end with box characters)
+		vector<string> box_lines;
+		for (const auto& line : lines) {
+			string stripped = StripAnsi(line);
+			if (stripped.empty()) continue;
+
+			auto chars = Utf8Split(stripped);
+			if (chars.empty()) continue;
+
+			// Check if this looks like a box line (starts with box char)
+			if (IsBoxChar(chars.front())) {
+				box_lines.push_back(stripped);
+			}
+		}
+
+		if (box_lines.empty()) return BoxValidationResult::Fail("No box lines found");
+		if (box_lines.size() < 3) return BoxValidationResult::Fail("Box too short (< 3 lines)");
+
+		// Validate width consistency
+		const size_t width = Tools::ulen(box_lines.front());
+		if (width < 3) return BoxValidationResult::Fail("Box too narrow");
+
+		for (size_t i = 0; i < box_lines.size(); ++i) {
+			size_t line_width = Tools::ulen(box_lines[i]);
+			if (line_width != width) {
+				return BoxValidationResult::Fail(
+					"Row " + std::to_string(i) + " width mismatch: expected " +
+					std::to_string(width) + ", got " + std::to_string(line_width),
+					(int)i);
+			}
+		}
+
+		// Validate corners
+		auto top = Utf8Split(box_lines.front());
+		auto bot = Utf8Split(box_lines.back());
+
+		if (!IsCorner(top.front())) return BoxValidationResult::Fail("Invalid TL corner: " + top.front(), 0, 0);
+		if (!IsCorner(top.back())) return BoxValidationResult::Fail("Invalid TR corner: " + top.back(), 0, (int)width - 1);
+		if (!IsCorner(bot.front())) return BoxValidationResult::Fail("Invalid BL corner: " + bot.front(), (int)box_lines.size() - 1, 0);
+		if (!IsCorner(bot.back())) return BoxValidationResult::Fail("Invalid BR corner: " + bot.back(), (int)box_lines.size() - 1, (int)width - 1);
+
+		// Validate vertical edges for middle rows
+		for (size_t r = 1; r + 1 < box_lines.size(); ++r) {
+			auto row = Utf8Split(box_lines[r]);
+			if (row.empty()) return BoxValidationResult::Fail("Empty row", (int)r);
+
+			if (!IsVertical(row.front())) {
+				return BoxValidationResult::Fail("Invalid left edge: " + row.front(), (int)r, 0);
+			}
+			if (!IsVertical(row.back())) {
+				return BoxValidationResult::Fail("Invalid right edge: " + row.back(), (int)r, (int)width - 1);
+			}
+		}
+
+		return BoxValidationResult::Ok();
+	}
+
+private:
+	static bool IsBoxChar(const string& s) {
+		static const std::set<string> kBoxChars = {
+			"┌", "┐", "└", "┘", "╭", "╮", "╰", "╯",
+			"│", "─", "├", "┤", "┬", "┴", "┼"
+		};
+		return kBoxChars.count(s);
+	}
+
+	static bool IsCorner(const string& s) {
+		static const std::set<string> kCorners = {"┌", "┐", "└", "┘", "╭", "╮", "╰", "╯"};
+		return kCorners.count(s);
+	}
+
+	static bool IsVertical(const string& s) {
+		return s == "│" || s == "├" || s == "┤" || IsCorner(s);
+	}
+};
+
+//? Test fixture that sets up the environment for Cpu::draw()
+class CpuDrawIntegrationTest : public ::testing::Test {
+protected:
+	void SetUp() override {
+		// Initialize Config with default values needed for drawing
+		InitConfig();
+
+		// Initialize Theme with default colors
+		InitTheme();
+
+		// Initialize global state
+		InitGlobals();
+
+		// Calculate box sizes (this sets internal b_width, b_columns, etc.)
+		Draw::calcSizes();
+	}
+
+	void TearDown() override {
+		// Reset state if needed
+	}
+
+	void InitConfig() {
+		// Set required config values
+		Config::bools["tty_mode"] = false;
+		Config::bools["truecolor"] = true;
+		Config::bools["lowcolor"] = false;
+		Config::bools["rounded_corners"] = true;
+		Config::bools["cpu_single_graph"] = false;
+		Config::bools["check_temp"] = false;
+		Config::bools["show_cpu_watts"] = false;
+		Config::bools["show_coretemp"] = true;
+		Config::bools["cpu_bottom"] = false;
+		Config::bools["cpu_invert_lower"] = false;
+		Config::bools["mem_below_net"] = false;
+		Config::bools["proc_left"] = false;
+		Config::bools["background_update"] = true;
+		Config::bools["show_detailed"] = false;
+		Config::bools["proc_gradient"] = false;
+		Config::bools["show_battery"] = false;
+		Config::bools["show_battery_watts"] = false;
+		Config::bools["show_uptime"] = false;
+		Config::bools["show_cpu_freq"] = false;
+
+		Config::strings["graph_symbol"] = "braille";
+		Config::strings["graph_symbol_cpu"] = "default";
+		Config::strings["cpu_graph_upper"] = "total";
+		Config::strings["cpu_graph_lower"] = "total";
+		Config::strings["temp_scale"] = "celsius";
+		Config::strings["shown_boxes"] = "cpu";
+		Config::strings["proc_sorting"] = "cpu direct";
+		Config::strings["clock_format"] = "";
+		Config::strings["custom_cpu_name"] = "";
+#ifdef __linux__
+		Config::strings["freq_mode"] = "current";
+#endif
+#ifdef GPU_SUPPORT
+		Config::strings["show_gpu_info"] = "Off";
+#endif
+
+		Config::ints["update_ms"] = 1000;
+		Config::ints["proc_per_core"] = 0;
+		Config::ints["selected_pid"] = 0;
+
+		Config::current_preset = 0;
+		Config::current_boxes = {"cpu"};
+	}
+
+	void InitTheme() {
+		// Set up minimal theme colors (empty strings = no color codes)
+		Theme::colors["main_fg"] = "";
+		Theme::colors["main_bg"] = "";
+		Theme::colors["title"] = "";
+		Theme::colors["hi_fg"] = "";
+		Theme::colors["cpu_box"] = "";
+		Theme::colors["mem_box"] = "";
+		Theme::colors["net_box"] = "";
+		Theme::colors["proc_box"] = "";
+		Theme::colors["div_line"] = "";
+		Theme::colors["meter_bg"] = "";
+		Theme::colors["inactive_fg"] = "";
+		Theme::colors["graph_text"] = "";
+		Theme::colors["process_start"] = "";
+		Theme::colors["process_mid"] = "";
+		Theme::colors["process_end"] = "";
+
+		// Set up gradients (101 entries each)
+		std::array<string, 101> empty_gradient;
+		for (auto& s : empty_gradient) s = "";
+		Theme::gradients["cpu"] = empty_gradient;
+		Theme::gradients["temp"] = empty_gradient;
+		Theme::gradients["free"] = empty_gradient;
+		Theme::gradients["cached"] = empty_gradient;
+		Theme::gradients["used"] = empty_gradient;
+		Theme::gradients["download"] = empty_gradient;
+		Theme::gradients["upload"] = empty_gradient;
+		Theme::gradients["process"] = empty_gradient;
+	}
+
+	void InitGlobals() {
+		// Terminal size
+		Term::width = 120;
+		Term::height = 40;
+
+		// Core count
+		Shared::coreCount = 8;
+
+		// CPU info
+		Cpu::cpuName = "Test CPU";
+		Cpu::cpuHz = "";
+		Cpu::available_fields = {"total"};
+		Cpu::got_sensors = false;
+		Cpu::cpu_temp_only = false;
+		Cpu::has_battery = false;
+		Cpu::supports_watts = false;
+		Cpu::shown = true;
+		Cpu::redraw = true;
+
+#ifdef __APPLE__
+		// Apple Silicon core info
+		Cpu::cpu_core_info.p_cores = 4;
+		Cpu::cpu_core_info.e_cores = 4;
+		Cpu::cpu_core_info.p_freq_mhz = 3200;
+		Cpu::cpu_core_info.e_freq_mhz = 2100;
+#endif
+	}
+
+#ifdef __APPLE__
+	void ApplyAppleSiliconConfig(int p_cores, int e_cores) {
+		Cpu::cpu_core_info.p_cores = p_cores;
+		Cpu::cpu_core_info.e_cores = e_cores;
+		Cpu::cpu_core_info.p_freq_mhz = 3200;
+		Cpu::cpu_core_info.e_freq_mhz = 2100;
+		Shared::coreCount = p_cores + e_cores;
+		Cpu::redraw = true;
+		Draw::calcSizes();
+	}
+#endif
+
+	// Create minimal cpu_info data for testing
+	Cpu::cpu_info CreateTestCpuInfo() {
+		Cpu::cpu_info cpu;
+
+		// Total CPU usage
+		cpu.cpu_percent["total"] = {50};
+
+		// Per-core usage (8 cores)
+		for (int i = 0; i < Shared::coreCount; ++i) {
+			cpu.core_percent.push_back({20 + i * 5});
+		}
+
+		// Load average
+		cpu.load_avg = {1.5, 1.2, 1.0};
+
+		return cpu;
+	}
+
+	BoxStructureValidator validator;
+};
+
+// Test that the real Cpu::draw() produces output
+TEST_F(CpuDrawIntegrationTest, DrawProducesOutput) {
+	auto cpu = CreateTestCpuInfo();
+	vector<Gpu::gpu_info> gpus;  // empty
+
+	// Call the actual draw function
+	string output = Cpu::draw(cpu, gpus, true, false);
+
+	// The draw function should produce output
+	EXPECT_FALSE(output.empty()) << "Cpu::draw should produce output";
+
+	// The box frame should also be set
+	EXPECT_FALSE(Cpu::box.empty()) << "Cpu::box should be set after draw";
+}
+
+// Test that the box contains expected structural elements
+TEST_F(CpuDrawIntegrationTest, BoxHasStructuralElements) {
+	auto cpu = CreateTestCpuInfo();
+	vector<Gpu::gpu_info> gpus;
+
+	Cpu::draw(cpu, gpus, true, false);
+	string stripped = StripAnsi(Cpu::box);
+
+	// Box should have corner characters
+	bool has_corners = stripped.find("╭") != string::npos ||
+					   stripped.find("┌") != string::npos;
+	EXPECT_TRUE(has_corners) << "Box should have corner characters";
+
+	// Box should have vertical lines
+	EXPECT_TRUE(stripped.find("│") != string::npos)
+		<< "Box should have vertical line characters";
+
+	// Box should have horizontal lines
+	EXPECT_TRUE(stripped.find("─") != string::npos)
+		<< "Box should have horizontal line characters";
+}
+
+#ifdef __APPLE__
+struct SiliconConfig {
+	int p_cores;
+	int e_cores;
+	string name;
+};
+
+vector<SiliconConfig> BuildAppleSiliconConfigs() {
+	return {
+		{4, 4, "M1"},
+		{8, 2, "M1_Pro"},
+		{8, 2, "M1_Max"},
+		{16, 4, "M1_Ultra"},
+		{4, 4, "M2"},
+		{6, 4, "M2_Pro_10C"},
+		{8, 4, "M2_Pro_12C"},
+		{8, 4, "M2_Max"},
+		{16, 8, "M2_Ultra"},
+		{4, 4, "M3"},
+		{6, 6, "M3_Pro"},
+		{5, 6, "M3_Pro_11C"},
+		{12, 4, "M3_Max"},
+		{10, 4, "M3_Max_14C"},
+		{12, 4, "M3_Max_16C"},
+		{4, 6, "M4"},
+		{10, 4, "M4_Pro_12C"},
+		{10, 4, "M4_Pro_14C"},
+		{10, 4, "M4_Max_14C"},
+		{12, 4, "M4_Max_16C"},
+	};
+}
+
+vector<SiliconConfig> BuildAppleSiliconSweep() {
+	vector<SiliconConfig> configs;
+	for (int p = 1; p <= 8; ++p) {
+		for (int e = 1; e <= 8; ++e) {
+			configs.push_back({p, e, "P" + std::to_string(p) + "_E" + std::to_string(e)});
+		}
+	}
+	return configs;
+}
+
+vector<SiliconConfig> BuildAppleSiliconTestMatrix() {
+	auto configs = BuildAppleSiliconConfigs();
+	auto sweep = BuildAppleSiliconSweep();
+	configs.insert(configs.end(), sweep.begin(), sweep.end());
+	return configs;
+}
+
+string SanitizeTestName(const string& name) {
+	string sanitized;
+	sanitized.reserve(name.size() + 2);
+	for (char ch : name) {
+		if (std::isalnum(static_cast<unsigned char>(ch)) != 0) {
+			sanitized.push_back(ch);
+		} else {
+			sanitized.push_back('_');
+		}
+	}
+	if (sanitized.empty() || std::isdigit(static_cast<unsigned char>(sanitized.front())) != 0) {
+		sanitized.insert(sanitized.begin(), 'C');
+		sanitized.insert(sanitized.begin() + 1, '_');
+	}
+	return sanitized;
+}
+
+class CpuDrawAppleSiliconConfigTest
+	: public CpuDrawIntegrationTest
+	, public ::testing::WithParamInterface<SiliconConfig> {};
+
+TEST_P(CpuDrawAppleSiliconConfigTest, AppleSiliconLayoutHasExpectedContent) {
+	const auto& cfg = GetParam();
+	ApplyAppleSiliconConfig(cfg.p_cores, cfg.e_cores);
+
+	auto cpu = CreateTestCpuInfo();
+	vector<Gpu::gpu_info> gpus;
+
+	string output = Cpu::draw(cpu, gpus, true, false);
+	string stripped = StripAnsi(output);
+
+	EXPECT_FALSE(output.empty()) << cfg.name << ": Cpu::draw should produce output";
+
+	EXPECT_TRUE(stripped.find("P-CPU") != string::npos)
+		<< cfg.name << ": Apple Silicon output should contain P-CPU header";
+	EXPECT_TRUE(stripped.find("E-CPU") != string::npos)
+		<< cfg.name << ": Apple Silicon output should contain E-CPU header";
+
+	EXPECT_TRUE(stripped.find("P0") != string::npos)
+		<< cfg.name << ": Apple Silicon output should contain P-core labels (P0, P1, ...)";
+	EXPECT_TRUE(stripped.find("E0") != string::npos)
+		<< cfg.name << ": Apple Silicon output should contain E-core labels (E0, E1, ...)";
+
+	// Render box to virtual terminal buffer, then validate structure
+	TerminalBuffer term_buf(Term::height, Term::width);
+	term_buf.render(Cpu::box);
+	auto lines = term_buf.extractLines();
+	auto res = validator.Validate(lines);
+	EXPECT_TRUE(res) << cfg.name << ": " << res.error;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+	AppleSiliconConfigs,
+	CpuDrawAppleSiliconConfigTest,
+	::testing::ValuesIn(BuildAppleSiliconTestMatrix()),
+	[](const testing::TestParamInfo<SiliconConfig>& info) {
+		return SanitizeTestName(info.param.name);
+	});
+
+#endif
+
+}  // namespace

--- a/tests/ioreport_test.cpp
+++ b/tests/ioreport_test.cpp
@@ -1,0 +1,100 @@
+/* Copyright 2021 Aristocratos (jakob@qvantnet.com)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <gtest/gtest.h>
+#include "../src/osx/ioreport.hpp"
+
+// Test IOReport initialization and cleanup
+TEST(IOReportTest, InitAndCleanup) {
+	// Ensure clean state
+	IOReport::cleanup();
+
+	bool available = IOReport::init();
+
+	if (available) {
+		EXPECT_TRUE(IOReport::is_available());
+		IOReport::cleanup();
+		EXPECT_FALSE(IOReport::is_available());
+	} else {
+		// init() failed (not on Apple Silicon or missing privileges)
+		EXPECT_FALSE(IOReport::is_available());
+	}
+}
+
+// Test that double init is safe
+TEST(IOReportTest, DoubleInitIsSafe) {
+	IOReport::cleanup();
+
+	bool first = IOReport::init();
+	bool second = IOReport::init();
+
+	// Both calls should return the same result
+	EXPECT_EQ(first, second);
+	EXPECT_EQ(first, IOReport::is_available());
+
+	IOReport::cleanup();
+}
+
+// Test that double cleanup is safe
+TEST(IOReportTest, DoubleCleanupIsSafe) {
+	IOReport::cleanup();
+	IOReport::init();
+
+	// Should not crash or cause issues
+	IOReport::cleanup();
+	IOReport::cleanup();
+
+	EXPECT_FALSE(IOReport::is_available());
+}
+
+// Test frequency values are sensible when available
+TEST(IOReportTest, FrequencyValuesAreSensible) {
+	IOReport::cleanup();
+
+	if (!IOReport::init()) {
+		GTEST_SKIP() << "IOReport not available on this system";
+	}
+
+	auto freqs = IOReport::get_cpu_frequencies();
+	uint32_t e_freq = freqs.first;
+	uint32_t p_freq = freqs.second;
+
+	// Frequencies should either be 0 (no sample yet) or within reasonable bounds
+	// Apple Silicon CPUs run between ~600 MHz and ~4500 MHz
+	constexpr uint32_t MIN_FREQ = 500;
+	constexpr uint32_t MAX_FREQ = 9000;
+
+	if (e_freq > 0) {
+		EXPECT_GE(e_freq, MIN_FREQ) << "E-cluster frequency too low: " << e_freq << " MHz";
+		EXPECT_LE(e_freq, MAX_FREQ) << "E-cluster frequency too high: " << e_freq << " MHz";
+	}
+
+	if (p_freq > 0) {
+		EXPECT_GE(p_freq, MIN_FREQ) << "P-cluster frequency too low: " << p_freq << " MHz";
+		EXPECT_LE(p_freq, MAX_FREQ) << "P-cluster frequency too high: " << p_freq << " MHz";
+	}
+
+	IOReport::cleanup();
+}
+
+// Test CPU Frequency fetch when not available
+TEST(IOReportTest, GetCpuFrequenciesWhenNotAvailable) {
+	// Ensure cleanup
+	IOReport::cleanup();
+	
+	auto freqs = IOReport::get_cpu_frequencies();
+	EXPECT_EQ(freqs.first, 0u);
+	EXPECT_EQ(freqs.second, 0u);
+}


### PR DESCRIPTION
- Display P-cores and E-cores separately on Apple Silicon Macs
- Add sudoless CPU frequency monitoring via reverse engineered IOReport framework
- Add comprehensive tests for CPU box rendering 

This took a few weeks and I'd tried many different approaches, e.g: starting powermetrics as a subprocess w/ sudo. 
Tested on M1 Max Macbook and (8P+2E cores) and M1 Macbook Air (4P+4E). 

LoC
- +430 IOReport (new data source) 
- +230 btop ux & drawing
- +630 unit tests (most painful part of getting this to render correctly in all edge cases)

## Demo
Demo showing macpm (fka asitop), btop under load w/ stress-ng & when system is triggered to be energy efficient

![btop Apple Silicon P/E core monitoring](https://github.com/achille/btop/raw/assets/apple-silicon-demo/btop-asitop-stress-ng.gif)

ai: most of the code was extensively written and tested by ai agents: claude, gemini, codex and glm; largely coordinated by claude under my direction. I've reviewed the code manually, tested in github/circleci/locally and can vouch for it.