### PR TITLE
Improve workflow security

### DIFF
--- a/.github/workflows/cmake-freebsd.yml
+++ b/.github/workflows/cmake-freebsd.yml
@@ -1,5 +1,7 @@
 name: FreeBSD CMake
 
+permissions: {}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cmake-freebsd.yml
+++ b/.github/workflows/cmake-freebsd.yml
@@ -37,6 +37,8 @@ jobs:
         version: ['14.3', '15.0']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Compile
         uses: vmactions/freebsd-vm@4807432c7cab1c3f97688665332c0b932062d31f # v1.4.3

--- a/.github/workflows/cmake-freebsd.yml
+++ b/.github/workflows/cmake-freebsd.yml
@@ -36,10 +36,10 @@ jobs:
         arch: ['aarch64', 'x86_64']
         version: ['14.3', '15.0']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Compile
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@4807432c7cab1c3f97688665332c0b932062d31f # v1.4.3
         with:
           arch: ${{ matrix.arch }}
           release: ${{ matrix.version }}

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -44,6 +44,8 @@ jobs:
             version: 14
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install clang ${{ matrix.version }}
         if: ${{ matrix.compiler == 'clang' }}

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -1,5 +1,7 @@
 name: Linux CMake
 
+permissions: {}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -43,7 +43,7 @@ jobs:
           - compiler: gcc
             version: 14
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install clang ${{ matrix.version }}
         if: ${{ matrix.compiler == 'clang' }}

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -42,6 +42,9 @@ jobs:
             version: 21
           - compiler: gcc
             version: 14
+    env:
+      COMPILER: "${{ matrix.compiler }}"
+      VERSION: "${{ matrix.version }}"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -49,18 +52,18 @@ jobs:
 
       - name: Install clang ${{ matrix.version }}
         if: ${{ matrix.compiler == 'clang' }}
-        run: wget -qO - https://apt.llvm.org/llvm.sh | sudo bash -s -- ${{ matrix.version }} all
+        run: wget -qO - https://apt.llvm.org/llvm.sh | sudo bash -s -- ${VERSION} all
 
       - name: Configure
         run: |
-          if [[ "${{ matrix.compiler }}" == "clang" ]]; then
-            export CC=clang-${{ matrix.version }}
-            export CXX=clang++-${{ matrix.version }}
+          if [[ "${COMPILER}" == "clang" ]]; then
+            export CC=clang-${VERSION}
+            export CXX=clang++-${VERSION}
             export CXXFLAGS="-stdlib=libc++"
             export LDFLAGS="-fuse-ld=lld -rtlib=compiler-rt -unwindlib=libunwind"
           else
-            export CC=gcc-${{ matrix.version }}
-            export CXX=g++-${{ matrix.version }}
+            export CC=gcc-${VERSION}
+            export CXX=g++-${VERSION}
           fi
           cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
 

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -46,6 +46,8 @@ jobs:
             version: 14
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install clang ${{ matrix.version }}
         if: ${{ matrix.compiler == 'clang' }}

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -44,6 +44,9 @@ jobs:
             version: 22
           - compiler: gcc
             version: 14
+    env:
+      COMPILER: "${{ matrix.compiler }}"
+      VERSION: "${{ matrix.version }}"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -51,18 +54,18 @@ jobs:
 
       - name: Install clang ${{ matrix.version }}
         if: ${{ matrix.compiler == 'clang' }}
-        run: wget -qO - https://apt.llvm.org/llvm.sh | sudo bash -s -- ${{ matrix.version }} all
+        run: wget -qO - https://apt.llvm.org/llvm.sh | sudo bash -s -- ${VERSION} all
 
       - name: Configure
         run: |
-          if [[ "${{ matrix.compiler }}" == "clang" ]]; then
-            export CC=clang-${{ matrix.version }}
-            export CXX=clang++-${{ matrix.version }}
+          if [[ "${COMPILER}" == "clang" ]]; then
+            export CC=clang-${VERSION}
+            export CXX=clang++-${VERSION}
             export CXXFLAGS="-stdlib=libc++"
             export LDFLAGS="-fuse-ld=lld -rtlib=compiler-rt -unwindlib=libunwind"
           else
