### PR TITLE
issue #190:  added frequency per core on linux

### DIFF
--- a/.github/workflows/cmake-netbsd.yml
+++ b/.github/workflows/cmake-netbsd.yml
@@ -46,7 +46,11 @@ jobs:
             export PATH="/usr/pkg/sbin:/usr/pkg/bin:$PATH"
             export PKG_PATH="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${{ matrix.arch }}/${{ matrix.version }}/All/"
             /usr/sbin/pkg_add pkgin
-            pkgin -y install cmake gcc14 git ninja-build
+            # retry logic for truncation errors
+            for i in 1 2 3; do
+              pkgin -y install cmake gcc14 git ninja-build && break
+              sleep 2
+            done
           run: |
             export CXX="/usr/pkg/gcc14/bin/g++"
             cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -548,7 +548,11 @@ namespace Cpu {
 		if (Runner::stopping) return "";
 		if (force_redraw) redraw = true;
 		bool show_temps = (Config::getB("check_temp") and got_sensors);
-		bool show_freq = Config::getB("show_cpu_freq");
+		#ifdef __linux__
+			bool show_freq = Config::getB("show_cpu_freq");
+		#else
+			bool show_freq = false;
+		#endif
 		bool show_watts = (Config::getB("show_cpu_watts") and supports_watts);
 		auto single_graph = Config::getB("cpu_single_graph");
 		bool hide_cores = show_temps and (cpu_temp_only or not Config::getB("show_coretemp"));
@@ -2312,10 +2316,10 @@ namespace Draw {
 		#endif
 		#ifdef __linux__
 			const bool show_freq = Config::getB("show_cpu_freq");
-			const int freq_w = (show_freq ? 6 : 0);
 		#else
-			const int freq_w = 0;
+			const bool show_freq = false;
 		#endif
+			const int freq_w = (show_freq ? 6 : 0);
 
 			if (b_columns * (21 + freq_w + 12 * show_temp) < width - (width / 3)) {
 				b_column_size = 2;

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -886,13 +886,15 @@ namespace Cpu {
 				out += Theme::c("inactive_fg") + graph_bg * (5 * b_column_size + extra_width) + Mv::l(5 * b_column_size + extra_width)
 					+ core_graphs.at(n)(safeVal(cpu.core_percent, n), data_same or redraw);
 
+		#ifdef __linux__
 			if (show_freq and not cpu.core_hz.empty() and n < static_cast<int>(cpu.core_hz.size())) {
 				double hz = cpu.core_hz.at(n);
-				string hz_str;
-				if (hz > 999) hz_str = fmt::format("{:.1f}G", hz / 1000);
-				else hz_str = to_string((int)hz) + 'M';
-				out += Theme::c("inactive_fg") + rjust(hz_str, 5) + ' ';
+				if (hz > 999)
+					fmt::format_to(std::back_inserter(out), "{}{:>4.1f}G ", Theme::c("inactive_fg"), hz / 1000.0);
+				else
+					fmt::format_to(std::back_inserter(out), "{}{:>4.0f}M ", Theme::c("inactive_fg"), hz);
 			}
+		#endif
 
 			out += enabled ? Theme::g("cpu").at(clamp(safeVal(cpu.core_percent, n).back(), 0ll, 100ll)) : Theme::c("inactive_fg");
 			out += rjust(to_string(safeVal(cpu.core_percent, n).back()), (b_column_size < 2 ? 3 : 4)) + Theme::c(enabled ? "main_fg" : "inactive_fg") + '%';

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -548,6 +548,7 @@ namespace Cpu {
 		if (Runner::stopping) return "";
 		if (force_redraw) redraw = true;
 		bool show_temps = (Config::getB("check_temp") and got_sensors);
+		bool show_freq = Config::getB("show_cpu_freq");
 		bool show_watts = (Config::getB("show_cpu_watts") and supports_watts);
 		auto single_graph = Config::getB("cpu_single_graph");
 		bool hide_cores = show_temps and (cpu_temp_only or not Config::getB("show_coretemp"));
@@ -834,7 +835,7 @@ namespace Cpu {
 		#endif
 
 			//? Cpu clock and cpu meter
-			if (Config::getB("show_cpu_freq") and not cpuHz.empty())
+			if (show_freq and not cpuHz.empty())
 				out += Mv::to(b_y, b_x + b_width - (freq_range ? 20 : 10)) + Fx::ub + Theme::c("div_line")
 					+ Symbols::h_line * ((freq_range ? 17 : 7) - cpuHz.size())
 					+ Symbols::title_left + Fx::b + Theme::c("title") + cpuHz + Fx::ub + Theme::c("div_line") + Symbols::title_right;
@@ -884,6 +885,14 @@ namespace Cpu {
 			if ((b_column_size > 0 or extra_width > 0) and cmp_less(n, core_graphs.size()))
 				out += Theme::c("inactive_fg") + graph_bg * (5 * b_column_size + extra_width) + Mv::l(5 * b_column_size + extra_width)
 					+ core_graphs.at(n)(safeVal(cpu.core_percent, n), data_same or redraw);
+
+			if (show_freq and not cpu.core_hz.empty() and n < static_cast<int>(cpu.core_hz.size())) {
+				double hz = cpu.core_hz.at(n);
+				string hz_str;
+				if (hz > 999) hz_str = fmt::format("{:.1f}G", hz / 1000);
+				else hz_str = to_string((int)hz) + 'M';
+				out += Theme::c("inactive_fg") + rjust(hz_str, 5) + ' ';
+			}
 
 			out += enabled ? Theme::g("cpu").at(clamp(safeVal(cpu.core_percent, n).back(), 0ll, 100ll)) : Theme::c("inactive_fg");
 			out += rjust(to_string(safeVal(cpu.core_percent, n).back()), (b_column_size < 2 ? 3 : 4)) + Theme::c(enabled ? "main_fg" : "inactive_fg") + '%';
@@ -2299,23 +2308,26 @@ namespace Draw {
 		#else
 			b_columns = max(1, (int)ceil((double)(Shared::coreCount + 1) / (height - 5)));
 		#endif
-			if (b_columns * (21 + 12 * show_temp) < width - (width / 3)) {
+			const bool show_freq = Config::getB("show_cpu_freq");
+			const int freq_w = (show_freq ? 6 : 0);
+
+			if (b_columns * (21 + freq_w + 12 * show_temp) < width - (width / 3)) {
 				b_column_size = 2;
-				b_width =  max(29, (21 + 12 * show_temp) * b_columns - (b_columns - 1));
+				b_width =  max(29, (21 + freq_w + 12 * show_temp) * b_columns - (b_columns - 1));
 			}
-			else if (b_columns * (15 + 6 * show_temp) < width - (width / 3)) {
+			else if (b_columns * (15 + freq_w + 6 * show_temp) < width - (width / 3)) {
 				b_column_size = 1;
-				b_width = (15 + 6 * show_temp) * b_columns - (b_columns - 1);
+				b_width = (15 + freq_w + 6 * show_temp) * b_columns - (b_columns - 1);
 			}
-			else if (b_columns * (8 + 6 * show_temp) < width - (width / 3)) {
+			else if (b_columns * (8 + freq_w + 6 * show_temp) < width - (width / 3)) {
 				b_column_size = 0;
 			}
 			else {
-				b_columns = (width - width / 3) / (8 + 6 * show_temp);
+				b_columns = (width - width / 3) / (8 + freq_w + 6 * show_temp);
 				b_column_size = 0;
 			}
 
-			if (b_column_size == 0) b_width = (8 + 6 * show_temp) * b_columns + 1;
+			if (b_column_size == 0) b_width = (8 + freq_w + 6 * show_temp) * b_columns + 1;
 		#ifdef GPU_SUPPORT
 			//gpus_extra_height = max(0, gpus_extra_height - 1);
 			b_height = min(height - 2, (int)ceil((double)Shared::coreCount / b_columns) + 4 + gpus_extra_height);
@@ -2337,7 +2349,7 @@ namespace Draw {
 		#endif
 			const string cpu_title = uresize(
 					(custom.empty() ? Cpu::cpuName : custom),
-					b_width - (Config::getB("show_cpu_freq") and hasCpuHz ? (freq_range ? 24 : 14) : 5)
+					b_width - (show_freq and hasCpuHz ? (freq_range ? 24 : 14) : 5)
 			);
 			box += createBox(b_x, b_y, b_width, b_height, "", false, cpu_title);
 		}

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -2310,8 +2310,12 @@ namespace Draw {
 		#else
 			b_columns = max(1, (int)ceil((double)(Shared::coreCount + 1) / (height - 5)));
 		#endif
+		#ifdef __linux__
 			const bool show_freq = Config::getB("show_cpu_freq");
 			const int freq_w = (show_freq ? 6 : 0);
+		#else
+			const int freq_w = 0;
+		#endif
 
 			if (b_columns * (21 + freq_w + 12 * show_temp) < width - (width / 3)) {
 				b_column_size = 2;

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -227,6 +227,7 @@ namespace Cpu {
 		long long temp_max = 0;
 		array<double, 3> load_avg;
 		float usage_watts = 0;
+		vector<long long> core_hz;
 		std::optional<std::vector<std::int32_t>> active_cpus;
 	};
 

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -1047,12 +1047,31 @@ namespace Cpu {
                std::views::join | std::ranges::to<std::vector<std::int32_t>>();
     }
 
+	void update_core_hz() {
+		current_cpu.core_hz.clear();
+		for (const auto& path : core_freq) {
+			if (path.empty()) {
+				current_cpu.core_hz.push_back(0);
+				continue;
+			}
+			try {
+				current_cpu.core_hz.push_back(stoll(readfile(path, "0")) / 1000);
+			}
+			catch (const std::exception& e) {
+				Logger::debug("Cpu::update_core_hz() : {}", e.what());
+				current_cpu.core_hz.push_back(0);
+			}
+		}
+	}
+
 	auto collect(bool no_update) -> cpu_info& {
 		if (Runner::stopping or (no_update and not current_cpu.cpu_percent.at("total").empty())) return current_cpu;
 		auto& cpu = current_cpu;
 
-		if (Config::getB("show_cpu_freq"))
+		if (Config::getB("show_cpu_freq")) {
 			cpuHz = get_cpuHz();
+			update_core_hz();
+		}
 
 		if (getloadavg(cpu.load_avg.data(), cpu.load_avg.size()) < 0) {
 			Logger::error("failed to get load averages");


### PR DESCRIPTION
The PR is AI assisted, for the UI I didn't want to spend too much time on calculating width and different things, I just found it working right away this way and I didn't need to learn the API of fmt :D.

I decided to display only up to 4 characters by representing either xxxM or x.xG for MHz and GHz values, it should be enough and saves 2 characters to keep the core consumption bar long enough.

Hopefully someone can also add the frequency for the other platforms, I don't know how to test those.

Please tell me if you need me to edit or improve something, thank you.