### PR TITLE
fix: set tty mode if force_tty is true in config file

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -837,13 +837,17 @@ static auto configure_tty_mode(std::optional<bool> force_tty) {
 	if (force_tty.has_value()) {
 		Config::set("tty_mode", force_tty.value());
 		Logger::debug("TTY mode set via command line");
-  	}
+	}
+	else if (Config::getB("force_tty")) {
+		Config::set("tty_mode", true);
+		Logger::debug("TTY mode set via config");
+	}
 
 #if !defined(__APPLE__) && !defined(__OpenBSD__) && !defined(__NetBSD__)
 	else if (Term::current_tty.starts_with("/dev/tty")) {
 		Config::set("tty_mode", true);
 		Logger::debug("Auto detect real TTY");
-  	}
+	}
 #endif
 
 	Logger::debug("TTY mode enabled: {}", Config::getB("tty_mode"));

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -1455,9 +1455,13 @@ static int optionsMenu(const string& key) {
 					theme_refresh = true;
 					Config::flip("lowcolor");
 				}
+			#if !defined(__APPLE__) && !defined(__OpenBSD__) && !defined(__NetBSD__)
+				else if (option == "force_tty" and not Term::current_tty.starts_with("/dev/tty")) {
+			#else
 				else if (option == "force_tty") {
+			#endif
 					theme_refresh = true;
-					Config::flip("tty_mode");
+					Config::set("tty_mode", Config::getB("force_tty"));
 				}
 				else if (is_in(option, "rounded_corners", "theme_background"))
 					theme_refresh = true;


### PR DESCRIPTION
Fixes: #1514 

The `force_tty` menu option wasn't being applied when btop launched
even though it was being saved in the config file.

This fixes this by applying tty mode if this option is set to true in the config file