### PR TITLE
fix: render a non-ascii chars in proc list

### DIFF
--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -222,14 +222,17 @@ namespace Tools {
 		}
 		vector<wchar_t> w_str(w_len);
 		std::mbstowcs(&w_str[0], str_data, w_len);
-		for (size_t i = 0; i < w_str.size(); i++) {
+		for (size_t i = 0; i < w_str.size() - 1; i++) {
 			if (widechar_wcwidth(w_str[i]) > 1)
 				continue;
 			if (w_str[i] < 0x20)
 				w_str[i] = replacement;
 		}
-		str.resize(w_str.size());
-		std::wcstombs(&str[0], &w_str[0], w_str.size());
+		size_t bytes = std::wcstombs(nullptr, w_str.data(), 0);
+		if (bytes == static_cast<size_t>(-1))
+			return str;
+		str.resize(bytes);
+		std::wcstombs(&str[0], &w_str[0], bytes);
 
 		return str;
 	}


### PR DESCRIPTION
issue :  #1577 

fixed size calculation in wcstombs. The actual buffer size in bytes is now transmitted. Please let me know if any edits are needed
<img width="1029" height="634" alt="изображение" src="https://github.com/user-attachments/assets/7eb50750-7b8b-49dc-b7cd-90b335cce8ec" />
