### PR TITLE
Fix OpenBSD display of online CPUs

### DIFF
--- a/src/openbsd/btop_collect.cpp
+++ b/src/openbsd/btop_collect.cpp
@@ -127,7 +127,7 @@ namespace Shared {
 		//? Shared global variables init
 		int mib[2];
 		mib[0] = CTL_HW;
-		mib[1] = HW_NCPU;
+		mib[1] = HW_NCPUONLINE;
 		int ncpu;
 		size_t len = sizeof(ncpu);
 		if (sysctl(mib, 2, &ncpu, &len, nullptr, 0) == -1) {
@@ -392,12 +392,21 @@ namespace Cpu {
 			Logger::error("failed to get load averages");
 		}
 
+		//? Read total physical CPU count for sysctl iteration
+		//? (may differ from coreCount when SMT is disabled via hw.smt=0).
+		int ncpu_total = Shared::coreCount;
+		{
+			int mib[] = {CTL_HW, HW_NCPU};
+			size_t len = sizeof(ncpu_total);
+			sysctl(mib, 2, &ncpu_total, &len, nullptr, 0);
+		}
+
 		auto cp_time = std::unique_ptr<struct cpustats[]>{
-			new struct cpustats[Shared::coreCount]
+			new struct cpustats[ncpu_total]
 		};
 		size_t size = sizeof(struct cpustats);
 		static int cpustats_mib[] = {CTL_KERN, KERN_CPUSTATS, /*fillme*/0};
-		for (int i = 0; i < Shared::coreCount; i++) {
+		for (int i = 0; i < ncpu_total; i++) {
 			cpustats_mib[2] = i;
 			if (sysctl(cpustats_mib, 3, &cp_time[i], &size, NULL, 0) == -1) {
 				Logger::error("sysctl kern.cpustats failed");
@@ -407,11 +416,16 @@ namespace Cpu {
 		long long global_idles = 0;
 		vector<long long> times_summed = {0, 0, 0, 0};
 
-		for (long i = 0; i < Shared::coreCount; i++) {
+		//? j iterates all physical CPUs; offline ones are skipped
+		//? i is the display slot index, incremented only for online CPUs
+		for (long i = 0, j = 0; j < ncpu_total; j++) {
+			if (!(cp_time[j].cs_flags & CPUSTATS_ONLINE))
+				continue;
+
 			vector<long long> times;
 			//? 0=user, 1=nice, 2=system, 3=idle
 			for (int x = 0; const unsigned int c_state : {CP_USER, CP_NICE, CP_SYS, CP_IDLE}) {
-				auto val = cp_time[i].cs_time[c_state];
+				auto val = cp_time[j].cs_time[c_state];
 				times.push_back(val);
 				times_summed.at(x++) += val;
 			}
@@ -426,7 +440,6 @@ namespace Cpu {
 				global_idles += idles;
 
 				//? Calculate cpu total for each core
-				if (i > Shared::coreCount) break;
 				const long long calc_totals = max(0ll, totals - core_old_totals.at(i));
 				const long long calc_idles = max(0ll, idles - core_old_idles.at(i));
 				core_old_totals.at(i) = totals;
@@ -441,7 +454,7 @@ namespace Cpu {
 				Logger::error("Cpu::collect() : {}", e.what());
 				throw std::runtime_error(fmt::format("collect() : {}", e.what()));
 			}
-
+			i++;
 		}
 
 		const long long calc_totals = max(1ll, global_totals - cpu_old.at("totals"));
@@ -1222,7 +1235,7 @@ namespace Proc {
 				}
 				toggle_children = -1;
 			}
-			
+
 			if (auto find_pid = (collapse != -1 ? collapse : expand); find_pid != -1) {
 				auto collapser = rng::find(current_procs, find_pid, &proc_info::pid);
 				if (collapser != current_procs.end()) {

--- a/src/openbsd/btop_collect.cpp
+++ b/src/openbsd/btop_collect.cpp
@@ -395,10 +395,10 @@ namespace Cpu {
 		auto cp_time = std::unique_ptr<struct cpustats[]>{
 			new struct cpustats[Shared::coreCount]
 		};
-		size_t size = Shared::coreCount * sizeof(struct cpustats);
+		size_t size = sizeof(struct cpustats);
 		static int cpustats_mib[] = {CTL_KERN, KERN_CPUSTATS, /*fillme*/0};
 		for (int i = 0; i < Shared::coreCount; i++) {
-			cpustats_mib[2] = i / 2;
+			cpustats_mib[2] = i;
 			if (sysctl(cpustats_mib, 3, &cp_time[i], &size, NULL, 0) == -1) {
 				Logger::error("sysctl kern.cpustats failed");
 			}


### PR DESCRIPTION
This should fix issue #1237 where stats for only half of the CPU cores are effectively displayed, and their results are doubled in the output on OpenBSD.

OpenBSD by default disables multi-threading on amd64 platforms, though it can be reenabled with the hw.smt sysctl. There appears to have been an attempt earlier to deal with this behavior by dividing the CPU index in 2, which made all of the 8 threads appear to have activity in btop, when only the first 4 were actually active. The knock-on effect is any platform without SMT shows stats for only half of the cores, and the other lines are duplicates.

This fix first corrects the error in CPU stats collection by removing the CPU index divisor, and fixes an incorrect size passed to sysctl for the cpustats struct. The second change adjusts the collect loop to only collect stats for online CPUs, which produces the expected output when SMT is enabled, disabled, or does not exist in the first place.

This is an i7 with SMT enabled:
<img width="266" height="211" alt="image" src="https://github.com/user-attachments/assets/2f80b7c6-50be-4b58-a72a-ac61ca3ef930" />

SMT disabled:
<img width="276" height="154" alt="image" src="https://github.com/user-attachments/assets/7e103715-c6fb-44ac-8539-c36d545305bf" />


And a 12 core big/little ARM cpu where I've got the scheduler tuned to deprioritize cores 2-5 (how I first noticed this bug):
<img width="237" height="279" alt="image" src="https://github.com/user-attachments/assets/8864d4fa-732f-4606-afac-3b77f59093da" />
