### PR TITLE
proc: add cwd to process detail view

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1848,16 +1848,24 @@ namespace Proc {
 				if (item_fit >= 8) out += cjust("Nice:", item_width);
 
 
-				//? Command line
-				for (int i = 0; const auto& l : {'C', 'M', 'D'})
-				out += Mv::to(d_y + 5 + i++, d_x + 1) + l;
+				//? CWD and Command line
+				out += Mv::to(d_y + 5, d_x + 1) + Theme::c("title") + Fx::b + "CWD" + Fx::ub;
+				out += Mv::to(d_y + 6, d_x + 1) + Theme::c("title") + Fx::b + "CMD" + Fx::ub;
 
-				out += Theme::c("main_fg") + Fx::ub;
+				out += Theme::c("main_fg");
+				//? CWD line
+				out += Mv::to(d_y + 5, d_x + 5);
+				if (detailed.cwd.empty())
+					out += Theme::c("inactive_fg") + "(unavailable)";
+				else
+					out += uresize(detailed.cwd, d_width - 6, true);
+
+				//? Command lines (2 lines)
 				const auto san_cmd = replace_ascii_control(detailed.entry.cmd);
 				const int cmd_size = ulen(san_cmd, true);
-				for (int num_lines = min(3, (int)ceil((double)cmd_size / (d_width - 5))), i = 0; i < num_lines; i++) {
-					out += Mv::to(d_y + 5 + (num_lines == 1 ? 1 : i), d_x + 3)
-						+ cjust(luresize(san_cmd, cmd_size - (d_width - 5) * i, true), d_width - 5, true, true);
+				for (int num_lines = min(2, (int)ceil((double)cmd_size / (d_width - 6))), i = 0; i < num_lines; i++) {
+					out += Mv::to(d_y + 6 + (num_lines == 1 ? 0 : i), d_x + 5)
+						+ cjust(luresize(san_cmd, cmd_size - (d_width - 6) * i, true), d_width - 6, true, true);
 				}
 
 			}

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -422,7 +422,7 @@ namespace Proc {
 		size_t last_pid{};
 		bool skip_smaps{};
 		proc_info entry;
-		string elapsed, parent, status, io_read, io_write, memory;
+		string elapsed, parent, status, io_read, io_write, memory, cwd;
 		long long first_mem = -1;
 		deque<long long> cpu_percent;
 		deque<long long> mem_bytes;

--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -1074,6 +1074,16 @@ namespace Proc {
 		// 	detailed.io_read = floating_humanizer(rusage.ri_diskio_bytesread);
 		// 	detailed.io_write = floating_humanizer(rusage.ri_diskio_byteswritten);
 		// }
+
+		//? Get current working directory via sysctl
+		detailed.cwd.clear();
+		{
+			int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_CWD, (int)pid};
+			char cwdbuf[PATH_MAX];
+			size_t cwdlen = sizeof(cwdbuf);
+			if (sysctl(mib, 4, cwdbuf, &cwdlen, nullptr, 0) == 0)
+				detailed.cwd = cwdbuf;
+		}
 	}
 
 	//* Collects and sorts process information from /proc

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -2909,6 +2909,14 @@ namespace Proc {
 			catch (const std::out_of_range&) {}
 			d_read.close();
 		}
+
+		//? Get current working directory from proc/[pid]/cwd symlink
+		detailed.cwd.clear();
+		try {
+			if (fs::is_symlink(pid_path / "cwd"))
+				detailed.cwd = fs::read_symlink(pid_path / "cwd").string();
+		}
+		catch (...) {}
 	}
 
 	//* Collects and sorts process information from /proc

--- a/src/netbsd/btop_collect.cpp
+++ b/src/netbsd/btop_collect.cpp
@@ -1160,6 +1160,16 @@ namespace Proc {
 		}
 
 		while (cmp_greater(detailed.mem_bytes.size(), width)) detailed.mem_bytes.pop_front();
+
+		//? Get current working directory via sysctl
+		detailed.cwd.clear();
+		{
+			int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_CWD, (int)pid};
+			char cwdbuf[PATH_MAX];
+			size_t cwdlen = sizeof(cwdbuf);
+			if (sysctl(mib, 4, cwdbuf, &cwdlen, nullptr, 0) == 0)
+				detailed.cwd = cwdbuf;
+		}
 	}
 
 	//* Collects and sorts process information from /proc

--- a/src/openbsd/btop_collect.cpp
+++ b/src/openbsd/btop_collect.cpp
@@ -1025,6 +1025,9 @@ namespace Proc {
 		}
 
 		while (cmp_greater(detailed.mem_bytes.size(), width)) detailed.mem_bytes.pop_front();
+
+		//? OpenBSD doesn't expose other processes' cwd
+		detailed.cwd.clear();
 	}
 
 	//* Collects and sorts process information from /proc

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1657,6 +1657,13 @@ namespace Proc {
 			detailed.io_read = floating_humanizer(rusage.ri_diskio_bytesread);
 			detailed.io_write = floating_humanizer(rusage.ri_diskio_byteswritten);
 		}
+
+		//? Get current working directory
+		detailed.cwd.clear();
+		struct proc_vnodepathinfo vpi;
+		if (proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &vpi, sizeof(vpi)) > 0) {
+			detailed.cwd = vpi.pvi_cdir.vip_path;
+		}
 	}
 
 	//* Collects and sorts process information from /proc


### PR DESCRIPTION
The process detail panel now shows the working directory above the command line. On Linux this reads the `/proc/[pid]/cwd` symlink, on macOS it uses `proc_pidinfo` with `PROC_PIDVNODEPATHINFO`, and on FreeBSD/NetBSD it uses `sysctl` with `KERN_PROC_CWD`. OpenBSD doesn't expose other processes' cwd so it shows "(unavailable)" there.

The CMD display goes from 3 lines to 2 to make room, which means longer commands truncate a line sooner.