### PR TITLE
fix: Use SVG features compatible with Qt SVG Tiny 1.1

### DIFF
--- a/Img/icon.svg
+++ b/Img/icon.svg
@@ -10,12 +10,6 @@
   <defs
      id="defs26">
     <pattern
-       xlink:href="#gray-stripes"
-       id="pattern1888" />
-    <pattern
-       xlink:href="#red-stripes"
-       id="pattern1870" />
-    <pattern
        id="red-stripes"
        width="341"
        height="90"
@@ -102,10 +96,10 @@
     <path
        d="M 2,7 V 90 H 47 V 74 h 7 V 55 H 47 V 42 h 7 V 23 H 47 V 7 Z m 1,1 h 43 v 16 h 7 v 17 h -7 v 15 h 7 V 73 H 46 V 89 H 3 Z M 18,25 H 38 V 40 H 18 Z m 1,1 V 39 H 37 V 26 Z M 18,57 H 38 V 72 H 18 Z m 1,1 V 71 H 37 V 58 Z M 4,9 V 88 H 45 V 72 h 7 V 57 H 45 V 40 h 7 V 25 H 45 V 9 Z m 1,1 h 39 v 16 h 7 v 13 h -7 v 19 h 7 V 71 H 44 V 87 H 5 Z M 16,23 H 40 V 42 H 16 Z m 1,1 V 41 H 39 V 24 Z M 16,55 H 40 V 74 H 16 Z m 1,1 V 73 H 39 V 56 Z"
        id="path42"
-       style="fill:url(#pattern1888)" />
+       style="fill:url(#gray-stripes)" />
     <path
        d="M 0,0 V 80 H 42 V 64 h 7 V 48 H 42 V 32 h 7 V 16 H 42 V 0 Z M 14,16 H 35 V 32 H 14 Z m 0,32 H 35 V 64 H 14 Z"
        id="path56"
-       style="fill:url(#pattern1870)" />
+       style="fill:url(#red-stripes)" />
   </g>
 </svg>


### PR DESCRIPTION
Committed on behalf of https://t.me/SergeiR

Downgrades incompatible (advanced) SVG features to something supported by a default Qt SVG rendered. Besides, xlink:href is deprecated[1], and in this case introduces an unnecessary indirection. Fixes these errors causing the icon to be all black in Plasma and Qt apps:

qt.svg: icon.svg:27:6: Could not resolve property: #pattern1888
qt.svg: icon.svg:27:6: Could not resolve property: #pattern1870

Interestingly enough, logo.svg doesn't need any adjustments, it's fine.

[1]: https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/xlink:href

<img width="870" height="480" alt="comparison" src="https://github.com/user-attachments/assets/393cff09-e3f8-4e7b-bae0-7b56546dd0dd" />

<details>
<summary>test.qml</summary>

```qml
import QtQuick
import QtQuick.Layouts

Window {
    width: 580
    height: 320
    visible: true
    title: qsTr("btop")

    component Showcase : ColumnLayout {
        id: comp

        required property string text
        required property url url
        readonly property int size: 256

        Rectangle {
            Layout.preferredHeight: comp.size + border.width * 2
            Layout.preferredWidth: comp.size + border.width * 2
            border.width: 2
            border.color: "gray"

            Image {
                anchors.centerIn: parent
                height: comp.size
                width: comp.size
                source: comp.url
            }
        }

        Text {
            text: comp.text
            font.pixelSize: 36
            Layout.fillWidth: true
            horizontalAlignment: Text.AlignHCenter
        }
    }

    RowLayout {
        id: item

        anchors.centerIn: parent
        spacing: 16

        Showcase {
            url: "old/icon.svg"
            text: "Old"
        }


        Showcase {
            url: "new/icon.svg"
            text: "New"
        }
    }

    Component.onCompleted: {
        contentItem.grabToImage((result) => {
            result.saveToFile("comparison.png")
        })
    }
}
```

</details>