### PR TITLE
Add show user and command switch

### DIFF
--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -232,6 +232,7 @@ namespace Config {
 		{"log_level", 			"#* Set loglevel for \"~/.local/state/btop.log\" levels are: \"ERROR\" \"WARNING\" \"INFO\" \"DEBUG\".\n"
 								"#* The level set includes all lower levels, i.e. \"DEBUG\" will show all logging info."},
 		{"save_config_on_exit",  "#* Automatically save current settings to config file on exit."},
+		{"hide_user_and_command", "#* Hide user and command columns in the proc box"},
 	#ifdef GPU_SUPPORT
 
 		{"nvml_measure_pcie_speeds",
@@ -357,6 +358,7 @@ namespace Config {
 		{"terminal_sync", true},
 		{"save_config_on_exit", true},
 		{"disable_mouse", false},
+		{"hide_user_and_command", false},
 	};
 	std::unordered_map<std::string_view, bool> boolsTmp;
 

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1691,6 +1691,7 @@ namespace Proc {
 		int followed = Config::getI("proc_followed");
 		bool should_selection_return_to_followed = Config::getB("should_selection_return_to_followed");
 		auto proc_banner_shown = pause_proc_list or follow_process;
+		bool hide_user_and_command = Config::getB("hide_user_and_command");
 		Config::set("proc_banner_shown", proc_banner_shown);
 		start = Config::getI("proc_start");
 		selected = Config::getI("proc_selected");
@@ -2083,7 +2084,7 @@ namespace Proc {
 				out += Mv::to(y+2+lc, x+1)
 					+ g_color + rjust(to_string(p.pid), 8) + ' '
 					+ c_color + ljust(p.name, prog_size, true) + ' ' + end
-					+ (cmd_size > 0 ? g_color + ljust(san_cmd, cmd_size, true, p_wide_cmd[p.pid]) + Mv::to(y+2+lc, x+11+prog_size+cmd_size) + ' ' : "");
+					+ (cmd_size > 0 ? g_color + ljust((hide_user_and_command ? "*****" : san_cmd), cmd_size, true, p_wide_cmd[p.pid]) + Mv::to(y+2+lc, x+11+prog_size+cmd_size) + ' ' : "");
 			}
 			//? Tree view line
 			else {
@@ -2132,7 +2133,7 @@ namespace Proc {
 			}();
 
 			out += (thread_size > 0 ? t_color + rjust(proc_threads_string, thread_size) + ' ' + end : "" )
-				+ g_color + ljust((cmp_greater(p.user.size(), user_size) ? p.user.substr(0, user_size - 1) + '+' : p.user), user_size) + ' '
+				+ g_color + ljust((hide_user_and_command ? "***" : (cmp_greater(p.user.size(), user_size) ? p.user.substr(0, user_size - 1) + '+' : p.user)), user_size) + ' '
 				+ m_color + rjust(mem_str, 5) + end + ' '
 				+ (is_selected or is_followed ? "" : Theme::c("inactive_fg")) + (show_graphs ? graph_bg * 5: "")
 				+ (p_graphs.contains(p.pid) ? Mv::l(5) + c_color + p_graphs.at(p.pid)({(p.cpu_p >= 0.1 and p.cpu_p < 5 ? 5ll : (long long)round(p.cpu_p))}, data_same) : "") + end + ' '

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -886,6 +886,11 @@ namespace Menu {
 				"followed in the list. Pressing enter",
 				"again will close the detailed view",
 				"and stop following the process."},
+			{"hide_user_and_command",
+				"hide username and command columns",
+				"",
+				"Setting this option to true may be help-",
+				"ful if you prefer to keep usernames hidden"}
 		}
 	};
 


### PR DESCRIPTION
Solves issue #1596 

This commit adds a feature to hide the user column in the proc box. This may be beneficial for those who like to showcase their themes or rices without showing their usernames.

<img width="1366" height="768" alt="example" src="https://github.com/user-attachments/assets/923a778d-fbd9-487b-a10d-2318ba30c447" />


