### PR TITLE
fix: net min size for gpu compiled build

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -2381,7 +2381,7 @@ namespace Draw {
 
 			width = round((double)Term::width * (Proc::shown ? width_p : 100) / 100);
 		#ifdef GPU_SUPPORT
-			height = ceil((double)Term::height * (100 - Net::height_p * Net::shown*4 / ((Gpu::shown != 0 and Cpu::shown) + 4)) / 100) - Cpu::height - Gpu::total_height;
+			height = floor(static_cast<double>(Term::height) * (100 - Net::height_p * Net::shown*4 / ((Gpu::shown != 0 and Cpu::shown) + 4)) / 100) - Cpu::height - Gpu::total_height;
 		#else
 			height = floor(static_cast<double>(Term::height) * (100 - Cpu::height_p * Cpu::shown - Net::height_p * Net::shown) / 100);
 		#endif


### PR DESCRIPTION
Fixes: #1509 

So I found out that the mem border fix solved this issue on non gpu compiled builds. while running btop on my gpu compiled build though I noticed it also had the problem.

Changing `ceil` to `floor` fixed it there as well.