-            export CC=gcc-${{ matrix.version }}
-            export CXX=g++-${{ matrix.version }}
+            export CC=gcc-${VERSION}
+            export CXX=g++-${VERSION}
           fi
           cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
 

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -45,7 +45,7 @@ jobs:
           - compiler: gcc
             version: 14
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install clang ${{ matrix.version }}
         if: ${{ matrix.compiler == 'clang' }}

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -31,7 +31,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install build tools
         run: |

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -1,5 +1,7 @@
 name: macOS CMake
 
+permissions: {}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -32,6 +32,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install build tools
         run: |

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -24,12 +24,13 @@ on:
       - 'src/*pp'
       - 'src/osx/*pp'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cmake_build_on_macos:
     runs-on: macos-15
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-      cancel-in-progress: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/cmake-netbsd.yml
+++ b/.github/workflows/cmake-netbsd.yml
@@ -36,10 +36,10 @@ jobs:
         arch: ['aarch64', 'amd64']
         version: ['10.1']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Compile
-        uses: vmactions/netbsd-vm@v1
+        uses: vmactions/netbsd-vm@ca7ff0556959998c82761c34ea0c3c99fa084c48 # v1.3.7
         with:
           arch: ${{ matrix.arch }}
           release: ${{ matrix.version }}

--- a/.github/workflows/cmake-netbsd.yml
+++ b/.github/workflows/cmake-netbsd.yml
@@ -1,5 +1,7 @@
 name: NetBSD CMake
 
+permissions: {}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cmake-netbsd.yml
+++ b/.github/workflows/cmake-netbsd.yml
@@ -37,6 +37,8 @@ jobs:
         version: ['10.1']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Compile
         uses: vmactions/netbsd-vm@ca7ff0556959998c82761c34ea0c3c99fa084c48 # v1.3.7

--- a/.github/workflows/cmake-openbsd.yml
+++ b/.github/workflows/cmake-openbsd.yml
@@ -37,6 +37,8 @@ jobs:
         version: ['7.8']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Compile
         uses: vmactions/openbsd-vm@3fafb45f2e2e696249c583835939323fe1c3448c # v1.3.7

--- a/.github/workflows/cmake-openbsd.yml
+++ b/.github/workflows/cmake-openbsd.yml
@@ -36,10 +36,10 @@ jobs:
         arch: ['aarch64', 'x86_64']
         version: ['7.8']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Compile
-        uses: vmactions/openbsd-vm@v1
+        uses: vmactions/openbsd-vm@3fafb45f2e2e696249c583835939323fe1c3448c # v1.3.7
         with:
           arch: ${{ matrix.arch }}
           release: ${{ matrix.version }}

--- a/.github/workflows/cmake-openbsd.yml
+++ b/.github/workflows/cmake-openbsd.yml
@@ -1,5 +1,7 @@
 name: OpenBSD CMake
 
+permissions: {}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/continuous-build-freebsd.yml
+++ b/.github/workflows/continuous-build-freebsd.yml
@@ -1,5 +1,7 @@
 name: Continuous Build FreeBSD
 
+permissions: {}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/continuous-build-freebsd.yml
+++ b/.github/workflows/continuous-build-freebsd.yml
@@ -35,6 +35,9 @@ jobs:
   build-freebsd:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.compiler }}
+      cancel-in-progress: true
     strategy:
       matrix:
         compiler: ["clang++", "g++"]

