### PR TITLE
fix: wrap std::thread to join in destructor in btop_collect.cpp

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -110,6 +110,33 @@ long long get_monotonicTimeUSec()
 	return time.tv_sec * 1000000 + time.tv_nsec / 1000;
 }
 
+// Wrapper with join behavior of std::jthread to avoid -fexperimental-library
+// flag usage for Clang 19, ideally replace once flag is no longer needed.
+struct join_thread
+{
+	std::thread t;
+
+	join_thread() noexcept = default;
+
+	template<typename... Args>
+	explicit join_thread(Args&&... args) : t(std::forward<Args>(args)...) {}
+
+	~join_thread() { if (t.joinable()) t.join(); }
+
+	join_thread(join_thread&&) noexcept = default;
+
+	join_thread& operator=(join_thread&& other) noexcept {
+		if (t.joinable()) t.join();
+		t = std::move(other.t);
+		return *this;
+	}
+
+	void join() {
+		t.join();
+	}
+
+};
+
 }
 
 namespace Cpu {
@@ -1293,7 +1320,8 @@ namespace Gpu {
 			if (!initialized) return false;
 
 			nvmlReturn_t result;
-			std::thread pcie_tx_thread, pcie_rx_thread;
+			join_thread pcie_tx_thread;
+			join_thread pcie_rx_thread;
 			// DebugTimer nvTotalTimer("Nvidia Total");
 			for (unsigned int i = 0; i < device_count; ++i) {
 				if constexpr(is_init) {
@@ -1338,7 +1366,7 @@ namespace Gpu {
 
 				//? PCIe link speeds, the data collection takes >=20ms each call so they run on separate threads
 				if (gpus_slice[i].supported_functions.pcie_txrx and (Config::getB("nvml_measure_pcie_speeds") or is_init)) {
-					pcie_tx_thread = std::thread([gpus_slice, i]() {
+					pcie_tx_thread = join_thread([gpus_slice, i]() {
 						unsigned int tx;
 						nvmlReturn_t result = nvmlDeviceGetPcieThroughput(devices[i], NVML_PCIE_UTIL_TX_BYTES, &tx);
     					if (result != NVML_SUCCESS) {
@@ -1347,7 +1375,7 @@ namespace Gpu {
 						} else gpus_slice[i].pcie_tx = (long long)tx;
 					});
 
-					pcie_rx_thread = std::thread([gpus_slice, i]() {
+					pcie_rx_thread = join_thread([gpus_slice, i]() {
 						unsigned int rx;
 						nvmlReturn_t result = nvmlDeviceGetPcieThroughput(devices[i], NVML_PCIE_UTIL_RX_BYTES, &rx);
     					if (result != NVML_SUCCESS) {


### PR DESCRIPTION
These changes prevent the IOT instruction core dump from NVML after waking up from suspend, specifically `nvmlDeviceGetPcieThroughput()`. This resolves #1050.