### PR TITLE
Fix: Use correct PID for signals to processes

### DIFF
--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -981,10 +981,14 @@ namespace Menu {
 	};
 
 	static int signalChoose(const string& key) {
-		auto s_pid = (Config::getB("show_detailed") and Config::getI("selected_pid") == 0 ? Config::getI("detailed_pid") : Config::getI("selected_pid"));
+		static std::optional<int> s_pid;
 		static int x{};
 		static int y{};
 		static int selected_signal = -1;
+
+		if (!s_pid) {
+			s_pid = (Config::getB("show_detailed") and Config::getI("selected_pid") == 0 ? Config::getI("detailed_pid") : Config::getI("selected_pid"));
+		}
 
 		if (bg.empty()) selected_signal = -1;
 		auto& out = Global::overlay;
@@ -994,11 +998,11 @@ namespace Menu {
 			x = Term::width/2 - 40;
 			y = Term::height/2 - 9;
 			bg = Draw::createBox(x + 2, y, 78, 19, Theme::c("hi_fg"), true, "signals");
-			bg += Mv::to(y+2, x+3) + Theme::c("title") + Fx::b + cjust("Send signal to PID " + to_string(s_pid) + " ("
+			bg += Mv::to(y+2, x+3) + Theme::c("title") + Fx::b + cjust("Send signal to PID " + to_string(s_pid.value()) + " ("
 				+ uresize((s_pid == Config::getI("detailed_pid") ? Proc::detailed.entry.name : Config::getS("selected_name")), 30) + ")", 76);
 		}
 		else if (is_in(key, "escape", "q")) {
-			return Closed;
+			goto MenuClosing;
 		}
 		else if (key.starts_with("button_")) {
 			if (int new_select = stoi(key.substr(7)); new_select == selected_signal)
@@ -1013,11 +1017,11 @@ namespace Menu {
 				signalKillRet = ESRCH;
 				menuMask.set(SignalReturn);
 			}
-			else if (kill(s_pid, selected_signal) != 0) {
+			else if (kill(s_pid.value(), selected_signal) != 0) {
 				signalKillRet = errno;
 				menuMask.set(SignalReturn);
 			}
-			return Closed;
+			goto MenuClosing;
 		}
 		else if (key.size() == 1 and isdigit(key.at(0)) and selected_signal < 10) {
 			selected_signal = std::min(std::stoi((selected_signal < 1 ? key : to_string(selected_signal) + key)), 64);
@@ -1086,6 +1090,10 @@ namespace Menu {
 		}
 
 		return (redraw ? Changed : retval);
+
+		MenuClosing:
+			s_pid.reset();
+			return Closed;
 	}
 
 	static int sizeError(const string& key) {
@@ -1111,8 +1119,12 @@ namespace Menu {
 	}
 
 	static int signalSend(const string& key) {
-		auto s_pid = (Config::getB("show_detailed") and Config::getI("selected_pid") == 0 ? Config::getI("detailed_pid") : Config::getI("selected_pid"));
-		if (s_pid == 0) return Closed;
+		static std::optional<int> s_pid;
+
+		if (!s_pid) {
+			s_pid = (Config::getB("show_detailed") and Config::getI("selected_pid") == 0 ? Config::getI("detailed_pid") : Config::getI("selected_pid"));
+		}
+
 		if (redraw) {
 			atomic_wait(Runner::active);
 			auto& p_name = (s_pid == Config::getI("detailed_pid") ? Proc::detailed.entry.name : Config::getS("selected_name"));
@@ -1120,7 +1132,7 @@ namespace Menu {
 				Fx::b + Theme::c("main_fg") + "Send signal: " + Fx::ub + Theme::c("hi_fg") + to_string(signalToSend)
 				+ (signalToSend > 0 and signalToSend <= 32 ? Theme::c("main_fg") + " (" + P_Signals.at(signalToSend) + ')' : ""),
 
-				Fx::b + Theme::c("main_fg") + "To PID: " + Fx::ub + Theme::c("hi_fg") + to_string(s_pid) + Theme::c("main_fg") + " ("
+				Fx::b + Theme::c("main_fg") + "To PID: " + Fx::ub + Theme::c("hi_fg") + to_string(s_pid.value()) + Theme::c("main_fg") + " ("
 				+ uresize(p_name, 16) + ')' + Fx::reset,
 			};
 			messageBox = Menu::msgBox{50, 1, cont_vec, (signalToSend > 1 and signalToSend <= 32 and signalToSend != 17 ? P_Signals.at(signalToSend) : "signal")};
@@ -1129,16 +1141,16 @@ namespace Menu {
 		auto ret = messageBox.input(key);
 		if (ret == msgBox::Ok_Yes) {
 			signalKillRet = 0;
-			if (kill(s_pid, signalToSend) != 0) {
+			if (kill(s_pid.value(), signalToSend) != 0) {
 				signalKillRet = errno;
 				menuMask.set(SignalReturn);
 			}
 			messageBox.clear();
-			return Closed;
+			goto MenuClosing;
 		}
 		else if (ret == msgBox::No_Esc) {
 			messageBox.clear();
-			return Closed;
+			goto MenuClosing;
 		}
 		else if (ret == msgBox::Select) {
 			Global::overlay = messageBox();
@@ -1148,6 +1160,10 @@ namespace Menu {
 			return Changed;
 		}
 		return NoChange;
+
+		MenuClosing:
+			s_pid.reset();
+			return Closed;
 	}
 
 	static int signalReturn(const string& key) {
@@ -1709,11 +1725,15 @@ static int optionsMenu(const string& key) {
 	}
 
 	static int reniceMenu(const string& key) {
-		auto s_pid = (Config::getB("show_detailed") and Config::getI("selected_pid") == 0 ? Config::getI("detailed_pid") : Config::getI("selected_pid"));
+		static std::optional<int> s_pid;
 		static int x{};
 		static int y{};
 		static int selected_nice = 0;
 		static string nice_edit;
+
+		if (!s_pid) {
+			s_pid = (Config::getB("show_detailed") and Config::getI("selected_pid") == 0 ? Config::getI("detailed_pid") : Config::getI("selected_pid"));
+		}
 
 		if (bg.empty()) {
 			selected_nice = 0;
@@ -1726,11 +1746,11 @@ static int optionsMenu(const string& key) {
 			x = Term::width/2 - 25;
 			y = Term::height/2 - 6;
 			bg = Draw::createBox(x + 2, y, 50, 13, Theme::c("hi_fg"), true, "renice");
-			bg += Mv::to(y+2, x+3) + Theme::c("title") + Fx::b + cjust("Renice PID " + to_string(s_pid) + " ("
+			bg += Mv::to(y+2, x+3) + Theme::c("title") + Fx::b + cjust("Renice PID " + to_string(s_pid.value()) + " ("
 				+ uresize((s_pid == Config::getI("detailed_pid") ? Proc::detailed.entry.name : Config::getS("selected_name")), 15) + ")", 48);
 		}
 		else if (is_in(key, "escape", "q")) {
-			return Closed;
+			goto MenuClosing;
 		}
 		else if (is_in(key, "enter", "space")) {
 			if (s_pid > 0) {
@@ -1740,11 +1760,11 @@ static int optionsMenu(const string& key) {
 					}
 					catch (...) { selected_nice = 0; }
 				}
-				if (not Proc::set_priority(s_pid, selected_nice)) {
+				if (not Proc::set_priority(s_pid.value(), selected_nice)) {
 					// TODO: show error message
 				}
 			}
-			return Closed;
+			goto MenuClosing;
 		}
 		else if (key.size() == 1 and (isdigit(key.at(0)) or (key.at(0) == '-' and nice_edit.empty()))) {
 			nice_edit += key;
@@ -1794,6 +1814,10 @@ static int optionsMenu(const string& key) {
 		}
 
 		return (redraw ? Changed : retval);
+
+		MenuClosing:
+			s_pid.reset();
+			return Closed;
 	}
 
 	//* Add menus here and update enum Menus in header


### PR DESCRIPTION
Fixes #846. Process signal popup menus use the "current" selected process, which can drift around when not following processes. Fix by retaining and using the initial PID selected at popup creation. Applies to `t`erminate, `K`ill, `s`ignals and `N`ice.