### PR TITLE
Add rule to editorconfig for parity with CONTRIBUTING.md

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 [*.{cpp,h,hpp,sh,md,cfg,sample}]
 indent_style = tab
 indent_size = 4
+brace_style = same_line
 
 [*.{yml,yaml}]
 indent_style = space


### PR DESCRIPTION
In [CONTRIBUTING.md](https://github.com/aristocratos/btop/blob/main/CONTRIBUTING.md), there is a line that reads:
```md
- Opening curly braces { at the end of the same line as the statement/condition.
```
Along with the other two rules which are defined (4-space-wide tabs, not spaces), the .editorconfig should now match the requirements.

In the future, I think more rules should be added to the editorconfig file, since if I were to format the code it would likely look very different to if somebody else formatted the code. This leads to every source file being a big mix of different styles and since it is not proper etiquette to make a PR for just formatting, the current mess will stick.