### PR TITLE
fix: gate Apple Silicon GPU support to unbreak intel Mac builds (#1641)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,14 +205,20 @@ endif()
 
 # Other platform dependent flags
 if(APPLE)
-  target_link_libraries(libbtop
-    $<LINK_LIBRARY:FRAMEWORK,CoreFoundation> $<LINK_LIBRARY:FRAMEWORK,IOKit>
-  )
-  if(BTOP_GPU)
-    find_library(IOREPORT_LIB IOReport)
-    if(IOREPORT_LIB)
-      target_link_libraries(libbtop ${IOREPORT_LIB})
+  # Only link these frameworks if we are on Apple Silicon (arm64)
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+    target_link_libraries(libbtop
+      $<LINK_LIBRARY:FRAMEWORK,CoreFoundation> $<LINK_LIBRARY:FRAMEWORK,IOKit>
+    )
+    if(BTOP_GPU)
+      find_library(IOREPORT_LIB IOReport)
+      if(IOREPORT_LIB)
+        target_link_libraries(libbtop ${IOREPORT_LIB})
+      endif()
     endif()
+  else()
+    # On Intel Macs, we disable GPU support to prevent build errors
+    set(BTOP_GPU OFF)
   endif()
 elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "MidnightBSD")
   # Avoid version mismatch for libstdc++ when a specific version of GCC is installed and not the

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ifeq ($(PLATFORM_LC)$(ARCH),linuxx86_64)
 		INTEL_GPU_SUPPORT := true
 	endif
 endif
-ifeq ($(PLATFORM_LC),macos)
+ifeq ($(PLATFORM_LC)$(ARCH),macosarm64)
 	GPU_SUPPORT := true
 endif
 ifneq ($(GPU_SUPPORT),true)
@@ -118,8 +118,11 @@ else ifeq ($(PLATFORM_LC),$(filter $(PLATFORM_LC),freebsd midnightbsd))
 else ifeq ($(PLATFORM_LC),macos)
 	PLATFORM_DIR := osx
 	THREADS	:= $(shell sysctl -n hw.ncpu || echo 1)
-	override ADDFLAGS += -framework IOKit -framework CoreFoundation -lIOReport -Wno-format-truncation
 	SU_GROUP := wheel
+	override ADDFLAGS += -Wno-format-truncation
+	ifeq ($(ARCH),arm64)
+	  override ADDFLAGS += -framework IOKit -framework CoreFoundation -lIOReport
+	endif
 else ifeq ($(PLATFORM_LC),openbsd)
 	PLATFORM_DIR := openbsd
 	THREADS	:= $(shell sysctl -n hw.ncpu || echo 1)

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -47,6 +47,11 @@ tab-size = 4
 #include <unistd.h>
 #include <stdexcept>
 #include <utility>
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED > 101504
+#include "sensors.hpp"
+#endif
+#include "smc.hpp"
 #endif
 
 #include <cmath>
@@ -64,13 +69,6 @@ tab-size = 4
 #include "../btop_log.hpp"
 #include "../btop_shared.hpp"
 #include "../btop_tools.hpp"
-
-#ifdef __APPLE__
-#if __MAC_OS_X_VERSION_MIN_REQUIRED > 101504
-#include "sensors.hpp"
-#endif
-#include "smc.hpp"
-#endif
 
 #if defined(GPU_SUPPORT) && defined(__APPLE__) && defined(__arm64__)
 #include <dlfcn.h>

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -16,6 +16,7 @@ indent = tab
 tab-size = 4
 */
 
+#ifdef __APPLE__
 #include <Availability.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/IOKitLib.h>
@@ -46,6 +47,7 @@ tab-size = 4
 #include <unistd.h>
 #include <stdexcept>
 #include <utility>
+#endif
 
 #include <cmath>
 #include <fstream>
@@ -63,12 +65,14 @@ tab-size = 4
 #include "../btop_shared.hpp"
 #include "../btop_tools.hpp"
 
+#ifdef __APPLE__
 #if __MAC_OS_X_VERSION_MIN_REQUIRED > 101504
 #include "sensors.hpp"
 #endif
 #include "smc.hpp"
+#endif
 
-#if defined(GPU_SUPPORT)
+#if defined(GPU_SUPPORT) && defined(__APPLE__) && defined(__arm64__)
 #include <dlfcn.h>
 #include <mach/mach_time.h>
 

--- a/src/osx/smc.hpp
+++ b/src/osx/smc.hpp
@@ -18,6 +18,7 @@ tab-size = 4
 
 #pragma once
 
+#ifdef __APPLE_
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/IOKitLib.h>
 #include <IOKit/ps/IOPSKeys.h>
@@ -115,3 +116,4 @@ namespace Cpu {
 		io_object_t device;
 	};
 }  // namespace Cpu
+#endif // __APPLE__

--- a/src/osx/smc.hpp
+++ b/src/osx/smc.hpp
@@ -18,7 +18,7 @@ tab-size = 4
 
 #pragma once
 
-#ifdef __APPLE_
+#ifdef __APPLE__
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/IOKitLib.h>
 #include <IOKit/ps/IOPSKeys.h>


### PR DESCRIPTION
Solves issue #1641
This commit gates apple silicon GPU monitoring behind arm64 arch checks in the makefile and preprocessor. Unbreaks the build for Intel Macs and other such platforms.