### PR TITLE
fix: prevent runner thread deadlock on macOS/OpenBSD/NetBSD [AI generated]

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -127,6 +127,7 @@ namespace Global {
 
 namespace Runner {
 	static pthread_t runner_id;
+	void safe_thread_trigger();
 } // namespace Runner
 
 //* Handler for SIGWINCH and general resizing events, does nothing if terminal hasn't been resized unless force=true
@@ -215,6 +216,12 @@ void clean_quit(int sig) {
 	Runner::stop();
 	if (Global::_runner_started) {
 	#if defined __APPLE__ || defined __OpenBSD__ || defined __NetBSD__
+		// binary_semaphore::acquire() is not a POSIX cancellation point on macOS;
+		// pthread_join() would hang if the thread is parked in thread_wait(). Post
+		// a token so it wakes, sees Global::quitting==true, and exits the loop.
+		// safe_thread_trigger() drains any pre-existing token to avoid undefined behavior on the
+		// max-1 semaphore.
+		Runner::safe_thread_trigger();
 		if (pthread_join(Runner::runner_id, nullptr) != 0) {
 			Logger::warning("Failed to join _runner thread on exit!");
 			pthread_cancel(Runner::runner_id);
@@ -374,6 +381,9 @@ namespace Runner {
 	std::binary_semaphore do_work { 0 };
 	inline void thread_wait() { do_work.acquire(); }
 	inline void thread_trigger() { do_work.release(); }
+	// Guarantees exactly one token is posted: drains any pre-existing token
+	// before release() to avoid undefined behavior on the max-1 binary_semaphore.
+	inline void safe_thread_trigger() { do_work.try_acquire(); do_work.release(); }
 
 	//* Wrapper for raising privileges when using SUID bit
 	class gain_priv {
@@ -742,14 +752,35 @@ namespace Runner {
 			Logger::error("Stall in Runner thread, restarting!");
 			set_active(false);
 			// exit(1);
+			// pthread_cancel() marks cancellation pending before thread_trigger() wakes
+			// the thread. binary_semaphore::acquire() is not a POSIX cancellation point
+			// on macOS; sleep_ms(1) is. With cancellation already pending when the
+			// thread reaches sleep_ms(), delivery is guaranteed regardless of scheduling.
+			stopping = true;
 			pthread_cancel(Runner::runner_id);
+			thread_trigger();
 
 			// Wait for the thread to actually terminate before creating a new one
 			void* thread_result;
 			int join_result = pthread_join(Runner::runner_id, &thread_result);
 			if (join_result != 0) {
-				Logger::warning("Failed to join cancelled thread: {}", strerror(join_result));
+				Logger::error("Failed to join cancelled thread: {} — aborting to avoid deadlock", strerror(join_result));
+				Global::exit_error_msg = "Failed to join cancelled Runner thread!";
+				clean_quit(1);
 			}
+			// pthread_cancel does not reliably invoke C++ destructors on macOS,
+			// so the cancelled thread's lock_guard on mtx may not have fired.
+			// The thread is gone (joined above); unlock the orphaned mutex so
+			// the replacement thread can acquire it. Technically undefined
+			// behavior per [thread.mutex.requirements.mutex] (calling unlock
+			// from a non-owning thread), but the mutex would otherwise remain
+			// permanently locked.
+			mtx.unlock();
+			// A thread cancelled mid-work never calls do_work.acquire(), leaving the
+			// counter at 1. Drain it so the new thread blocks on its first thread_wait()
+			// rather than racing on current_conf.
+			do_work.try_acquire();
+			stopping = false;
 
 			if (pthread_create(&Runner::runner_id, nullptr, &Runner::_runner, nullptr) != 0) {
 				Global::exit_error_msg = "Failed to re-create _runner thread!";

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -735,10 +735,17 @@ namespace Runner {
 
 			//? If overlay isn't empty, print output without color and then print overlay on top
 			const bool term_sync = Config::getB("terminal_sync");
+			// Disable cancellation so pthread_cancel() cannot interrupt between
+			// sync_start and sync_end — an incomplete synchronized frame leaves
+			// the terminal holding a stale
+			// image indefinitely (observed on macOS Terminal.app).
+			int old_cancel_state = PTHREAD_CANCEL_ENABLE;
+			pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old_cancel_state);
 			cout << (term_sync ? Term::sync_start : "") << (conf.overlay.empty()
 					? output
 					: (output.empty() ? "" : Fx::ub + Theme::c("inactive_fg") + Fx::uncolor(output)) + conf.overlay)
 				<< (term_sync ? Term::sync_end : "") << flush;
+			pthread_setcancelstate(old_cancel_state, nullptr);
 		}
 		//* ----------------------------------------------- THREAD LOOP -----------------------------------------------
 		return {};


### PR DESCRIPTION
This introduction was written by a human (and is slightly repetitive of what is below, but I wanted to assert some context and hopefully convince you that this is not just an AI slop PR).

Many thanks for btop!  I use it every day.  I periodically run into the MacOS btop hang cited in https://github.com/aristocratos/btop/issues/1349.  I used Claude to help me investigate how this happened, and how to fix it.

I apologize for the length of this description.  But the macOS hang is a complicated thread-related issue, and it is worth explaining both the problems and the proposed solutions.

Below is a more detailed writeup of the issues discovered.  It turns out that btop freezes in macOS in both the v4.1.6 release (i.e., from the `v1.4.6` git tag) as well the tip of the `main` branch, but for different reasons.

* The `v4.1.6` tag has 1 deadlock
* The tip of `main` has 2 deadlocks

During my investigation with Claude, it made a claim to me that I found surprising: `pthread_cancel()` does *not* invoke C++ destructors of objects on the thread-local stacks that it deletes.  After a bunch of research, I could not find any documentation definitively stating whether `pthread_cancel()` is *supposed* to invoke destructors on the thread it cancels or not.  The issue seems to be that `pthread_cancel()` is a C library and is not well defined with the C++ object model (i.e., that it should -- or should not -- unwind a thread's stack and call the destructor all corresponding objects).  It appears to be an implementation issue.  Claude tells me this:

* The POSIX standard specifies that "cancellation cleanup handlers" (registered via `pthread_cleanup_push`) are called, but says nothing about C++ destructors or stack unwinding. The interaction is implementation-defined.
* Linux (glibc): chose to implement cancellation by throwing a special exception (`__cxxabiv1::__forced_unwind`) on the target thread. This does trigger C++ stack unwinding and does call destructors — *but it can be accidentally swallowed by `catch(...)` blocks.*  See the [GCC libstdc++ exception documentation](https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_exceptions.html).
* macOS (libc++): uses a different mechanism that does not trigger C++ stack unwinding.  Destructors are simply not called.

Apparently (according to Claude) this is solved in C++20:

* C++20 acknowledged this gap by introducing `std::jthread` and `std::stop_token` — cooperative cancellation where the thread checks a flag at safe points and unwinds itself via a normal return or exception. That sidesteps `pthread_cancel()` entirely.

Claude and I therefore wrote up [a proof-of-concept C++ program](https://gist.github.com/jsquyres/4f752835171e72c023e0adca90d01762) that -- at least with libc++ on macOS Tahoe 26.4.1 -- reliably seems to confirm that this is true: `pthread_cancel()` **does not** invoke C++ destructors.

This turned out to be an important point in the btop code base, and is discussed below.

-----

The majority of the rest of this document is AI written, but edited and amended a bit by a human for clarity, additional context, etc.

## Summary

btop freezes after running for a period of time on macOS (and likely OpenBSD/NetBSD). The freeze is caused by deadlocks in the stall-recovery path of `Runner::run()`, where a stalled runner thread is cancelled via `pthread_cancel` and replaced with a new one. Two distinct bugs exist, one present since v1.4.6 and a second introduced by a later refactor on `main`.

---

## Testing methodology

I was not able to reliably reproduce the issue other than just letting btop run for a (long) while.  Inducing high load on my Mac did not reliably cause the issue, nor did artificially creating a (very) large number of processes.  The root cause of the problem appears when `Runner::_runner()` takes longer than 5 seconds to collect data; macOS is apparently *usually* very good at making all the data available in far less than 5 seconds.

Hence, I typically just had let two copies of btop run for long periods of time:

1. Unmodified 1.4.6 release, installed by Homebrew
1. Hand-compiled git clone at the tip of `main` with the fixes (described below)

Eventually, the problem would occur in both copies of btop at approximately the same time.  Here's a screenshot showing a Homebrew-installed 1.4.6 btop in the bottom, and a patched / locally-compiled btop running on the top.  You can see that the Homebrew-installed btop (bottom) froze about 2.5 hours earlier; the locally-compiled btop (top) is still running / is not frozen.

<img width="1356" height="721" alt="Screenshot 2026-05-04 at 6 48 51 PM" src="https://github.com/user-attachments/assets/7843b9e1-826b-4f92-b218-31aa880f89fa" />

Ultimately, I ended up manually injected stalls into `Runner::_runner()` to shorten the debugging cycle; I can provide that patch if it's useful.

## Pull request

This pull request contains just the fix for the tip of `main`.

Looking through the git history of this repo, it looks like most (all?) of the release tags are on `main`.  I'm therefore guessing that a `v4.1.6`-specific fix is therefore not needed.

## Bug 1: `binary_semaphore::acquire()` is not a cancellation point (v1.4.6+)

### Root cause

The runner thread uses a `std::binary_semaphore` (`do_work`) to sleep between collection cycles:

```cpp
inline void thread_wait() { do_work.acquire(); }
```

On macOS, `binary_semaphore::acquire()` is implemented via `__libcpp_atomic_wait` / `__ulock_wait`, which are **not** POSIX thread cancellation points. When `Runner::run()` detects a stall (the runner thread's collection cycle exceeds 5 seconds) and calls `pthread_cancel()`, the cancellation is set to pending but can never be delivered if the runner thread has already finished its work and parked in `thread_wait()`. The subsequent `pthread_join()` then hangs forever.

### How the race occurs

1. Runner thread starts a collection cycle (`active` = true).
2. Collection takes long enough to trigger stall detection (> 5 seconds).
3. Runner thread finishes its work, `active` becomes false, and the thread loops back to `thread_wait()` → `binary_semaphore::acquire()`.  Main thread's `atomic_wait_for(active, true, 5000)` times out, re-checks `active` — it was true at the timeout instant.
5. Main thread calls `pthread_cancel()` — but the runner is now in `acquire()`, not at a cancellation point.
6. Main thread calls `pthread_join()` — hangs forever.

### Observed behavior

Both the main btop display **and** the clock at the top of the btop display freeze. The main thread is stuck in `pthread_join` and can no longer poll for input or update the clock.

Stack trace (from a frozen homebrew-installed btop 1.4.6):

```
thread #1 (main):  __ulock_wait → _pthread_join → Runner::run()
thread #3 (runner): __ulock_wait → __libcpp_atomic_wait  (= semaphore::acquire)
```

---

## Bug 2: Orphaned `std::mutex` after `pthread_cancel` (`main` branch)

### Introducing commit

Commit [`651b50c`](https://github.com/aristocratos/btop/commit/651b50c) ("refactor: replace custom RAII lock with stdlib") (after the `v4.1.6` tag) replaced:

- `pthread_mutex_t mtx` → `std::mutex mtx`
- `thread_lock pt_lck(mtx)` → `std::lock_guard lock{mtx}`

This removed the `pthread_mutex_init()` call that was resetting the mutex after stall recovery.

### Root cause

As discussed above, `pthread_cancel()` does not reliably invoke C++ destructors on macOS.  When the runner thread is cancelled, its `lock_guard` destructor never fires, leaving `std::mutex mtx` permanently locked. The replacement thread calls `mtx.lock()` at startup and blocks forever.

### Proof

A standalone proof-of-concept program demonstrates the "`pthread_cancel()` doesn't invoke destructors on macOS" issue on macOS(): [**test_pthread_cancel.cpp**](https://gist.github.com/jsquyres/4f752835171e72c023e0adca90d01762)

```bash
c++ -std=c++17 -pthread -o test_pthread_cancel test_pthread_cancel.cpp
./test_pthread_cancel
```

Output on macOS (Apple Silicon, Apple Clang 21.0.0):

```
--- Test 1: std::mutex + lock_guard (current btop main) ---
  Destructor ran:       NO
  Mutex lockable after: NO (orphaned!)

--- Test 2: pthread_mutex_t + RAII wrapper (btop v1.4.6) ---
  Destructor ran:       NO
  Mutex lockable after: NO (orphaned!)
```

Neither case invokes the C++ destructor. 

### Why v1.4.6 doesn't have the 2nd deadlock that is on main

The v1.4.6 code did not have this problem only because `pthread_mutex_init()` reset the mutex — not because destructors ran. Specifically, the v1.4.6 code uses a custom `thread_lock` class wrapping `pthread_mutex_t`:

```cpp
explicit thread_lock(pthread_mutex_t& mtx) : pt_mutex(mtx) {
    pthread_mutex_init(&pt_mutex, nullptr);  // reinitializes the mutex!
    status = pthread_mutex_lock(&pt_mutex);
}
```

The `pthread_mutex_init()` call in the constructor **reinitializes** the mutex every time a new runner thread starts. Even though `pthread_cancel()` does not invoke the old thread's C++ destructors (leaving the mutex locked), the replacement thread's `thread_lock` constructor resets the mutex state before locking it. This masked the mutex orphan problem.

### Observed behavior

The display freezes but **the visible clock keeps updating**. The main thread is not deadlocked — it continues polling for input and updating the clock via `Runner::run("clock")`. But the runner thread (which does all data collection and drawing) is permanently blocked on `std::mutex::lock()`.

Stack trace (from a frozen hand-compiled btop on `main`):

```
thread #1 (main):  __pselect → Input::poll()  (normal — clock updates work)
thread #3 (runner): __psynch_mutexwait → std::mutex::lock() → Runner::_runner()
```

---

## Fixes

All fixes are in `src/btop.cpp`. The changes address both bugs on the current `main` branch.

### Fix 1: Wake the thread from `semaphore::acquire()` during stall recovery

In the stall-recovery path in `Runner::run()`, call `pthread_cancel()` **before** `thread_trigger()`. This sets cancellation to pending first. `thread_trigger()` then wakes the thread from `semaphore::acquire()`. Combined with setting `stopping = true`, the thread reaches `sleep_ms(1)` — a real POSIX cancellation point — where the pending cancellation is delivered.

```cpp
stopping = true;
pthread_cancel(Runner::runner_id);
thread_trigger();
```

### Fix 2: Unlock the orphaned mutex after `pthread_join()`

After `pthread_join()` succeeds, force-unlock the mutex. The cancelled thread's `lock_guard` destructor did not run, so `mtx` is permanently locked. Calling `unlock()` from a non-owning thread is technically undefined behavior per \[thread.mutex.requirements.mutex\], but `PTHREAD_MUTEX_NORMAL` (the default underlying `std::mutex` on all btop target platforms) does not check ownership, and the alternative is a permanent deadlock.

Bottom line: this is a "good enough" solution, even though it is technically undefined behavior.

```cpp
if (join_result == 0) {
    mtx.unlock();
}
```

### Fix 3: Drain unconsumed semaphore token after stall recovery

A thread cancelled mid-work never loops back to `thread_wait()` (`do_work.acquire()`), leaving the semaphore counter at 1. Drain it after `pthread_join()` so the replacement thread blocks properly on its first `thread_wait()`.

```cpp
do_work.try_acquire();
```

### Fix 4: Wake the thread in `clean_quit()` on macOS/OpenBSD/NetBSD

In `clean_quit()`, call `safe_thread_trigger()` (see below) before `pthread_join()` so a thread parked in `semaphore::acquire()` wakes, sees `Global::quitting == true`, and exits the loop cleanly. 

### Fix 5: Introduce `safe_thread_trigger()`

`binary_semaphore` has a max count of 1. Calling `release()` when the counter is already 1 is undefined behavior per \[thread.sema.cnt\]. `stop()` can post a token that the thread never consumes when it exits the `while(!quitting)` loop. `safe_thread_trigger()` drains any pre-existing token before releasing:

```cpp
inline void safe_thread_trigger() { do_work.try_acquire(); do_work.release(); }
```

## Thanks!

You made it to the bottom -- thanks for reading all of this! 🎉 