### PR TITLE
fix: avoid SIGFPE when temp_max is zero in temperature scaling

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -843,7 +843,7 @@ namespace Cpu {
 			+ Theme::g("cpu").at(clamp(safeVal(cpu.cpu_percent, "total"s).back(), 0ll, 100ll)) + rjust(to_string(safeVal(cpu.cpu_percent, "total"s).back()), 4) + Theme::c("main_fg") + '%';
 		if (show_temps) {
 			const auto [temp, unit] = celsius_to(safeVal(cpu.temp, 0).back(), temp_scale);
-			const auto temp_color = Theme::g("temp").at(clamp(safeVal(cpu.temp, 0).back() * 100 / cpu.temp_max, 0ll, 100ll));
+			const auto temp_color = Theme::g("temp").at(clamp(safeVal(cpu.temp, 0).back() * 100 / max(1ll, cpu.temp_max), 0ll, 100ll));
 			if ((b_column_size > 1 or b_columns > 1) and temp_graphs.size() >= 1ll)
 				out += ' ' + Theme::c("inactive_fg") + graph_bg * 5 + Mv::l(5) + temp_color
 					+ temp_graphs.at(0)(safeVal(cpu.temp, 0), data_same or redraw);
@@ -895,7 +895,7 @@ namespace Cpu {
 					// something like `std::nullopt`.
 					const auto last_temp = core_temps.back();
 					const auto [temp, unit] = celsius_to(last_temp, temp_scale);
-					const auto temp_color = enabled ? Theme::g("temp").at(clamp(last_temp * 100 / cpu.temp_max, 0ll, 100ll)) : Theme::c("inactive_fg");
+					const auto temp_color = enabled ? Theme::g("temp").at(clamp(last_temp * 100 / max(1ll, cpu.temp_max), 0ll, 100ll)) : Theme::c("inactive_fg");
 					if (b_column_size > 1 and std::cmp_greater_equal(temp_graphs.size(), n)) {
 						fmt::format_to(
 							std::back_inserter(out),
@@ -971,9 +971,9 @@ namespace Cpu {
 					const auto [temp, unit] = celsius_to(gpus[i].temp.back(), temp_scale);
 					out += ' ';
 					if (b_columns > 1)
-						out += Theme::c("inactive_fg") + graph_bg * 5 + Mv::l(5) + Theme::g("temp").at(clamp(gpus[i].temp.back() * 100 / gpus[i].temp_max, 0ll, 100ll))
+						out += Theme::c("inactive_fg") + graph_bg * 5 + Mv::l(5) + Theme::g("temp").at(clamp(gpus[i].temp.back() * 100 / max(1ll, gpus[i].temp_max), 0ll, 100ll))
 							+ gpu_temp_graphs[i](gpus[i].temp, data_same or redraw);
-					else out += Theme::g("temp").at(clamp(gpus[i].temp.back() * 100 / gpus[i].temp_max, 0ll, 100ll));
+					else out += Theme::g("temp").at(clamp(gpus[i].temp.back() * 100 / max(1ll, gpus[i].temp_max), 0ll, 100ll));
 					out += rjust(to_string(temp), 3) + Theme::c("main_fg") + unit;
 				}
 				if (gpus[i].supported_functions.pwr_usage) {
@@ -1088,7 +1088,7 @@ namespace Gpu {
 			//? Temperature graph, I assume the device supports utilization if it supports temperature
 			if (show_temps) {
 				const auto [temp, unit] = celsius_to(gpu.temp.back(), temp_scale);
-				out += ' ' + Theme::c("inactive_fg") + graph_bg * 6 + Mv::l(6) + Theme::g("temp").at(clamp(gpu.temp.back() * 100 / gpu.temp_max, 0ll, 100ll))
+				out += ' ' + Theme::c("inactive_fg") + graph_bg * 6 + Mv::l(6) + Theme::g("temp").at(clamp(gpu.temp.back() * 100 / max(1ll, gpu.temp_max), 0ll, 100ll))
 					+ temp_graph(gpu.temp, data_same or redraw[index]);
 				out += rjust(to_string(temp), 4) + Theme::c("main_fg") + unit;
 			}

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -224,7 +224,7 @@ namespace Cpu {
 		};
 		vector<deque<long long>> core_percent;
 		vector<deque<long long>> temp;
-		long long temp_max = 0;
+		long long temp_max = 95; // 0 would divide-by-zero in draw when scaling temps to 0…100
 		array<double, 3> load_avg;
 		float usage_watts = 0;
 		std::optional<std::vector<std::int32_t>> active_cpus;

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -501,7 +501,8 @@ namespace Cpu {
 						const string label = readfile(fs::path(basepath + "label"), "temp" + to_string(file_id));
 						const string sensor_name = pname + "/" + label;
 						const int64_t temp = stol(readfile(fs::path(basepath + "input"), "0")) / 1000;
-						const int64_t crit = stol(readfile(fs::path(basepath + "crit"), "95000")) / 1000;
+						int64_t crit = stol(readfile(fs::path(basepath + "crit"), "95000")) / 1000;
+						if (crit < 1) crit = 95; // <1000 m°C rounds to 0; avoid 0 in temp_max (SIGFPE in draw)
 
 						found_sensors[sensor_name] = Sensor { fs::path(basepath + "input"), temp, crit };
 


### PR DESCRIPTION
## Summary

On Linux x86-64, **integer division by zero** while scaling temperatures for the UI can raise **SIGFPE** (often reported as a “floating point exception”). This change ensures `temp_max` is never used as a zero divisor, and that hwmon critical temperature values are never stored as 0 when they would break scaling.

## Root cause

1. **`Cpu::cpu_info::temp_max` defaulted to 0** until sensors were updated, so any draw that computed `temp * 100 / cpu.temp_max` could divide by zero.
2. **Linux hwmon `crit` values** are read in millidegrees and divided by 1000. Values in the range 0–999 m°C become **0** as an `int64_t` critical temperature, unlike the `/sys/class/thermal` path which already clamps sub-1°C values to a safe default.
3. **UI code** used integer division for the 0…100 color scale. Defensive `max(1ll, temp_max)` in the draw path prevents a regression if a zero slips through from another source (e.g. drivers).

## Changes

| Area | Change |
|------|--------|
| `src/btop_shared.hpp` | Default `cpu_info::temp_max` to **95** instead of **0**. |
| `src/linux/btop_collect.cpp` | After reading hwmon `crit`, if **`crit < 1`**, set **`crit = 95`** (same idea as the thermal_zone trip-point loop). |
| `src/btop_draw.cpp` | Use **`max(1ll, cpu.temp_max)`** and **`max(1ll, gpu.temp_max)`** (where applicable) in temperature percentage clamps for the CPU box, per-core display, and GPU brief/detail views. |