### PR TITLE
Add E hotkey to collapse/expand all processes in tree mode

### DIFF
--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -328,6 +328,7 @@ namespace Input {
 						cur_i = Proc::sort_vector.size() - 1;
 					Config::set("proc_sorting", Proc::sort_vector.at(cur_i));
 					Config::set("update_following", true);
+					if (Config::getB("proc_tree")) no_update = false;
 				}
 				else if (key == "right" or (vim_keys and key == "l")) {
 					int cur_i = v_index(Proc::sort_vector, Config::getS("proc_sorting"));
@@ -335,6 +336,7 @@ namespace Input {
 						cur_i = 0;
 					Config::set("proc_sorting", Proc::sort_vector.at(cur_i));
 					Config::set("update_following", true);
+					if (Config::getB("proc_tree")) no_update = false;
 				}
 				else if (is_in(key, "f", "/")) {
 					Config::flip("proc_filtering");

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -346,6 +346,11 @@ namespace Input {
 					no_update = false;
 					Config::set("update_following", true);
 				}
+				else if (key == "E" and Config::getB("proc_tree")) {
+					atomic_wait(Runner::active);
+					Proc::collapse_all = 1;
+					no_update = false;
+				}
 				else if (is_in(key, "u")) {
 					Config::flip("pause_proc_list");
 				}

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -205,7 +205,7 @@ namespace Menu {
 		{"c", "Toggle per-core cpu usage of processes."},
 		{"r", "Reverse sorting order in processes box."},
 		{"e", "Toggle processes tree view."},
-			{"E", "Collapse/expand all processes in tree view."},
+		{"E", "Collapse/expand all processes in tree view."},
 		{"%", "Toggles memory display mode in processes box."},
 		{"Selected +, -", "Expand/collapse the selected process in tree view."},
 		{"Selected t", "Terminate selected process with SIGTERM - 15."},

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -205,6 +205,7 @@ namespace Menu {
 		{"c", "Toggle per-core cpu usage of processes."},
 		{"r", "Reverse sorting order in processes box."},
 		{"e", "Toggle processes tree view."},
+			{"E", "Collapse/expand all processes in tree view."},
 		{"%", "Toggles memory display mode in processes box."},
 		{"Selected +, -", "Expand/collapse the selected process in tree view."},
 		{"Selected t", "Terminate selected process with SIGTERM - 15."},

--- a/src/btop_shared.cpp
+++ b/src/btop_shared.cpp
@@ -22,6 +22,7 @@ tab-size = 4
 #include <ranges>
 #include <regex>
 #include <string>
+#include <unordered_set>
 
 #include "btop_config.hpp"
 #include "btop_shared.hpp"
@@ -267,6 +268,26 @@ bool set_priority(pid_t pid, int priority) {
 		for (auto child = t.children.begin(); child != t.children.end(); ++child) {
 			_collect_prefixes(*child, child == (t.children.end() - 1),
 				is_filtered ? "": header + (is_last ? "   ": " │ "));
+		}
+	}
+
+	void toggle_tree_collapse(std::vector<proc_info>& current_procs) {
+		//? Build sets of all pids and parent pids to identify root processes
+		std::unordered_set<size_t> pid_set, parent_pids;
+		for (const auto& p : current_procs) {
+			pid_set.insert(p.pid);
+			parent_pids.insert(static_cast<size_t>(p.ppid));
+		}
+		//? If any non-root parent is expanded, collapse; otherwise expand
+		const bool do_collapse = rng::any_of(current_procs, [&parent_pids, &pid_set](const proc_info& p) {
+			return parent_pids.contains(p.pid)
+				and pid_set.contains(static_cast<size_t>(p.ppid))
+				and not p.collapsed;
+		});
+		//? Root processes (parent not in tracked list) are never touched
+		for (auto& p : current_procs) {
+			if (not pid_set.contains(static_cast<size_t>(p.ppid))) continue;
+			p.collapsed = do_collapse;
 		}
 	}
 }

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -360,7 +360,7 @@ namespace Proc {
 	extern bool shown, redraw;
 	extern int select_max;
 	extern atomic<int> detailed_pid;
-	extern int selected_pid, start, selected, collapse, expand, filter_found, selected_depth, toggle_children;
+	extern int selected_pid, start, selected, collapse, expand, filter_found, selected_depth, toggle_children, collapse_all;
 	extern int scroll_pos;
 	extern string selected_name;
 	extern atomic<bool> resized;

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -464,6 +464,9 @@ namespace Proc {
 
 	//* Build prefixes for tree view
 	void _collect_prefixes(tree_proc& t, bool is_last, const string &header = "");
+
+	//* Toggle collapse/expand of all tree entries
+	void toggle_tree_collapse(std::vector<proc_info>& current_procs);
 }
 
 /// Detect container engine.

--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -1303,15 +1303,23 @@ namespace Proc {
 			}
 
 			if (collapse_all != -1) {
-				//? If any parent process is currently expanded, collapse all; otherwise expand all
-				std::unordered_set<size_t> parent_pids;
-				for (const auto& p : current_procs)
+				//? Build sets of all pids and parent pids to identify root processes
+				std::unordered_set<size_t> pid_set, parent_pids;
+				for (const auto& p : current_procs) {
+					pid_set.insert(p.pid);
 					parent_pids.insert(static_cast<size_t>(p.ppid));
-				const bool do_collapse = rng::any_of(current_procs, [&parent_pids](const proc_info& p) {
-					return parent_pids.contains(p.pid) and not p.collapsed;
+				}
+				//? If any non-root parent is expanded, collapse; otherwise expand
+				const bool do_collapse = rng::any_of(current_procs, [&parent_pids, &pid_set](const proc_info& p) {
+					return parent_pids.contains(p.pid)
+						and pid_set.contains(static_cast<size_t>(p.ppid))
+						and not p.collapsed;
 				});
-				for (auto& p : current_procs)
+				//? Root processes (parent not in tracked list) are never touched
+				for (auto& p : current_procs) {
+					if (not pid_set.contains(static_cast<size_t>(p.ppid))) continue;
 					p.collapsed = do_collapse;
+				}
 				collapse_all = -1;
 				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
 			}

--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -630,7 +630,7 @@ namespace Mem {
 
 		if (show_swap) {
 			char buf[_POSIX2_LINE_MAX];
-			Shared::KvmPtr kd {kvm_openfiles(nullptr, _PATH_DEVNULL, nullptr, O_RDONLY, buf)}; 
+			Shared::KvmPtr kd {kvm_openfiles(nullptr, _PATH_DEVNULL, nullptr, O_RDONLY, buf)};
    			struct kvm_swap swap[16];
    			int nswap = kvm_getswapinfo(kd.get(), swap, 16, 0);
 			int totalSwap = 0, usedSwap = 0;
@@ -1045,7 +1045,7 @@ namespace Proc {
 		struct timeval currentTime;
 		gettimeofday(&currentTime, nullptr);
 		// only interested in second granularity, so ignoring tc_usec
-		if (detailed.entry.state != 'X') detailed.elapsed = sec_to_dhms(currentTime.tv_sec - detailed.entry.cpu_s); 
+		if (detailed.entry.state != 'X') detailed.elapsed = sec_to_dhms(currentTime.tv_sec - detailed.entry.cpu_s);
 		else detailed.elapsed = sec_to_dhms(detailed.entry.death_time);
 		if (detailed.elapsed.size() > 8) detailed.elapsed.resize(detailed.elapsed.size() - 3);
 
@@ -1284,7 +1284,7 @@ namespace Proc {
 				}
 				toggle_children = -1;
 			}
-			
+
 			if (auto find_pid = (collapse != -1 ? collapse : expand); find_pid != -1) {
 				auto collapser = rng::find(current_procs, find_pid, &proc_info::pid);
 				if (collapser != current_procs.end()) {
@@ -1303,23 +1303,7 @@ namespace Proc {
 			}
 
 			if (collapse_all != -1) {
-				//? Build sets of all pids and parent pids to identify root processes
-				std::unordered_set<size_t> pid_set, parent_pids;
-				for (const auto& p : current_procs) {
-					pid_set.insert(p.pid);
-					parent_pids.insert(static_cast<size_t>(p.ppid));
-				}
-				//? If any non-root parent is expanded, collapse; otherwise expand
-				const bool do_collapse = rng::any_of(current_procs, [&parent_pids, &pid_set](const proc_info& p) {
-					return parent_pids.contains(p.pid)
-						and pid_set.contains(static_cast<size_t>(p.ppid))
-						and not p.collapsed;
-				});
-				//? Root processes (parent not in tracked list) are never touched
-				for (auto& p : current_procs) {
-					if (not pid_set.contains(static_cast<size_t>(p.ppid))) continue;
-					p.collapsed = do_collapse;
-				}
+				toggle_tree_collapse(current_procs);
 				collapse_all = -1;
 				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
 			}

--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -1007,7 +1007,7 @@ namespace Proc {
 	fs::file_time_type passwd_time;
 
 	uint64_t cputimes;
-	int collapse = -1, expand = -1, toggle_children = -1;
+	int collapse = -1, expand = -1, toggle_children = -1, collapse_all = -1;
 	uint64_t old_cputimes = 0;
 	atomic<int> numpids = 0;
 	int filter_found = 0;
@@ -1301,6 +1301,21 @@ namespace Proc {
 				}
 				collapse = expand = -1;
 			}
+
+			if (collapse_all != -1) {
+				//? If any parent process is currently expanded, collapse all; otherwise expand all
+				std::unordered_set<size_t> parent_pids;
+				for (const auto& p : current_procs)
+					parent_pids.insert(static_cast<size_t>(p.ppid));
+				const bool do_collapse = rng::any_of(current_procs, [&parent_pids](const proc_info& p) {
+					return parent_pids.contains(p.pid) and not p.collapsed;
+				});
+				for (auto& p : current_procs)
+					p.collapsed = do_collapse;
+				collapse_all = -1;
+				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
+			}
+
 			if (should_filter or not filter.empty()) filter_found = 0;
 
 			vector<tree_proc> tree_procs;

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -2879,7 +2879,7 @@ namespace Proc {
 	fs::file_time_type passwd_time;
 
 	uint64_t cputimes;
-	int collapse = -1, expand = -1, toggle_children = -1;
+	int collapse = -1, expand = -1, toggle_children = -1, collapse_all = -1;
 	uint64_t old_cputimes{};
 	atomic<int> numpids{};
 	int filter_found{};
@@ -3354,6 +3354,21 @@ namespace Proc {
 				}
 				collapse = expand = -1;
 			}
+
+			if (collapse_all != -1) {
+				//? If any parent process is currently expanded, collapse all; otherwise expand all
+				std::unordered_set<size_t> parent_pids;
+				for (const auto& p : current_procs)
+					parent_pids.insert(static_cast<size_t>(p.ppid));
+				const bool do_collapse = rng::any_of(current_procs, [&parent_pids](const proc_info& p) {
+					return parent_pids.contains(p.pid) and not p.collapsed;
+				});
+				for (auto& p : current_procs)
+					p.collapsed = do_collapse;
+				collapse_all = -1;
+				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
+			}
+
 			if (should_filter or not filter.empty()) filter_found = 0;
 
 			vector<tree_proc> tree_procs;

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -3356,15 +3356,23 @@ namespace Proc {
 			}
 
 			if (collapse_all != -1) {
-				//? If any parent process is currently expanded, collapse all; otherwise expand all
-				std::unordered_set<size_t> parent_pids;
-				for (const auto& p : current_procs)
+				//? Build sets of all pids and parent pids to identify root processes
+				std::unordered_set<size_t> pid_set, parent_pids;
+				for (const auto& p : current_procs) {
+					pid_set.insert(p.pid);
 					parent_pids.insert(static_cast<size_t>(p.ppid));
-				const bool do_collapse = rng::any_of(current_procs, [&parent_pids](const proc_info& p) {
-					return parent_pids.contains(p.pid) and not p.collapsed;
+				}
+				//? If any non-root parent is expanded, collapse; otherwise expand
+				const bool do_collapse = rng::any_of(current_procs, [&parent_pids, &pid_set](const proc_info& p) {
+					return parent_pids.contains(p.pid)
+						and pid_set.contains(static_cast<size_t>(p.ppid))
+						and not p.collapsed;
 				});
-				for (auto& p : current_procs)
+				//? Root processes (parent not in tracked list) are never touched
+				for (auto& p : current_procs) {
+					if (not pid_set.contains(static_cast<size_t>(p.ppid))) continue;
 					p.collapsed = do_collapse;
+				}
 				collapse_all = -1;
 				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
 			}

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -3337,7 +3337,7 @@ namespace Proc {
 				}
 				toggle_children = -1;
 			}
-			
+
 			if (auto find_pid = (collapse != -1 ? collapse : expand); find_pid != -1) {
 				auto collapser = rng::find(current_procs, find_pid, &proc_info::pid);
 				if (collapser != current_procs.end()) {
@@ -3356,23 +3356,7 @@ namespace Proc {
 			}
 
 			if (collapse_all != -1) {
-				//? Build sets of all pids and parent pids to identify root processes
-				std::unordered_set<size_t> pid_set, parent_pids;
-				for (const auto& p : current_procs) {
-					pid_set.insert(p.pid);
-					parent_pids.insert(static_cast<size_t>(p.ppid));
-				}
-				//? If any non-root parent is expanded, collapse; otherwise expand
-				const bool do_collapse = rng::any_of(current_procs, [&parent_pids, &pid_set](const proc_info& p) {
-					return parent_pids.contains(p.pid)
-						and pid_set.contains(static_cast<size_t>(p.ppid))
-						and not p.collapsed;
-				});
-				//? Root processes (parent not in tracked list) are never touched
-				for (auto& p : current_procs) {
-					if (not pid_set.contains(static_cast<size_t>(p.ppid))) continue;
-					p.collapsed = do_collapse;
-				}
+				toggle_tree_collapse(current_procs);
 				collapse_all = -1;
 				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
 			}

--- a/src/netbsd/btop_collect.cpp
+++ b/src/netbsd/btop_collect.cpp
@@ -1100,7 +1100,7 @@ namespace Proc {
 	fs::file_time_type passwd_time;
 
 	uint64_t cputimes;
-	int collapse = -1, expand = -1, toggle_children = -1;
+	int collapse = -1, expand = -1, toggle_children = -1, collapse_all = -1;
 	uint64_t old_cputimes = 0;
 	atomic<int> numpids = 0;
 	int filter_found = 0;
@@ -1362,6 +1362,21 @@ namespace Proc {
 				}
 				collapse = expand = -1;
 			}
+
+			if (collapse_all != -1) {
+				//? If any parent process is currently expanded, collapse all; otherwise expand all
+				std::unordered_set<size_t> parent_pids;
+				for (const auto& p : current_procs)
+					parent_pids.insert(static_cast<size_t>(p.ppid));
+				const bool do_collapse = rng::any_of(current_procs, [&parent_pids](const proc_info& p) {
+					return parent_pids.contains(p.pid) and not p.collapsed;
+				});
+				for (auto& p : current_procs)
+					p.collapsed = do_collapse;
+				collapse_all = -1;
+				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
+			}
+
 			if (should_filter or not filter.empty()) filter_found = 0;
 
 			vector<tree_proc> tree_procs;

--- a/src/netbsd/btop_collect.cpp
+++ b/src/netbsd/btop_collect.cpp
@@ -1364,23 +1364,7 @@ namespace Proc {
 			}
 
 			if (collapse_all != -1) {
-				//? Build sets of all pids and parent pids to identify root processes
-				std::unordered_set<size_t> pid_set, parent_pids;
-				for (const auto& p : current_procs) {
-					pid_set.insert(p.pid);
-					parent_pids.insert(static_cast<size_t>(p.ppid));
-				}
-				//? If any non-root parent is expanded, collapse; otherwise expand
-				const bool do_collapse = rng::any_of(current_procs, [&parent_pids, &pid_set](const proc_info& p) {
-					return parent_pids.contains(p.pid)
-						and pid_set.contains(static_cast<size_t>(p.ppid))
-						and not p.collapsed;
-				});
-				//? Root processes (parent not in tracked list) are never touched
-				for (auto& p : current_procs) {
-					if (not pid_set.contains(static_cast<size_t>(p.ppid))) continue;
-					p.collapsed = do_collapse;
-				}
+				toggle_tree_collapse(current_procs);
 				collapse_all = -1;
 				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
 			}

--- a/src/netbsd/btop_collect.cpp
+++ b/src/netbsd/btop_collect.cpp
@@ -1364,15 +1364,23 @@ namespace Proc {
 			}
 
 			if (collapse_all != -1) {
-				//? If any parent process is currently expanded, collapse all; otherwise expand all
-				std::unordered_set<size_t> parent_pids;
-				for (const auto& p : current_procs)
+				//? Build sets of all pids and parent pids to identify root processes
+				std::unordered_set<size_t> pid_set, parent_pids;
+				for (const auto& p : current_procs) {
+					pid_set.insert(p.pid);
 					parent_pids.insert(static_cast<size_t>(p.ppid));
-				const bool do_collapse = rng::any_of(current_procs, [&parent_pids](const proc_info& p) {
-					return parent_pids.contains(p.pid) and not p.collapsed;
+				}
+				//? If any non-root parent is expanded, collapse; otherwise expand
+				const bool do_collapse = rng::any_of(current_procs, [&parent_pids, &pid_set](const proc_info& p) {
+					return parent_pids.contains(p.pid)
+						and pid_set.contains(static_cast<size_t>(p.ppid))
+						and not p.collapsed;
 				});
-				for (auto& p : current_procs)
+				//? Root processes (parent not in tracked list) are never touched
+				for (auto& p : current_procs) {
+					if (not pid_set.contains(static_cast<size_t>(p.ppid))) continue;
 					p.collapsed = do_collapse;
+				}
 				collapse_all = -1;
 				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
 			}

--- a/src/openbsd/btop_collect.cpp
+++ b/src/openbsd/btop_collect.cpp
@@ -1267,15 +1267,23 @@ namespace Proc {
 			}
 
 			if (collapse_all != -1) {
-				//? If any parent process is currently expanded, collapse all; otherwise expand all
-				std::unordered_set<size_t> parent_pids;
-				for (const auto& p : current_procs)
+				//? Build sets of all pids and parent pids to identify root processes
+				std::unordered_set<size_t> pid_set, parent_pids;
+				for (const auto& p : current_procs) {
+					pid_set.insert(p.pid);
 					parent_pids.insert(static_cast<size_t>(p.ppid));
-				const bool do_collapse = rng::any_of(current_procs, [&parent_pids](const proc_info& p) {
-					return parent_pids.contains(p.pid) and not p.collapsed;
+				}
+				//? If any non-root parent is expanded, collapse; otherwise expand
+				const bool do_collapse = rng::any_of(current_procs, [&parent_pids, &pid_set](const proc_info& p) {
+					return parent_pids.contains(p.pid)
+						and pid_set.contains(static_cast<size_t>(p.ppid))
+						and not p.collapsed;
 				});
-				for (auto& p : current_procs)
+				//? Root processes (parent not in tracked list) are never touched
+				for (auto& p : current_procs) {
+					if (not pid_set.contains(static_cast<size_t>(p.ppid))) continue;
 					p.collapsed = do_collapse;
+				}
 				collapse_all = -1;
 				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
 			}

--- a/src/openbsd/btop_collect.cpp
+++ b/src/openbsd/btop_collect.cpp
@@ -1267,23 +1267,7 @@ namespace Proc {
 			}
 
 			if (collapse_all != -1) {
-				//? Build sets of all pids and parent pids to identify root processes
-				std::unordered_set<size_t> pid_set, parent_pids;
-				for (const auto& p : current_procs) {
-					pid_set.insert(p.pid);
-					parent_pids.insert(static_cast<size_t>(p.ppid));
-				}
-				//? If any non-root parent is expanded, collapse; otherwise expand
-				const bool do_collapse = rng::any_of(current_procs, [&parent_pids, &pid_set](const proc_info& p) {
-					return parent_pids.contains(p.pid)
-						and pid_set.contains(static_cast<size_t>(p.ppid))
-						and not p.collapsed;
-				});
-				//? Root processes (parent not in tracked list) are never touched
-				for (auto& p : current_procs) {
-					if (not pid_set.contains(static_cast<size_t>(p.ppid))) continue;
-					p.collapsed = do_collapse;
-				}
+				toggle_tree_collapse(current_procs);
 				collapse_all = -1;
 				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
 			}

--- a/src/openbsd/btop_collect.cpp
+++ b/src/openbsd/btop_collect.cpp
@@ -991,7 +991,7 @@ namespace Proc {
 	fs::file_time_type passwd_time;
 
 	uint64_t cputimes;
-	int collapse = -1, expand = -1, toggle_children = -1;
+	int collapse = -1, expand = -1, toggle_children = -1, collapse_all = -1;
 	uint64_t old_cputimes = 0;
 	atomic<int> numpids = 0;
 	int filter_found = 0;
@@ -1265,6 +1265,21 @@ namespace Proc {
 				}
 				collapse = expand = -1;
 			}
+
+			if (collapse_all != -1) {
+				//? If any parent process is currently expanded, collapse all; otherwise expand all
+				std::unordered_set<size_t> parent_pids;
+				for (const auto& p : current_procs)
+					parent_pids.insert(static_cast<size_t>(p.ppid));
+				const bool do_collapse = rng::any_of(current_procs, [&parent_pids](const proc_info& p) {
+					return parent_pids.contains(p.pid) and not p.collapsed;
+				});
+				for (auto& p : current_procs)
+					p.collapsed = do_collapse;
+				collapse_all = -1;
+				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
+			}
+
 			if (should_filter or not filter.empty()) filter_found = 0;
 
 			vector<tree_proc> tree_procs;

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1905,7 +1905,7 @@ namespace Proc {
 				}
 				toggle_children = -1;
 			}
-			
+
 			if (auto find_pid = (collapse != -1 ? collapse : expand); find_pid != -1) {
 				auto collapser = rng::find(current_procs, find_pid, &proc_info::pid);
 				if (collapser != current_procs.end()) {
@@ -1924,23 +1924,7 @@ namespace Proc {
 			}
 
 			if (collapse_all != -1) {
-				//? Build sets of all pids and parent pids to identify root processes
-				std::unordered_set<size_t> pid_set, parent_pids;
-				for (const auto& p : current_procs) {
-					pid_set.insert(p.pid);
-					parent_pids.insert(static_cast<size_t>(p.ppid));
-				}
-				//? If any non-root parent is expanded, collapse; otherwise expand
-				const bool do_collapse = rng::any_of(current_procs, [&parent_pids, &pid_set](const proc_info& p) {
-					return parent_pids.contains(p.pid)
-						and pid_set.contains(static_cast<size_t>(p.ppid))
-						and not p.collapsed;
-				});
-				//? Root processes (parent not in tracked list) are never touched
-				for (auto& p : current_procs) {
-					if (not pid_set.contains(static_cast<size_t>(p.ppid))) continue;
-					p.collapsed = do_collapse;
-				}
+				toggle_tree_collapse(current_procs);
 				collapse_all = -1;
 				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
 			}

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1924,15 +1924,23 @@ namespace Proc {
 			}
 
 			if (collapse_all != -1) {
-				//? If any parent process is currently expanded, collapse all; otherwise expand all
-				std::unordered_set<size_t> parent_pids;
-				for (const auto& p : current_procs)
+				//? Build sets of all pids and parent pids to identify root processes
+				std::unordered_set<size_t> pid_set, parent_pids;
+				for (const auto& p : current_procs) {
+					pid_set.insert(p.pid);
 					parent_pids.insert(static_cast<size_t>(p.ppid));
-				const bool do_collapse = rng::any_of(current_procs, [&parent_pids](const proc_info& p) {
-					return parent_pids.contains(p.pid) and not p.collapsed;
+				}
+				//? If any non-root parent is expanded, collapse; otherwise expand
+				const bool do_collapse = rng::any_of(current_procs, [&parent_pids, &pid_set](const proc_info& p) {
+					return parent_pids.contains(p.pid)
+						and pid_set.contains(static_cast<size_t>(p.ppid))
+						and not p.collapsed;
 				});
-				for (auto& p : current_procs)
+				//? Root processes (parent not in tracked list) are never touched
+				for (auto& p : current_procs) {
+					if (not pid_set.contains(static_cast<size_t>(p.ppid))) continue;
 					p.collapsed = do_collapse;
+				}
 				collapse_all = -1;
 				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
 			}

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1590,7 +1590,7 @@ namespace Proc {
 	fs::file_time_type passwd_time;
 
 	uint64_t cputimes;
-	int collapse = -1, expand = -1, toggle_children = -1;
+	int collapse = -1, expand = -1, toggle_children = -1, collapse_all = -1;
 	uint64_t old_cputimes = 0;
 	atomic<int> numpids = 0;
 	int filter_found = 0;
@@ -1922,6 +1922,21 @@ namespace Proc {
 				}
 				collapse = expand = -1;
 			}
+
+			if (collapse_all != -1) {
+				//? If any parent process is currently expanded, collapse all; otherwise expand all
+				std::unordered_set<size_t> parent_pids;
+				for (const auto& p : current_procs)
+					parent_pids.insert(static_cast<size_t>(p.ppid));
+				const bool do_collapse = rng::any_of(current_procs, [&parent_pids](const proc_info& p) {
+					return parent_pids.contains(p.pid) and not p.collapsed;
+				});
+				for (auto& p : current_procs)
+					p.collapsed = do_collapse;
+				collapse_all = -1;
+				if (Config::ints.at("proc_selected") > 0) locate_selection = true;
+			}
+
 			if (should_filter or not filter.empty()) filter_found = 0;
 
 			vector<tree_proc> tree_procs;


### PR DESCRIPTION
Closes #1563, addresses #520, #673, #1528 and #686.

Been using btop for years, it's my favorite system monitor by far. 
Tree mode is great but I always found myself tediously spacebar-collapsing every single node just to get the per-app summary view. Finally sat down gave it a try.

Here's the overview:

- `E` collapses all processes in tree mode at once, or expands them all if everything is already collapsed
- Root processes (launchd, systemd, top-level daemons) are left untouched since collapsing them would just hide everything underneath rather than giving you the summary view
- `E` pairs naturally with the existing `e` (toggle tree mode on/off)
- Also fixes the one-frame rendering glitch from #1563: sort key presses were calling `Runner::run` with `no_update=true`, which meant `_tree_gen` skipped setting `p.filtered=true` for collapsed children while [line 211 of `btop_shared.cpp`](https://github.com/aristocratos/btop/blob/1ec8b7379ac0660ce5615ce2d10313f957fe0da9/src/btop_shared.cpp#L211) was unconditionally clearing their stale flag from the previous cycle. Fixed by forcing `no_update=false` on left/right when `proc_tree` is active.


This is my first time contributing to a project so large so please tell me if there's anything I need to update/change.

Before and After:

https://github.com/user-attachments/assets/88068790-fd1f-48ec-adef-446ec4b0f198

