### PR TITLE
fix: mem/net proportions different after fixing min net size / mem border

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1162,7 +1162,7 @@ namespace Gpu {
 #endif
 
 namespace Mem {
-	int width_p = 45, height_p = 36;
+	int width_p = 45, height_p = 40;
 	int min_width = 36, min_height = 10;
 	int x = 1, y, width = 20, height;
 	int mem_width, disks_width, divider, item_height, mem_size, mem_meter, graph_height, disk_meter;
@@ -1428,7 +1428,7 @@ namespace Mem {
 }
 
 namespace Net {
-	int width_p = 45, height_p = 32;
+	int width_p = 45, height_p = 28;
 	int min_width = 36, min_height = 6;
 	int x = 1, y, width = 20, height;
 	int b_x, b_y, b_width, b_height, d_graph_height, u_graph_height;


### PR DESCRIPTION
Fixes: #1517

I have fixed this by changing `Net::height_p` from `32` to `28`. This compensates for the difference caused by using `floor` instead of `ceil` (and not adding `1` in the non-gpu build) and gets the mem and net box proportions in all possible configurations  and window sizes for the gpu support build as close as I can to how it was before without breaking the net box minimum size or causing the mem box bottom border to disappear. I compared this with the gpu build box size proportions from before the min net box size fix.

~I have fixed this by adding 1 to the height if the cpu box is shown, the net box is shown, and no gpu boxes are shown. In doing so it looks correct with no gpus shown, it looks correct with a gpu shown, it looks correct with no cpu shown and when only the mem and net boxes are shown the minimum net box size is still obeyed. The reason it checks for the net box being shown before adding 1 to the height is because if the net box is not shown then the mem bottom border will disappear like it did in the non-gpu build.~

<hr>

Edit: It would appear that for the Non-gpu builds that while using `floor` instead of `ceil`  and not adding `+1` does fix the net box minimum size and the mem bottom border when the net box is not shown,  it also makes the mem box a tiny bit smaller and the net box a tiny bit bigger then it was before the change at various different window sizes for the no-gpu builds. Perhaps I should try to figure out a better fix that keeps the proportions of the boxes the exact same as they were before while still fixing the net box minimum size and mem bottom border. Thoughts? Personally I think it still looks fine even with the the net box closer in size to the mem box. When the cpu box isn't shown the mem box is still much bigger then the net box. And minimum sizes are obeyed. All the alternatives I have tried to keep the proportions the same while still fixing the issues with the mem bottom border and net box minimum size have resulted in inconsistent sizing of the net box when shrinking the height of the window past a certain size, breaking the net box minimum size again, or breaking the mem box bottom border with the net box not shown.

Edit 2: I have now fixed this problem in the non-gpu-support build as well with the same change. In testing the net and mem boxes now match the original proportions from before the mem border and net min size fix in almost every single window size that I have tested. The only times that it is slightly different is when the window is very short (right around at the minimum height without proc box shown) and it is not really noticeable.

<hr>

<details><summary><b>Screenshots of it fixed</b></summary>

GPU not shown (mem box is same size as net box and mem graphs are same size as when gpu is shown)
<img width="1045" height="1345" alt="Screenshot_20260127_190004" src="https://github.com/user-attachments/assets/4a383c0b-da28-4248-8c3b-9aa314613a9e" />

</br>

GPU shown
<img width="1045" height="1373" alt="Screenshot_20260127_190026" src="https://github.com/user-attachments/assets/6fcc6672-d86b-4823-be14-ce9969a6ae01" />

</details>

My apologies for missing this