### PR TITLE
Fix deque OOB in Draw::Graph::_create on multi-GPU hosts (#1118, #1017)

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -476,7 +476,7 @@ namespace Draw {
 		if (max_value == 0 and offset > 0) max_value = 100;
 		this->max_value = max_value;
 		const int value_width = (tty_mode ? data.size() : ceil((double)data.size() / 2));
-		int data_offset = (value_width > width) ? data.size() - width * (tty_mode ? 1 : 2) : 0;
+		int data_offset = (width > 0 and value_width > width) ? data.size() - width * (tty_mode ? 1 : 2) : 0;
 
 		if (not tty_mode and (data.size() - data_offset) % 2 != 0) {
 			data_offset--;
@@ -624,7 +624,10 @@ namespace Cpu {
 						gpu_mem_graphs.resize(gpus.size());
 						gpu_meters.resize(gpus.size());
 						const int gpu_draw_count = gpu_always ? Gpu::count : Gpu::count - Gpu::shown;
-						graph_width = gpu_draw_count <= 0 ? graph_default_width : graph_default_width/gpu_draw_count - gpu_draw_count + 1 + graph_default_width%gpu_draw_count;
+						// Fairly distribute graph_default_width across gpu_draw_count GPUs, leaving 1 col per separator.
+						// Clamp to >=1 to avoid degenerate/negative widths reaching Draw::Graph::_create (upstream #1118).
+						const int gpu_drawable_width = graph_default_width - max(0, gpu_draw_count - 1);
+						graph_width = gpu_draw_count <= 0 ? graph_default_width : max(1, gpu_drawable_width / gpu_draw_count);
 						for (size_t i = 0; i < gpus.size(); i++) {
 							if (gpu_auto and v_contains(Gpu::shown_panels, i))
 								continue;
@@ -637,7 +640,7 @@ namespace Cpu {
 								}
 								else {
 									graph = Draw::Graph{
-										graph_width + graph_default_width%graph_width - (int)gpus.size() + 1,
+										max(1, graph_width + (gpu_draw_count > 0 ? gpu_drawable_width % gpu_draw_count : 0)),
 										graph_height, "cpu", safeVal(gpu.gpu_percent, graph_field), graph_symbol, invert, true
 									};
 								}


### PR DESCRIPTION
# Fix deque OOB in `Draw::Graph::_create` on multi-GPU + multi-socket hosts (#1118, #1017)

## Summary

On hosts with many GPUs + a narrow-ish CPU box, `Cpu::draw()` computes a **negative** per-GPU graph width and passes it to the `Draw::Graph` constructor. The constructor's `data_offset` formula then produces an index far past the end of the data deque, and `_create()` throws:

```
Exception in runner thread -> Cpu:: -> deque::_M_range_check: __n (which is 7)>= this->size() (which is 2)
```

Reproduced on a dual-socket AMD EPYC 9575F (256 threads, 2 NUMA nodes) with 8× NVIDIA GPUs on Ubuntu 24.04. Reporter of #1118 saw the same failure mode on a 10+ GPU host ("index 17, size 2").

## Root cause

Three problems compose into the crash:

1. **Bad per-GPU width distribution formula** (`btop_draw.cpp` — the `if (graph_field.starts_with("gpu"))` branch of `init_graphs`):

   ```cpp
   graph_width = gpu_draw_count <= 0
       ? graph_default_width
       : graph_default_width/gpu_draw_count - gpu_draw_count + 1 + graph_default_width%gpu_draw_count;
   ```

   For `gpu_draw_count` ≥ 8 and modest `graph_default_width`, this goes negative. The expression `- gpu_draw_count + 1` (intended to reserve 1 col per separator) subtracts once per GPU instead of once total per pair-of-GPUs.

2. **Bad "last GPU" width**: even when the per-GPU width clamps back positive, the last-GPU adjustment compounds the problem:

   ```cpp
   graph_width + graph_default_width%graph_width - (int)gpus.size() + 1
   ```

   which for 8 GPUs yields width ≈ `graph_width - 7`, typically negative.

3. **No guard in `Draw::Graph::_create`**: when the constructor receives a non-positive width, the `data_offset = (value_width > width) ? data.size() - width * (tty_mode ? 1 : 2) : 0` formula produces `data_offset ≫ data.size()` (since `width * N` is negative), then `data.at(data_offset - 1)` throws.

## Fix

Three small changes:

- Rewrite the per-GPU width distribution with a standard "each gets `drawable/count`, last gets the remainder" formula. Introduces a local `gpu_drawable_width` variable equal to `graph_default_width - (gpu_draw_count - 1)` (for the N-1 separators).
- Rewrite the last-GPU width to use that remainder directly.
- Clamp widths to `max(1, ...)` and add a `width > 0` guard in `Graph::_create`'s `data_offset` calculation as defense-in-depth against any remaining caller computing a degenerate width.

Three-hunk patch, 11 insertions / 4 deletions in one file.

## Reproduction details

- **Hardware:** AMD EPYC 9575F × 2 sockets (64 cores/socket, 256 threads), 2 NUMA nodes, 8× NVIDIA L40 GPUs
- **OS:** Ubuntu 24.04.4 LTS
- **btop:** v1.4.6 (and the v1.3.0 apt package on the same release)
- **Config trigger:** `check_temp = true` + default `show_gpu_info`

Backtrace captured via an `LD_PRELOAD` hook on `__cxa_throw`:

```
--- throw: type=St12out_of_range what="deque::_M_range_check: __n (which is 7)>= this->size() (which is 2)" ---
libstdc++.so.6(__throw_out_of_range_fmt+0x15c)
btop(+0x554a2)                                          ← deque::_M_range_check inlined
btop(Draw::Graph::Graph(int, int, ..., const std::deque<long long>&, ...)+0x932)
btop(+0xdcf52)                                          ← lambda in Cpu::draw() at btop_draw.cpp:636
btop(Cpu::draw(...)+0x567d)
```

After the patch: crashes stop, the GPU time-series panel fills the full allotted width across all 8 cards, and CPU temp (k10temp Tctl) displays correctly.

Fixes #1118, likely fixes #1017.
