### PR TITLE
fix: linux process cpu usage under-reported when vm guests active

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -2989,12 +2989,13 @@ namespace Proc {
 				pread.close();
 			}
 
-			//? Get cpu total times from /proc/stat
+			//? Get cpu total times from /proc/stat up to the guest field
 			cputimes = 0;
 			pread.open(Shared::procPath / "stat");
 			if (pread.good()) {
 				pread.ignore(SSmax, ' ');
-				for (uint64_t times; pread >> times; cputimes += times);
+				int i = 0;
+				for (uint64_t times; i < 8 and pread >> times; cputimes += times, i++);
 			}
 			else throw std::runtime_error("Failure to read /proc/stat");
 			pread.close();


### PR DESCRIPTION
The Linux /proc/stat fields "guest" and "guest_nice" are already included in "user" and "nice".  In Proc::collect do like Cpu::collect does and don't double count them.  The double-counting caused the CPU usage denominator to be too large when VM guests were active, causing the reported CPU usage percentages of all processes to be too small.

Closes: https://github.com/aristocratos/btop/issues/1608