### PR TITLE
feat: show/hide ip address option

### DIFF
--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -223,6 +223,8 @@ namespace Config {
 
 	    {"base_10_bitrate",     "#* \"True\" shows bitrates in base 10 (Kbps, Mbps). \"False\" shows bitrates in binary sizes (Kibps, Mibps, etc.). \"Auto\" uses base_10_sizes."},
 
+		{"net_hide_ip", 		"#* Toggles ip address visibility in the net box."},
+
 		{"show_battery", 		"#* Show battery stats in top right if battery is present."},
 
 		{"selected_battery",	"#* Which battery to use if multiple are present. \"Auto\" for auto detection."},
@@ -332,6 +334,7 @@ namespace Config {
 		{"io_graph_combined", false},
 		{"net_auto", true},
 		{"net_sync", true},
+		{"net_hide_ip", false},
 		{"show_battery", true},
 		{"show_battery_watts", true},
 		{"vim_keys", false},

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1467,6 +1467,7 @@ namespace Net {
 		if (force_redraw) redraw = true;
 		auto net_sync = Config::getB("net_sync");
 		auto net_auto = Config::getB("net_auto");
+		auto net_hide_ip = Config::getB("net_hide_ip");
 		auto tty_mode = Config::getB("tty_mode");
 		auto swap_upload_download = Config::getB("swap_upload_download");
 		auto& graph_symbol = (tty_mode ? "tty" : Config::getS("graph_symbol_net"));
@@ -1520,7 +1521,7 @@ namespace Net {
 		}
 
 		//? IP or device address
-		if (not ip_addr.empty() and cmp_greater(width - i_size - 36, ip_addr.size())) {
+		if (not net_hide_ip and not ip_addr.empty() and cmp_greater(width - i_size - 36, ip_addr.size())) {
 			out += Mv::to(y, x + 8) + title_left + Theme::c("title") + Fx::b + ip_addr + title_right;
 		}
 

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1470,6 +1470,7 @@ namespace Net {
 		if (force_redraw) redraw = true;
 		auto net_sync = Config::getB("net_sync");
 		auto net_auto = Config::getB("net_auto");
+		auto net_hide_ip = Config::getB("net_hide_ip");
 		auto tty_mode = Config::getB("tty_mode");
 		auto swap_upload_download = Config::getB("swap_upload_download");
 		auto& graph_symbol = (tty_mode ? "tty" : Config::getS("graph_symbol_net"));
@@ -1523,7 +1524,7 @@ namespace Net {
 		}
 
 		//? IP or device address
-		if (not ip_addr.empty() and cmp_greater(width - i_size - 36, ip_addr.size())) {
+		if (not net_hide_ip and not ip_addr.empty() and cmp_greater(width - i_size - 36, ip_addr.size())) {
 			out += Mv::to(y, x + 8) + title_left + Theme::c("title") + Fx::b + ip_addr + title_right;
 		}
 

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -799,6 +799,10 @@ namespace Menu {
 			    "       setting for bitrates",
 			    "",
 			    "True, False, or Auto",},
+			{"net_hide_ip",
+				"Hides the IP address in the net box.",
+				"",
+				"True or False."},
 		},
 		{
 			{"proc_left",

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -800,6 +800,10 @@ namespace Menu {
 			    "       setting for bitrates",
 			    "",
 			    "True, False, or Auto",},
+			{"net_hide_ip",
+				"Hides the IP address in the net box.",
+				"",
+				"True or False."},
 		},
 		{
 			{"proc_left",


### PR DESCRIPTION
This implements a menu option to show or hide ip addresses. This is useful on systems with public ip addresses.

Closes #1273

Built and tested on Arch Linux 6.19.6