### PR TITLE
fix: Clamp GPU graph widths to prevent crash on small terminals

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -625,7 +625,7 @@ namespace Cpu {
 						gpu_mem_graphs.resize(gpus.size());
 						gpu_meters.resize(gpus.size());
 						const int gpu_draw_count = gpu_always ? Gpu::count : Gpu::count - Gpu::shown;
-						graph_width = gpu_draw_count <= 0 ? graph_default_width : graph_default_width/gpu_draw_count - gpu_draw_count + 1 + graph_default_width%gpu_draw_count;
+						graph_width = gpu_draw_count <= 0 ? graph_default_width : max(1, graph_default_width/gpu_draw_count - gpu_draw_count + 1 + graph_default_width%gpu_draw_count);
 						for (size_t i = 0; i < gpus.size(); i++) {
 							if (gpu_auto and v_contains(Gpu::shown_panels, i))
 								continue;
@@ -638,7 +638,7 @@ namespace Cpu {
 								}
 								else {
 									graph = Draw::Graph{
-										graph_width + graph_default_width%graph_width - (int)gpus.size() + 1,
+										max(1, graph_width + graph_default_width%graph_width - (int)gpus.size() + 1),
 										graph_height, "cpu", safeVal(gpu.gpu_percent, graph_field), graph_symbol, invert, true
 									};
 								}
@@ -793,8 +793,8 @@ namespace Cpu {
 							}
 							if (Gpu::count - (gpu_auto ? Gpu::shown : 0) > 1) {
 								auto i_str = to_string(i);
-								out += Mv::l(graph_width-1) + Mv::u(graph_height/2) + (graph_width > 5 ? "GPU" : "") + i_str
-									+ Mv::d(graph_height/2) + Mv::r(graph_width - 1 - (graph_width > 5)*3 - i_str.size());
+								out += Mv::l(max(0, graph_width-1)) + Mv::u(graph_height/2) + (graph_width > 5 ? "GPU" : "") + i_str
+									+ Mv::d(graph_height/2) + Mv::r(max(0, (int)(graph_width - 1 - (graph_width > 5)*3 - i_str.size())));
 							}
 
 							if (++gpu_drawn < Gpu::count - (gpu_auto ? Gpu::shown : 0))

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -641,7 +641,7 @@ namespace Cpu {
 								}
 								else {
 									graph = Draw::Graph{
-										max(1, graph_width + graph_default_width%graph_width - (int)gpus.size() + 1),
+                                                                                max(1, graph_width + (gpu_draw_count > 0 ? gpu_drawable_width % gpu_draw_count : 0)),
 										graph_height, "cpu", safeVal(gpu.gpu_percent, graph_field), graph_symbol, invert, true
 									};
 								}

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -625,7 +625,10 @@ namespace Cpu {
 						gpu_mem_graphs.resize(gpus.size());
 						gpu_meters.resize(gpus.size());
 						const int gpu_draw_count = gpu_always ? Gpu::count : Gpu::count - Gpu::shown;
-						graph_width = gpu_draw_count <= 0 ? graph_default_width : max(1, graph_default_width/gpu_draw_count - gpu_draw_count + 1 + graph_default_width%gpu_draw_count);
+                                                // Fairly distribute graph_default_width across gpu_draw_count GPUs, leaving 1 col per separator.
+                                                // Clamp to >=1 to avoid degenerate/negative widths reaching Draw::Graph::_create (#1118, #1017).
+                                                const int gpu_drawable_width = graph_default_width - max(0, gpu_draw_count - 1);
+                                                graph_width = gpu_draw_count <= 0 ? graph_default_width : max(1, gpu_drawable_width / gpu_draw_count);
 						for (size_t i = 0; i < gpus.size(); i++) {
 							if (gpu_auto and v_contains(Gpu::shown_panels, i))
 								continue;

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -624,7 +624,7 @@ namespace Cpu {
 						gpu_mem_graphs.resize(gpus.size());
 						gpu_meters.resize(gpus.size());
 						const int gpu_draw_count = gpu_always ? Gpu::count : Gpu::count - Gpu::shown;
-						graph_width = gpu_draw_count <= 0 ? graph_default_width : graph_default_width/gpu_draw_count - gpu_draw_count + 1 + graph_default_width%gpu_draw_count;
+						graph_width = gpu_draw_count <= 0 ? graph_default_width : max(1, graph_default_width/gpu_draw_count - gpu_draw_count + 1 + graph_default_width%gpu_draw_count);
 						for (size_t i = 0; i < gpus.size(); i++) {
 							if (gpu_auto and v_contains(Gpu::shown_panels, i))
 								continue;
@@ -637,7 +637,7 @@ namespace Cpu {
 								}
 								else {
 									graph = Draw::Graph{
-										graph_width + graph_default_width%graph_width - (int)gpus.size() + 1,
+										max(1, graph_width + graph_default_width%graph_width - (int)gpus.size() + 1),
 										graph_height, "cpu", safeVal(gpu.gpu_percent, graph_field), graph_symbol, invert, true
 									};
 								}
@@ -792,8 +792,8 @@ namespace Cpu {
 							}
 							if (Gpu::count - (gpu_auto ? Gpu::shown : 0) > 1) {
 								auto i_str = to_string(i);
-								out += Mv::l(graph_width-1) + Mv::u(graph_height/2) + (graph_width > 5 ? "GPU" : "") + i_str
-									+ Mv::d(graph_height/2) + Mv::r(graph_width - 1 - (graph_width > 5)*3 - i_str.size());
+								out += Mv::l(max(0, graph_width-1)) + Mv::u(graph_height/2) + (graph_width > 5 ? "GPU" : "") + i_str
+									+ Mv::d(graph_height/2) + Mv::r(max(0, (int)(graph_width - 1 - (graph_width > 5)*3 - i_str.size())));
 							}
 
 							if (++gpu_drawn < Gpu::count - (gpu_auto ? Gpu::shown : 0))

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -624,7 +624,10 @@ namespace Cpu {
 						gpu_mem_graphs.resize(gpus.size());
 						gpu_meters.resize(gpus.size());
 						const int gpu_draw_count = gpu_always ? Gpu::count : Gpu::count - Gpu::shown;
-						graph_width = gpu_draw_count <= 0 ? graph_default_width : max(1, graph_default_width/gpu_draw_count - gpu_draw_count + 1 + graph_default_width%gpu_draw_count);
+                                                // Fairly distribute graph_default_width across gpu_draw_count GPUs, leaving 1 col per separator.
+                                                // Clamp to >=1 to avoid degenerate/negative widths reaching Draw::Graph::_create (#1118, #1017).
+                                                const int gpu_drawable_width = graph_default_width - max(0, gpu_draw_count - 1);
+                                                graph_width = gpu_draw_count <= 0 ? graph_default_width : max(1, gpu_drawable_width / gpu_draw_count);
 						for (size_t i = 0; i < gpus.size(); i++) {
 							if (gpu_auto and v_contains(Gpu::shown_panels, i))
 								continue;

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -640,7 +640,7 @@ namespace Cpu {
 								}
 								else {
 									graph = Draw::Graph{
-										max(1, graph_width + graph_default_width%graph_width - (int)gpus.size() + 1),
+                                                                                max(1, graph_width + (gpu_draw_count > 0 ? gpu_drawable_width % gpu_draw_count : 0)),
 										graph_height, "cpu", safeVal(gpu.gpu_percent, graph_field), graph_symbol, invert, true
 									};
 								}


### PR DESCRIPTION
…terminals

When many GPUs are present and the terminal is small, the GPU graph width calculations in Cpu::draw init_graphs and draw_graphs can produce negative values. This causes std::out_of_range from the Draw::Graph constructor, surfacing as "Exception in runner thread -> Cpu:: -> deque".

The root cause is the remainder-distribution formula for the last GPU graph: graph_width + graph_default_width%graph_width - gpus.size() + 1 which underflows when gpus.size() exceeds the available remainder plus graph_width. The per-GPU graph_width itself can also go below 1 when graph_default_width is small relative to gpu_draw_count.

Clamp both graph_width and the last-GPU width to a minimum of 1, and clamp the cursor movement arguments in draw_graphs to prevent negative Mv::l and Mv::r values.

---

I see

```
ERROR: Exception in runner thread -> Cpu:: -> deque
```

otherwise