### PR TITLE
Fix btop with amd gpu on rocm 7 as in Ubuntu 26.04

### DIFF
--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -1546,7 +1546,8 @@ namespace Gpu {
 				"librocm_smi64.so",
 				"librocm_smi64.so.5", // fedora
 				"librocm_smi64.so.1.0", // debian
-				"librocm_smi64.so.6"
+				"librocm_smi64.so.6",
+				"librocm_smi64.so.7" // rocm 7 support / Ubuntu 26.04
 			};
 
 			for (const auto& l : libRocAlts) {


### PR DESCRIPTION
Fixes #1651

The librocm library version incremented to .7, so you need to start looking for that name as well.