### PR TITLE
Fix deque OOB crash in Graph on narrow terminals with many GPUs

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -468,6 +468,11 @@ namespace Draw {
 				 bool invert, bool no_zero, long long max_value, long long offset)
 	: width(width), height(height), color_gradient(color_gradient),
 	  invert(invert), no_zero(no_zero), offset(offset) {
+		//? Guard against non-positive widths: callers (e.g. init_graphs when
+		//? many GPUs are squeezed into a narrow CPU panel) can compute a
+		//? negative graph_width, which previously caused out-of-bounds deque
+		//? access in _create() via unsigned wrap-around of `data.size() - data_offset`.
+		if (width <= 0) { this->width = 0; return; }
 		if (Config::getB("tty_mode") or symbol == "tty") this->symbol = "tty";
 		else if (symbol != "default") this->symbol = symbol;
 		else this->symbol = Config::getS("graph_symbol");
@@ -492,6 +497,7 @@ namespace Draw {
 	}
 
 	string& Graph::operator()(const deque<long long>& data, bool data_same) {
+		if (width <= 0) return out;
 		if (data_same) return out;
 
 		//? Make room for new characters on graph


### PR DESCRIPTION
## Summary

On hosts with many GPUs displayed in the CPU panel (e.g. 8× H100) and a moderately narrow terminal, btop crashes almost immediately on startup with:

```
ERROR: Exception in runner thread -> Cpu:: -> deque::_M_range_check: __n (which is 13)>= this->size() (which is 2)
```

(or, depending on the compiler / stdlib version, the related `basic_string::at: __n (which is 0) >= this->size() (which is 0)`.) Widening the terminal makes the crash go away, which is the clue to the root cause.

## Root cause

When `cpu_graph_lower = "Auto"` and `show_gpu_info` resolves to auto-show, `init_graphs` takes the `graph_field.starts_with("gpu") && …"totals"` branch in `Cpu::draw()` and computes

```cpp
graph_width = graph_default_width / gpu_draw_count
              - gpu_draw_count + 1
              + graph_default_width % gpu_draw_count;
```

With `gpu_draw_count = 8` and small `graph_default_width` (e.g. 1) this yields `graph_width = -6`. That negative width is then passed to `Draw::Graph::Graph`, where

```cpp
int data_offset = (value_width > width)
    ? data.size() - width * (tty_mode ? 1 : 2)
    : 0;
```

becomes `data.size() - (-6)*2 = 14`, i.e. `data_offset > data.size()`. `Graph::_create` then evaluates

```cpp
bool mult = (data.size() - data_offset > 1);
```

in unsigned arithmetic, wraps to a huge value, so `mult == true`, and `data.at(data_offset - 1) == data.at(13)` is called on a deque with 2 samples — exactly the error message above.

## Fix

Guard `Graph::Graph()` and `Graph::operator()()` against non-positive widths: such pathological sizes degenerate to a no-op graph (the panel still renders fine; the empty strip is just not drawn) instead of corrupting state inside `_create`. The hot path for valid widths is unchanged — a single integer compare against zero.

A deeper fix could also sanitise the `graph_width` arithmetic in `init_graphs`, but since `Draw::Graph` is called from several call sites with user-derived widths, defending at the class boundary is cheaper and more robust.

## Fixes

- Fixes #874 (instant crash on 8-GPU system if window too narrow)
- Fixes #1118 (btop 1.4 `deque::_M_range_check` exception)
- Fixes #1017 (same `deque::_M_range_check` exception)
- Related: #742, #949

## Test plan

- [x] Reproduced the original crash on an Ubuntu 20.04 host with 8× NVIDIA H100 and an 80-col terminal (btop 1.4.4, GPU_SUPPORT=true, conda gcc 15.2.0, `-static-libstdc++`, `-D_GLIBCXX_ASSERTIONS` enabled as per Makefile).
- [x] With the patch applied, btop launches cleanly at the same terminal width and survives arbitrary resizing down to very narrow widths; the lower CPU/GPU graph simply collapses to a thin strip instead of crashing.
- [x] Widening the terminal still produces the normal per-GPU split graphs.
- [x] No change in behaviour for the other boxes or for the CPU panel on hosts without GPUs.