### PR TITLE
Detect true color support for better compatibility

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -948,6 +948,15 @@ static auto configure_tty_mode(std::optional<bool> force_tty) {
 		Logger::info("Using custom themes directory: {}", Theme::custom_theme_dir.string());
 	}
 
+	//? Detect if true color is supported and adjust settings for better compatibility
+	{
+		const char* color_term = std::getenv("COLORTERM");
+		if (color_term == nullptr || std::string(color_term) != "truecolor" || std::string(color_term) != "24bit") {
+			cli.low_color = true;
+			Logger::info("no true-color support detected: disabling true-color for better compatibility");
+		}
+	}
+
 	//? Config init
 	init_config(cli.low_color, cli.filter);
 


### PR DESCRIPTION
If true color is not supported, such as in Apple Terminal, fallback to 256-color to avoid color issues.