### PR TITLE
Fix atomic issues and data races in btop

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -292,14 +292,9 @@ static void _crash_handler(const int sig) {
 static void _signal_handler(const int sig) {
 	switch (sig) {
 		case SIGINT:
-			if (Runner::active) {
-				Global::should_quit = true;
-				Runner::stopping = true;
-				Input::interrupt();
-			}
-			else {
-				clean_quit(0);
-			}
+			Global::should_quit = true;
+			if (Runner::active) Runner::stopping = true;
+			Input::interrupt();
 			break;
 		case SIGTSTP:
 			if (Runner::active) {
@@ -365,7 +360,7 @@ namespace Runner {
 	atomic<bool> coreNum_reset (false);
 
 	static inline auto set_active(bool value) noexcept {
-		active.store(value, std::memory_order_relaxed);
+		active.store(value, std::memory_order_release);
 		active.notify_all();
 	}
 

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -353,15 +353,14 @@ void init_config(bool low_color, std::optional<std::string>& filter) {
 
 //* Manages secondary thread for collection and drawing of boxes
 namespace Runner {
-	atomic<bool> active (false);
+	atomic_waiting_lock active;
 	atomic<bool> stopping (false);
 	atomic<bool> waiting (false);
 	atomic<bool> redraw (false);
 	atomic<bool> coreNum_reset (false);
 
 	static inline auto set_active(bool value) noexcept {
-		active.store(value, std::memory_order_release);
-		active.notify_all();
+		active.store(value);
 	}
 
 	//* Setup semaphore for triggering thread to do work
@@ -482,7 +481,7 @@ namespace Runner {
 			}
 
 			//? Atomic lock used for blocking non thread-safe actions in main thread
-			atomic_lock lck(active);
+			auto lck = active.lock();
 
 			//? Set effective user if SUID bit is set
 			gain_priv powers{};

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -261,6 +261,7 @@ namespace Input {
 				}
 				else if (is_in(key, "p", "P") and Config::getS("disable_presets") != "All") {
 					if (Config::getS("disable_presets") == "Default" and Config::preset_list.size() <= 1) return;
+					atomic_wait(Runner::active);
 					const auto old_preset = Config::current_preset;
 					const int first_preset = (Config::getS("disable_presets") == "Default") ? 1 : 0;
 					if (Config::getS("disable_presets") == "Custom") Config::current_preset = 0;
@@ -272,7 +273,6 @@ namespace Input {
 					}
 					else Config::current_preset = (key == "p") ? first_preset : Config::preset_list.size() - 1;
 					if (Config::current_preset == old_preset) return;
-					atomic_wait(Runner::active);
 					if (not Config::apply_preset(Config::preset_list.at(Config::current_preset.value()))) {
 						Menu::show(Menu::Menus::SizeError);
 						Config::current_preset = old_preset;

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -1373,6 +1373,7 @@ static int optionsMenu(const string& key) {
 						screen_redraw = true;
 					else if (is_in(option, "shown_boxes", "presets")) {
 						screen_redraw = true;
+						atomic_wait(Runner::active);
 						Config::current_preset.reset();
 					}
 					else if (option == "clock_format") {
@@ -1530,8 +1531,10 @@ static int optionsMenu(const string& key) {
 				}
 				else if (is_in(option, "proc_sorting", "cpu_sensor", "show_gpu_info") or option.starts_with("graph_symbol") or option.starts_with("cpu_graph_"))
 					screen_redraw = true;
-				else if (option == "disable_presets" and optList.at(i) != "Off")
+				else if (option == "disable_presets" and optList.at(i) != "Off") {
+					atomic_wait(Runner::active);
 					Config::current_preset.reset();
+				}
 			}
 			else
 				retval = NoChange;

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -51,6 +51,10 @@ using std::vector;
 
 using namespace std::literals; // for operator""s
 
+namespace Tools {
+	class atomic_waiting_lock;
+}
+
 void term_resize(bool force=false);
 void banner_gen();
 
@@ -71,7 +75,7 @@ namespace Global {
 }
 
 namespace Runner {
-	extern atomic<bool> active;
+	extern Tools::atomic_waiting_lock active;
 	extern atomic<bool> reading;
 	extern atomic<bool> stopping;
 	extern atomic<bool> redraw;

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -551,14 +551,17 @@ namespace Tools {
 	}
 
 	atomic_lock::atomic_lock(atomic<bool>& atom, bool wait) : atom(atom) {
-		if (wait) while (not this->atom.compare_exchange_strong(this->not_true, true, std::memory_order_acquire, std::memory_order_relaxed)) this->not_true = false;
+		if (wait) {
+			bool expected = false;
+			while (not this->atom.compare_exchange_strong(expected, true, std::memory_order_acquire, std::memory_order_relaxed)) expected = false;
+		}
 		else this->atom.store(true, std::memory_order_release);
-		this->atom.notify_all();
+		this->atom.notify_one();
 	}
 
 	atomic_lock::~atomic_lock() noexcept {
 		this->atom.store(false, std::memory_order_release);
-		this->atom.notify_all();
+		this->atom.notify_one();
 	}
 
 	string readfile(const std::filesystem::path& path, const string& fallback) {

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -545,11 +545,6 @@ namespace Tools {
 		atom.wait(old, std::memory_order_acquire);
 	}
 
-	void atomic_wait_for(const atomic<bool>& atom, bool old, const uint64_t wait_ms) noexcept {
-		const uint64_t start_time = time_ms();
-		while (atom.load(std::memory_order_acquire) == old and (time_ms() - start_time < wait_ms)) sleep_ms(1);
-	}
-
 	atomic_lock::atomic_lock(atomic<bool>& atom, bool wait) : atom(atom) {
 		if (wait) {
 			bool expected = false;
@@ -562,6 +557,62 @@ namespace Tools {
 	atomic_lock::~atomic_lock() noexcept {
 		this->atom.store(false, std::memory_order_release);
 		this->atom.notify_one();
+	}
+
+	void atomic_waiting_lock::store(bool new_value) noexcept {
+		{
+			std::lock_guard lock {mtx};
+			value = new_value;
+		}
+		cv.notify_all();
+	}
+
+	void atomic_waiting_lock::wait(bool old) const noexcept {
+		std::unique_lock lock {mtx};
+		cv.wait(lock, [this, old] { return value != old; });
+	}
+
+	void atomic_waiting_lock::wait_for(bool old, uint64_t wait_ms) const noexcept {
+		std::unique_lock lock {mtx};
+		cv.wait_for(lock, std::chrono::milliseconds(wait_ms), [this, old] { return value != old; });
+	}
+
+	atomic_waiting_lock::guard atomic_waiting_lock::lock(bool wait) {
+		return guard(*this, wait);
+	}
+
+	atomic_waiting_lock::operator bool() const noexcept {
+		std::lock_guard lock {mtx};
+		return value;
+	}
+
+	atomic_waiting_lock::guard::guard(atomic_waiting_lock& atom, bool wait) : atom(atom) {
+		if (wait) {
+			std::unique_lock lock {this->atom.mtx};
+			this->atom.cv.wait(lock, [this] { return not this->atom.value; });
+			this->atom.value = true;
+		}
+		else {
+			std::lock_guard lock {this->atom.mtx};
+			this->atom.value = true;
+		}
+		this->atom.cv.notify_one();
+	}
+
+	atomic_waiting_lock::guard::~guard() noexcept {
+		{
+			std::lock_guard lock {this->atom.mtx};
+			this->atom.value = false;
+		}
+		this->atom.cv.notify_one();
+	}
+
+	void atomic_wait(const atomic_waiting_lock& atom, bool old) noexcept {
+		atom.wait(old);
+	}
+
+	void atomic_wait_for(const atomic_waiting_lock& atom, bool old, const uint64_t wait_ms) {
+		atom.wait_for(old, wait_ms);
 	}
 
 	string readfile(const std::filesystem::path& path, const string& fallback) {

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -542,22 +542,22 @@ namespace Tools {
 	}
 
 	void atomic_wait(const atomic<bool>& atom, bool old) noexcept {
-		atom.wait(old, std::memory_order_relaxed);
+		atom.wait(old, std::memory_order_acquire);
 	}
 
 	void atomic_wait_for(const atomic<bool>& atom, bool old, const uint64_t wait_ms) noexcept {
 		const uint64_t start_time = time_ms();
-		while (atom.load(std::memory_order_relaxed) == old and (time_ms() - start_time < wait_ms)) sleep_ms(1);
+		while (atom.load(std::memory_order_acquire) == old and (time_ms() - start_time < wait_ms)) sleep_ms(1);
 	}
 
 	atomic_lock::atomic_lock(atomic<bool>& atom, bool wait) : atom(atom) {
-		if (wait) while (not this->atom.compare_exchange_strong(this->not_true, true));
-		else this->atom.store(true);
+		if (wait) while (not this->atom.compare_exchange_strong(this->not_true, true, std::memory_order_acquire)) this->not_true = false;
+		else this->atom.store(true, std::memory_order_release);
 		this->atom.notify_all();
 	}
 
 	atomic_lock::~atomic_lock() noexcept {
-		this->atom.store(false);
+		this->atom.store(false, std::memory_order_release);
 		this->atom.notify_all();
 	}
 

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -551,7 +551,7 @@ namespace Tools {
 	}
 
 	atomic_lock::atomic_lock(atomic<bool>& atom, bool wait) : atom(atom) {
-		if (wait) while (not this->atom.compare_exchange_strong(this->not_true, true, std::memory_order_acquire)) this->not_true = false;
+		if (wait) while (not this->atom.compare_exchange_strong(this->not_true, true, std::memory_order_acquire, std::memory_order_relaxed)) this->not_true = false;
 		else this->atom.store(true, std::memory_order_release);
 		this->atom.notify_all();
 	}

--- a/src/btop_tools.hpp
+++ b/src/btop_tools.hpp
@@ -371,7 +371,6 @@ namespace Tools {
 	//* Sets atomic<bool> to true on construct, sets to false on destruct
 	class atomic_lock {
 		atomic<bool>& atom;
-		bool not_true{};
 	public:
 		explicit atomic_lock(atomic<bool>& atom, bool wait = false);
 		~atomic_lock() noexcept;

--- a/src/btop_tools.hpp
+++ b/src/btop_tools.hpp
@@ -26,9 +26,11 @@ tab-size = 4
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <filesystem>
 #include <limits.h>
+#include <mutex>
 #include <ranges>
 #include <regex>
 #include <string>
@@ -366,8 +368,6 @@ namespace Tools {
 
 	void atomic_wait(const atomic<bool>& atom, bool old = true) noexcept;
 
-	void atomic_wait_for(const atomic<bool>& atom, bool old = true, const uint64_t wait_ms = 0) noexcept;
-
 	//* Sets atomic<bool> to true on construct, sets to false on destruct
 	class atomic_lock {
 		atomic<bool>& atom;
@@ -379,6 +379,34 @@ namespace Tools {
 		atomic_lock(atomic_lock&& other) = delete;
 		atomic_lock& operator=(atomic_lock&& other) = delete;
 	};
+
+	class atomic_waiting_lock {
+		bool value{};
+		mutable std::mutex mtx;
+		mutable std::condition_variable cv;
+
+	public:
+		class guard {
+			atomic_waiting_lock& atom;
+		public:
+			explicit guard(atomic_waiting_lock& atom, bool wait = false);
+			~guard() noexcept;
+			guard(const guard& other) = delete;
+			guard& operator=(const guard& other) = delete;
+			guard(guard&& other) = delete;
+			guard& operator=(guard&& other) = delete;
+		};
+
+		void store(bool value) noexcept;
+		void wait(bool old = true) const noexcept;
+		void wait_for(bool old, uint64_t wait_ms) const noexcept;
+		[[nodiscard]] guard lock(bool wait = false);
+		explicit operator bool() const noexcept;
+	};
+
+	void atomic_wait(const atomic_waiting_lock& atom, bool old = true) noexcept;
+
+	void atomic_wait_for(const atomic_waiting_lock& atom, bool old = true, const uint64_t wait_ms = 0);
 
 	//* Read a complete file and return as a string
 	string readfile(const std::filesystem::path& path, const string& fallback = "");

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -1908,12 +1908,16 @@ namespace Gpu {
 			engines = discover_engines(device);
 			if (!engines) {
 				Logger::debug("Failed to find Intel GPU engines, Intel GPUs will not be detected");
+				free(gpu_device_name);
 				return false;
 			}
 
 			int ret = pmu_init(engines);
 			if (ret) {
 				Logger::warning("Intel GPU: Failed to initialize PMU");
+				free(gpu_device_name);
+				free_engines(engines);
+				engines = nullptr;
 				return false;
 			}
 


### PR DESCRIPTION
This pr every race in #1042 and potentially dozens more.
Original idea was to fix the race on Config::current_preset but after i dug deeper, unless i am somehow horribly wrong, the whole locking mechanism in btop is fundamentally broken.

`atomic_wait`, `atomic_wait_for`, `atomic_lock::atomic_lock` and `atomic_lock::~atomic_lock` used wrong atomic orderings. Here is why:
- `atomic_wait` & `atomic_wait_for` used relaxed ordering for the state of the runner. This would have been file if the state of the runner was _not_ being used for synchronization but use of these function assumed it creates happen befores, the implementation does not.
	eg: `btop_input.cpp::Input::process` gaurds accesses to `Config::current_preset` by using `atomic_wait(Runner::active)` [well now it does] which promises absolutely nothing if relaxed ordering is used.
Now these use acquire ordering and `btop.cpp::Runner::set_active` uses release ordering to guarantee mutual exclusion.
- `atomic_lock::atomic_lock` used `if (wait) while (not this->atom.compare_exchange_strong(this->not_true, true));` which actually sets the `this->not_true` from false to true if it first exchange fails; this is now fixed by repeatedly setting `this->not_true` to false inside of the loop.
- `atomic_lock::atomic_lock` used `this->atom.store(true);` in the else branch which uses seq_cst which is not required here. only release ordering is
- `atomic_lock::~atomic_lock` also used `this->atom.store(false);` which uses sequential consistency as well which is not needed here; changed the ordering to release.

Apart from that, here are the rest of the changes
- `btop.cpp::_signal_handler` uses `clean_quit` in singal handler which eventually calls forbidden functions like malloc which are not allowed inside of signal handlers. Fixed that by not calling `clean_quit`. It eventually gets called as a result of input.interrupt call
- 557fbe5 adds guard before accessing the config to make sure that it is not being accessed by the ui draw call
- 677336f adds guards above 2 more potential accesses in the menu
- 327f695 added free's for 1 more leak detected by valgrind
- 5aaca91 made fail ordering relaxed since no locking is happening in that case.

NOTE: Even tho no code in this pr is written by ai, i did use ai to analyze the tsan dumps and point me to the right place.