### PR TITLE
fix: accurate macOS memory usage reporting

### DIFF
--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1200,11 +1200,13 @@ namespace Mem {
 
 		vm_statistics64 p;
 		mach_msg_type_number_t info_size = HOST_VM_INFO64_COUNT;
+		vm_size_t vm_page_size;
+		host_page_size(mach_host_self(), &vm_page_size);
 		if (host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t)&p, &info_size) == 0) {
-			mem.stats.at("free") = p.free_count * Shared::pageSize;
-			mem.stats.at("cached") = p.external_page_count * Shared::pageSize;
-			mem.stats.at("used") = (p.active_count + p.wire_count) * Shared::pageSize;
-			mem.stats.at("available") = Shared::totalMem - mem.stats.at("used");
+			mem.stats.at("free") = p.free_count * vm_page_size;
+			mem.stats.at("cached") = p.external_page_count * vm_page_size;
+			mem.stats.at("used") = Shared::totalMem - mem.stats.at("free") - mem.stats.at("cached");
+			mem.stats.at("available") = mem.stats.at("free") + mem.stats.at("cached");
 		}
 
 		int mib[2] = {CTL_VM, VM_SWAPUSAGE};


### PR DESCRIPTION
    - Use host_page_size() instead of sysconf(_SC_PAGE_SIZE) to get the hardware page size for vm_statistics64 calculations, fixing a 4x undercount on Apple Silicon
    - Add other pages to formula for more accurate data