### PR TITLE
[AI generated] fix: restore Intel Mac CPU temperature fallback

### DIFF
--- a/src/osx/smc.cpp
+++ b/src/osx/smc.cpp
@@ -101,7 +101,7 @@ namespace Cpu {
 		long long result = getSMCTemp(key);
 		if (result == -1) {
 			// try again with C
-			snprintf(key, 5, "TC%1dC", KeyIndexes[core]);
+			snprintf(key, 5, "TC%1cC", KeyIndexes[core]);
 			result = getSMCTemp(key);
 		}
 		return result;


### PR DESCRIPTION
## Summary
- Fix macOS Intel SMC fallback key formatting for per-core CPU temperatures.
- Use `%c` when formatting `KeyIndexes[core]`, producing keys like `TC0C` instead of invalid truncated ASCII-number keys like `TC48`.

## Why
- Commit `dcbdb736` changed SMC key indexing for many-core systems but left the uppercase fallback formatter as `%d`.
- On affected Intel Macs, the lowercase key path fails and the uppercase fallback is required, causing btop to display `-1C`.
- Related: #1049, #750

## Testing
- `make -B obj/osx/smc.o CXX="/usr/local/opt/llvm/bin/clang++"`

## AI Disclosure
- This PR was prepared with AI assistance.
