### PR TITLE
Handle dynamic changing of the number of active CPUs on OpenBSD

### DIFF
--- a/src/openbsd/btop_collect.cpp
+++ b/src/openbsd/btop_collect.cpp
@@ -125,15 +125,13 @@ namespace Shared {
 
 	void init() {
 		//? Shared global variables init
-		int mib[2];
-		mib[0] = CTL_HW;
-		mib[1] = HW_NCPUONLINE;
-		int ncpu;
-		size_t len = sizeof(ncpu);
-		if (sysctl(mib, 2, &ncpu, &len, nullptr, 0) == -1) {
+		int mib[] = {CTL_HW, HW_NCPUONLINE};
+		int ncpu_online;
+		size_t len = sizeof(ncpu_online);
+		if (sysctl(mib, 2, &ncpu_online, &len, nullptr, 0) == -1) {
 			Logger::warning("Could not determine number of cores, defaulting to 1.");
 		} else {
-			coreCount = ncpu;
+			coreCount = ncpu_online;
 		}
 
 		pageSize = sysconf(_SC_PAGE_SIZE);

--- a/src/openbsd/btop_collect.cpp
+++ b/src/openbsd/btop_collect.cpp
@@ -401,6 +401,21 @@ namespace Cpu {
 			sysctl(mib, 2, &ncpu_total, &len, nullptr, 0);
 		}
 
+		//? Re-query online CPU count in case it changed at runtime (e.g. hw.smt toggled).
+		{
+			int mib[] = {CTL_HW, HW_NCPUONLINE};
+			int ncpu_online = Shared::coreCount;
+			size_t len = sizeof(ncpu_online);
+			if (sysctl(mib, 2, &ncpu_online, &len, nullptr, 0) != -1 and ncpu_online != Shared::coreCount) {
+				Shared::coreCount = ncpu_online;
+				core_old_totals.resize(Shared::coreCount, 0);
+				core_old_idles.resize(Shared::coreCount, 0);
+				cpu.core_percent.resize(Shared::coreCount);
+				cpu.temp.resize(Shared::coreCount + 1);
+				Runner::coreNum_reset = true;
+			}
+		}
+
 		auto cp_time = std::unique_ptr<struct cpustats[]>{
 			new struct cpustats[ncpu_total]
 		};


### PR DESCRIPTION
This is an additional set of improvements on #1587

The set of online CPUs can change dynamically while btop is running, but the stats vectors and UI were only sized in init(). If the number of CPUs increases, say by switching hw.smt from 0 to 1, or with OpenBSD 7.9 removing 'S' from hw.blockcpu, the resulting vector is too small, resulting in this error:

ERROR: Exception in runner thread -> Cpu:: -> collect() : vector

This adds an additional check on each collect() call for the number of currently online CPUs. It also sets Runner::coreNum_reset when there is a change so the display is updated for the current number of CPUs.

Tested on an assortment of machines from 4 to 16 CPUs.