### PR TITLE
Add support for AMD ROCm 7

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -1576,7 +1576,8 @@ namespace Gpu {
 				if ((rsmi_dev_gpu_clk_freq_get_v5 = (decltype(rsmi_dev_gpu_clk_freq_get_v5))load_rsmi_sym("rsmi_dev_gpu_clk_freq_get")) == nullptr)
 					return false;
 			// In the release tarballs of rocm 6.0.0 and 6.0.2 the version queried with rsmi_version_get is 7.0.0.0
-			} else if (version.major == 6 || version.major == 7) {
+			// In rocm 7.2 the version is 1.0.0.0
+			} else if (version.major == 1 || version.major == 6 || version.major == 7) {
 				if ((rsmi_dev_gpu_clk_freq_get_v6 = (decltype(rsmi_dev_gpu_clk_freq_get_v6))load_rsmi_sym("rsmi_dev_gpu_clk_freq_get")) == nullptr)
 					return false;
 			} else {


### PR DESCRIPTION
Allows btop to continue providing GPU information after an upgrade to ROCm 7.  Resolves #1540 incorrectly marked as duplicate.