### PR TITLE
fix: mem bottom border when net is not shown

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -2383,7 +2383,7 @@ namespace Draw {
 		#ifdef GPU_SUPPORT
 			height = ceil((double)Term::height * (100 - Net::height_p * Net::shown*4 / ((Gpu::shown != 0 and Cpu::shown) + 4)) / 100) - Cpu::height - Gpu::total_height;
 		#else
-			height = ceil((double)Term::height * (100 - Cpu::height_p * Cpu::shown - Net::height_p * Net::shown) / 100) + 1;
+			height = floor(static_cast<double>(Term::height) * (100 - Cpu::height_p * Cpu::shown - Net::height_p * Net::shown) / 100);
 		#endif
 			x = (proc_left and Proc::shown) ? Term::width - width + 1: 1;
 			if (mem_below_net and Net::shown)


### PR DESCRIPTION
fixes: #1508 

The height was getting 1 added to it and it appears that it should only do that if the net box is also shown because simply not adding 1 to it if net box is not shown brought the bottom border back. 

Edit: oh this only fixes it the cpu box is also not shown

Edit 2: I have solved that by subtracting 1 from the height if cpu is shown and net isn't shown

Edit 3: While this does seem to fix it at most sizes, it breaks at a terminal height of 25, 50, or 75 lines (so multiples of 25) where it is one line shorter then it should be when the cpu box is also shown

Edit 4: Solved this next problem by not subtracting 1 if cpu is shown but term height is a multiple of 25.

Edit 5: Well I have discovered something interesting. I noticed the same issue as @deckstose when using btop on my mac (15.7.3) however testing with the current main branch `HEAD` on my arch linux machine running btop I don't notice the problem at all. never happens. The weird thing is that when I test my fix branch on that same machine nothing changes and it still works perfectly fine with the bottom border exactly where it should be. So I don't exactly know what is going on here.

Edit 6: I tried replacing the modification I made with removing the `+1` at the end and replacing `ceil` with `floor` and that has also seemingly fixed the issue on my macos system and also makes no difference on my arch linux system where the issue never showed in the first place (but changing to floor didn't break it either)

Edit 7: I realized that the possible reason I don't notice the issue on my arch linux system is because it is compiled with gpu support and therefore a completely different `height=` line is run. Possibly the gpu support `height=` line doesn't have the same issue that it does if it is compiled without gpu support.

<details><summary><b>Image Examples</b></summary>

<img width="630" height="794" alt="Screenshot 2026-01-25 at 2 57 33 PM" src="https://github.com/user-attachments/assets/bfc5d204-5b6f-48f1-b512-f8717f7f4b44" />
<img width="881" height="892" alt="Screenshot 2026-01-25 at 3 16 46 PM" src="https://github.com/user-attachments/assets/93aeea0d-94af-4408-ad86-f8d8106df6e0" />

</details>