--- a/.github/workflows/continuous-build-freebsd.yml
+++ b/.github/workflows/continuous-build-freebsd.yml
@@ -40,6 +40,8 @@ jobs:
         compiler: ["clang++", "g++"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Compile
         uses: vmactions/freebsd-vm@4807432c7cab1c3f97688665332c0b932062d31f # v1.4.3

--- a/.github/workflows/continuous-build-freebsd.yml
+++ b/.github/workflows/continuous-build-freebsd.yml
@@ -39,10 +39,10 @@ jobs:
       matrix:
         compiler: ["clang++", "g++"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Compile
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@4807432c7cab1c3f97688665332c0b932062d31f # v1.4.3
         with:
           release: '14.3'
           usesh: true
@@ -62,7 +62,7 @@ jobs:
             mv bin/btop bin/btop-"$COMPILER"-"$GIT_HASH"
             ls -alh bin
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: btop-x86_64-freebsd-14-${{ matrix.compiler }}
           path: 'bin/*'

--- a/.github/workflows/continuous-build-freebsd.yml
+++ b/.github/workflows/continuous-build-freebsd.yml
@@ -39,10 +39,10 @@ jobs:
       matrix:
         compiler: ["clang++", "g++"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Compile
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@4807432c7cab1c3f97688665332c0b932062d31f # v1.4.3
         with:
           release: '15.0'
           usesh: true
@@ -62,7 +62,7 @@ jobs:
             mv bin/btop bin/btop-"$COMPILER"-"$GIT_HASH"
             ls -alh bin
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: btop-x86_64-freebsd-15-${{ matrix.compiler }}
           path: 'bin/*'

--- a/.github/workflows/continuous-build-gpu.yml
+++ b/.github/workflows/continuous-build-gpu.yml
@@ -49,4 +49,3 @@ jobs:
 
       - name: Compile
         run: make CXX=g++ GPU_SUPPORT=true
-

--- a/.github/workflows/continuous-build-gpu.yml
+++ b/.github/workflows/continuous-build-gpu.yml
@@ -1,5 +1,7 @@
 name: Continuous Build Gpu
 
+permissions: {}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/continuous-build-gpu.yml
+++ b/.github/workflows/continuous-build-gpu.yml
@@ -40,6 +40,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install build tools
         run: apk add --no-cache --update gcc g++ make linux-headers

--- a/.github/workflows/continuous-build-gpu.yml
+++ b/.github/workflows/continuous-build-gpu.yml
@@ -39,7 +39,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install build tools
         run: apk add --no-cache --update gcc g++ make linux-headers

--- a/.github/workflows/continuous-build-gpu.yml
+++ b/.github/workflows/continuous-build-gpu.yml
@@ -31,13 +31,14 @@ on:
       - 'Makefile'
       - '.github/workflows/continuous-build-gpu.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gpu_build_linux:
     runs-on: ubuntu-24.04
     container: alpine:edge
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-      cancel-in-progress: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/continuous-build-linux.yml
+++ b/.github/workflows/continuous-build-linux.yml
@@ -60,6 +60,8 @@ jobs:
           - riscv64-unknown-linux-musl
           - s390x-ibm-linux-musl
           - x86_64-unknown-linux-musl
+    env:
+      TOOLCHAIN: "${{ matrix.toolchain }}"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -68,19 +70,20 @@ jobs:
 
       - name: Install cross toolchain
         run: |
-          wget -q -P /tmp https://github.com/cross-tools/musl-cross/releases/download/20250929/${{ matrix.toolchain }}.tar.xz
-          wget -q -P /tmp https://github.com/cross-tools/musl-cross/releases/download/20250929/${{ matrix.toolchain }}.tar.xz.sha256
-          echo "$(cat /tmp/${{ matrix.toolchain }}.tar.xz.sha256) /tmp/${{ matrix.toolchain }}.tar.xz" | sha256sum --check --status
+          wget -q -P /tmp https://github.com/cross-tools/musl-cross/releases/download/20250929/${TOOLCHAIN}.tar.xz
+          wget -q -P /tmp https://github.com/cross-tools/musl-cross/releases/download/20250929/${TOOLCHAIN}.tar.xz.sha256
+          echo "$(cat /tmp/${TOOLCHAIN}.tar.xz.sha256) /tmp/${TOOLCHAIN}.tar.xz" | sha256sum --check --status
           mkdir -p /opt/x-tools/
-          tar -xf /tmp/${{ matrix.toolchain }}.tar.xz -C /opt/x-tools
+          tar -xf /tmp/${TOOLCHAIN}.tar.xz -C /opt/x-tools
 
       - name: Compile
-        run: CXX=/opt/x-tools/${{ matrix.toolchain }}/bin/${{ matrix.toolchain }}-g++ make STATIC=true STRIP=true
+        run: CXX=/opt/x-tools/${TOOLCHAIN}/bin/${TOOLCHAIN}-g++ make STATIC=true STRIP=true
 
       - name: Create binary artifacts
+        env:
+          GITHUB_SHA: "${{ github.sha }}"
         run: |
-          TOOLCHAIN=${{ matrix.toolchain }}
-          GIT_HASH=$(git rev-parse --short "${{ github.sha }}")
+          GIT_HASH=$(git rev-parse --short "${GITHUB_SHA}")
           FILENAME=btop-${TOOLCHAIN/linux-musl/}-$GIT_HASH
           mv bin/btop bin/$FILENAME
 

--- a/.github/workflows/continuous-build-linux.yml
+++ b/.github/workflows/continuous-build-linux.yml
@@ -1,5 +1,7 @@
 name: Continuous Build Linux
 
+permissions: {}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/continuous-build-linux.yml
+++ b/.github/workflows/continuous-build-linux.yml
@@ -63,6 +63,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install cross toolchain
         run: |

--- a/.github/workflows/continuous-build-linux.yml
+++ b/.github/workflows/continuous-build-linux.yml
@@ -62,7 +62,7 @@ jobs:
           - x86_64-unknown-linux-musl
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install cross toolchain
         run: |
@@ -83,7 +83,7 @@ jobs:
           mv bin/btop bin/$FILENAME
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: btop-${{ matrix.toolchain }}
           path: '${{ github.workspace }}/bin/*'

--- a/.github/workflows/continuous-build-linux.yml
+++ b/.github/workflows/continuous-build-linux.yml
@@ -60,6 +60,8 @@ jobs:
           - riscv64-unknown-linux-musl
           - s390x-ibm-linux-musl
           - x86_64-unknown-linux-musl
+    env:
+      TOOLCHAIN: "${{ matrix.toolchain }}"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -68,19 +70,20 @@ jobs:
 
       - name: Install cross toolchain
         run: |
-          wget -q -P /tmp https://github.com/cross-tools/musl-cross/releases/download/20260430/${{ matrix.toolchain }}.tar.xz
-          wget -q -P /tmp https://github.com/cross-tools/musl-cross/releases/download/20260430/${{ matrix.toolchain }}.tar.xz.sha256
+          wget -q -P /tmp https://github.com/cross-tools/musl-cross/releases/download/20260430/${TOOLCHAIN}.tar.xz
+          wget -q -P /tmp https://github.com/cross-tools/musl-cross/releases/download/20260430/${TOOLCHAIN}.tar.xz.sha256
           echo "$(cat /tmp/${{ matrix.toolchain }}.tar.xz.sha256) /tmp/${{ matrix.toolchain }}.tar.xz" | sha256sum --check --status
           mkdir -p /opt/x-tools/
-          tar -xf /tmp/${{ matrix.toolchain }}.tar.xz -C /opt/x-tools
+          tar -xf /tmp/${TOOLCHAIN}.tar.xz -C /opt/x-tools
 
       - name: Compile
-        run: CXX=/opt/x-tools/${{ matrix.toolchain }}/bin/${{ matrix.toolchain }}-g++ make STATIC=true STRIP=true
+        run: CXX=/opt/x-tools/${TOOLCHAIN}/bin/${TOOLCHAIN}-g++ make STATIC=true STRIP=true
 
       - name: Create binary artifacts
+        env:
+          GITHUB_SHA: "${{ github.sha }}"
         run: |
-          TOOLCHAIN=${{ matrix.toolchain }}
-          GIT_HASH=$(git rev-parse --short "${{ github.sha }}")
+          GIT_HASH=$(git rev-parse --short "${GITHUB_SHA}")
           FILENAME=btop-${TOOLCHAIN/linux-musl/}-$GIT_HASH
           mv bin/btop bin/$FILENAME
 

--- a/.github/workflows/continuous-build-macos.yml
+++ b/.github/workflows/continuous-build-macos.yml
@@ -41,11 +41,11 @@ jobs:
           - {runner: 'macos-15', version: 'Sequoia'}
     runs-on: ${{ matrix.os.runner }}
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install build tools
         run: |
@@ -60,7 +60,7 @@ jobs:
           mv bin/btop bin/btop-arm64-${{ matrix.os.runner }}-${{ matrix.os.version }}-$GIT_HASH
           ls -alh bin
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: btop-arm64-${{ matrix.os.runner }}-${{ matrix.os.version }}
           path: 'bin/*'

--- a/.github/workflows/continuous-build-macos.yml
+++ b/.github/workflows/continuous-build-macos.yml
@@ -46,6 +46,8 @@ jobs:
           xcode-version: latest-stable
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install build tools
         run: |

--- a/.github/workflows/continuous-build-macos.yml
+++ b/.github/workflows/continuous-build-macos.yml
@@ -33,6 +33,10 @@ on:
 
 jobs:
   build-macos:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.os.runner }}
+      cancel-in-progress: true
+    continue-on-error: true
     strategy:
       matrix:
         os:

--- a/.github/workflows/continuous-build-macos.yml
+++ b/.github/workflows/continuous-build-macos.yml
@@ -40,9 +40,10 @@ jobs:
     strategy:
       matrix:
         os:
-         # - {runner: 'macos-13', version: 'Ventura'}
-          - {runner: 'macos-14', version: 'Sonoma'}
-          - {runner: 'macos-15', version: 'Sequoia'}
+          - runner: macos-14
+            version: Sonoma
+          - runner: macos-15
+            version: Sequoia
     runs-on: ${{ matrix.os.runner }}
     steps:
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0

--- a/.github/workflows/continuous-build-macos.yml
+++ b/.github/workflows/continuous-build-macos.yml
@@ -1,5 +1,7 @@
 name: Continuous Build MacOS
 
+permissions: {}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/continuous-build-macos.yml
+++ b/.github/workflows/continuous-build-macos.yml
@@ -56,10 +56,13 @@ jobs:
           brew install --force --overwrite gcc@15 lowdown
 
       - name: Compile
+        env:
+          RUNNER: "${{ matrix.os.runner }}"
+          VERSION: "${{ matrix.os.version }}"
         run: |
           make CXX=$(brew --prefix)/bin/g++-15
           GIT_HASH=$(git rev-parse --short "$GITHUB_SHA")
-          mv bin/btop bin/btop-arm64-${{ matrix.os.runner }}-${{ matrix.os.version }}-$GIT_HASH
+          mv bin/btop bin/btop-arm64-${RUNNER}-${VERSION}-$GIT_HASH
           ls -alh bin
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/continuous-build-netbsd.yml
+++ b/.github/workflows/continuous-build-netbsd.yml
@@ -31,6 +31,10 @@ on:
       - 'Makefile'
       - '.github/workflows/continuous-build-netbsd.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-netbsd:
     runs-on: ubuntu-24.04

--- a/.github/workflows/continuous-build-netbsd.yml
+++ b/.github/workflows/continuous-build-netbsd.yml
@@ -37,6 +37,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Compile
         uses: vmactions/netbsd-vm@ca7ff0556959998c82761c34ea0c3c99fa084c48 # v1.3.7

--- a/.github/workflows/continuous-build-netbsd.yml
+++ b/.github/workflows/continuous-build-netbsd.yml
@@ -1,5 +1,7 @@
 name: Continuous Build NetBSD
 
+permissions: {}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/continuous-build-netbsd.yml
+++ b/.github/workflows/continuous-build-netbsd.yml
@@ -68,4 +68,3 @@ jobs:
           name: btop-x86_64-netbsd-9.3
           path: 'bin/*'
           if-no-files-found: error
-

--- a/.github/workflows/continuous-build-netbsd.yml
+++ b/.github/workflows/continuous-build-netbsd.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Compile
-        uses: vmactions/netbsd-vm@v1
+        uses: vmactions/netbsd-vm@ca7ff0556959998c82761c34ea0c3c99fa084c48 # v1.3.7
 
         with:
           release: '10.1'
@@ -57,7 +57,7 @@ jobs:
             mv bin/btop bin/btop-GCC10-"$GIT_HASH"
             ls -alh bin
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: btop-x86_64-netbsd-9.3
           path: 'bin/*'

--- a/.github/workflows/continuous-build-netbsd.yml
+++ b/.github/workflows/continuous-build-netbsd.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Compile
-        uses: vmactions/netbsd-vm@v1
+        uses: vmactions/netbsd-vm@ca7ff0556959998c82761c34ea0c3c99fa084c48 # v1.3.7
 
         with:
           release: '10.1'
@@ -57,7 +57,7 @@ jobs:
             mv bin/btop bin/btop-GCC10-"$GIT_HASH"
             ls -alh bin
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: btop-x86_64-netbsd-10.1
           path: 'bin/*'

--- a/.github/workflows/continuous-build-netbsd.yml
+++ b/.github/workflows/continuous-build-netbsd.yml
@@ -68,4 +68,3 @@ jobs:
           name: btop-x86_64-netbsd-10.1
           path: 'bin/*'
           if-no-files-found: error
-

--- a/.github/workflows/continuous-build-openbsd.yml
+++ b/.github/workflows/continuous-build-openbsd.yml
@@ -37,6 +37,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Compile
         uses: vmactions/openbsd-vm@3fafb45f2e2e696249c583835939323fe1c3448c # v1.3.7

--- a/.github/workflows/continuous-build-openbsd.yml
+++ b/.github/workflows/continuous-build-openbsd.yml
@@ -1,5 +1,7 @@
 name: Continuous Build OpenBSD
 
+permissions: {}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/continuous-build-openbsd.yml
+++ b/.github/workflows/continuous-build-openbsd.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Compile
-        uses: vmactions/openbsd-vm@v1
+        uses: vmactions/openbsd-vm@3fafb45f2e2e696249c583835939323fe1c3448c # v1.3.7
         with:
           release: '7.8'
           usesh: true
@@ -51,7 +51,7 @@ jobs:
             GIT_HASH=$(git rev-parse --short "$GITHUB_SHA")
             mv bin/btop bin/btop-"$GIT_HASH"
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: btop-x86_64-openbsd-7.8
           path: 'bin/*'

--- a/.github/workflows/continuous-build-openbsd.yml
+++ b/.github/workflows/continuous-build-openbsd.yml
@@ -31,6 +31,10 @@ on:
       - 'Makefile'
       - '.github/workflows/continuous-build-openbsd.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-openbsd:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -39,12 +39,12 @@ jobs:
         node-version: [20.x]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: snapcore/action-build@v1
+      - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
         id: build
 
-      - uses: diddlesnaps/snapcraft-review-action@v1
+      - uses: diddlesnaps/snapcraft-review-action@40554b42331cf84dab19ef98c382620427f13482 # v1.3.1
         with:
           snap: ${{ steps.build.outputs.snap }}
           isClassic: 'false'

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -5,10 +5,10 @@ permissions: {}
 on:
   workflow_dispatch:
   push:
-   branches: [ main ]
-   tags-ignore:
+    branches: [main]
+    tags-ignore:
       - '*.*'
-   paths:
+    paths:
       - 'src/**'
       - '!src/osx/**'
       - '!src/freebsd/**'
@@ -19,8 +19,8 @@ on:
       - '.github/workflows/test-snap-can-build.yml'
       - 'snap/snapcraft.yaml'
   pull_request:
-   branches: [ main ]
-   paths:
+    branches: [main]
+    paths:
       - 'src/**'
       - '!src/osx/**'
       - '!src/freebsd/**'

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -40,6 +40,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
         id: build

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,4 +1,7 @@
 name: 🧪 Test snap can be built on x86_64
+
+permissions: {}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -31,6 +31,10 @@ on:
       - '.github/workflows/test-snap-can-build.yml'
       - 'snap/snapcraft.yaml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+permissions: {}
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2


### PR DESCRIPTION
The recent [supply chain attack](https://cybernews.com/security/critical-litellm-supply-chain-attack-sends-shockwaves/) on LiteLLM has shown that github workflows are very much able to be exploited. This PR tries to improve the situation by using a tool called [zizmor](https://zizmor.sh) to lint workflow files.

* **Pin CI actions to hashes**
  This directly tries to mitigate what happened in the recent attack where a uploaded release
  was replaced by deleting and recreating it. A pinned commit, which changed through the 
  deletion, would have helped.
* **Reduce permission scope**