### PR TITLE
feat: add Qualcomm Adreno GPU support

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -231,6 +231,8 @@ void clean_quit(int sig) {
 #ifdef GPU_SUPPORT
 	Gpu::Nvml::shutdown();
 	Gpu::Rsmi::shutdown();
+	Gpu::Intel::shutdown();
+	Gpu::Adreno::shutdown();
 	#ifdef __APPLE__
 	Gpu::AppleSilicon::shutdown();
 	#endif

--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -239,7 +239,7 @@ namespace Config {
 		{"rsmi_measure_pcie_speeds",
 								"#* Measure PCIe throughput on AMD cards, may impact performance on certain cards."},
 		{"gpu_mirror_graph",	"#* Horizontally mirror the GPU graph."},
-		{"shown_gpus",			"#* Set which GPU vendors to show. Available values are \"nvidia amd intel apple\""},
+		{"shown_gpus",			"#* Set which GPU vendors to show. Available values are \"nvidia amd intel adreno apple\""},
 		{"custom_gpu_name0",	"#* Custom gpu0 model name, empty string to disable."},
 		{"custom_gpu_name1",	"#* Custom gpu1 model name, empty string to disable."},
 		{"custom_gpu_name2",	"#* Custom gpu2 model name, empty string to disable."},
@@ -288,7 +288,7 @@ namespace Config {
 		{"custom_gpu_name4", ""},
 		{"custom_gpu_name5", ""},
 		{"show_gpu_info", "Auto"},
-		{"shown_gpus", "nvidia amd intel apple"}
+		{"shown_gpus", "nvidia amd intel adreno apple"}
 	#endif
 	};
 	std::unordered_map<std::string_view, string> stringsTmp;

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -603,7 +603,7 @@ namespace Menu {
 				"",
 				"Available values are",
 				"\"nvidia\", \"amd\", \"intel\",",
-				"and \"apple\".",
+				"\"adreno\", and \"apple\".",
 				"Separate values with whitespace.",
 				"",
 				"A restart is required to apply changes."},

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -183,6 +183,12 @@ namespace Gpu {
 	namespace Rsmi {
 		extern bool shutdown();
 	}
+	namespace Intel {
+		extern bool shutdown();
+	}
+	namespace Adreno {
+		extern bool shutdown();
+	}
 	#ifdef __APPLE__
 	namespace AppleSilicon {
 		extern bool shutdown();

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -294,6 +294,17 @@ namespace Gpu {
 		template <bool is_init> bool collect(gpu_info* gpus_slice);
 		uint32_t device_count = 0;
 	}
+
+	//? Qualcomm Adreno data collection (via KGSL sysfs)
+	namespace Adreno {
+		const fs::path kgsl_path = "/sys/class/kgsl/kgsl-3d0";
+
+		bool initialized = false;
+		bool init();
+		bool shutdown();
+		template <bool is_init> bool collect(gpu_info* gpus_slice);
+		uint32_t device_count = 0;
+	}
 }
 
 #endif // GPU_SUPPORT
@@ -379,6 +390,10 @@ namespace Shared {
 
 		if (shown_gpus.contains("intel")) {
 			Gpu::Intel::init();
+		}
+
+		if (shown_gpus.contains("adreno")) {
+			Gpu::Adreno::init();
 		}
 
 		if (not Gpu::gpu_names.empty()) {
@@ -1997,6 +2012,169 @@ namespace Gpu {
 		}
 	}
 
+	//? Qualcomm Adreno GPU data collection via sysfs/devfreq
+	namespace Adreno {
+		static fs::path devfreq_path;
+		static fs::path power_path;
+		static fs::path thermal_path;
+		static long long prev_active = 0, prev_suspended = 0;
+
+		static long long read_sysfs_ll(const fs::path& path) {
+			ifstream f(path);
+			long long val = 0;
+			if (f.good()) f >> val;
+			return val;
+		}
+
+		static string find_gpu_devfreq() {
+			const fs::path devfreq_dir = "/sys/class/devfreq";
+			if (!fs::exists(devfreq_dir)) return "";
+			for (const auto& entry : fs::directory_iterator(devfreq_dir)) {
+				if (entry.path().filename().string().find("gpu") == string::npos) continue;
+				// Verify it's an Adreno device via compatible string
+				fs::path compat_path = entry.path() / "device" / "of_node" / "compatible";
+				ifstream f(compat_path);
+				string compat;
+				if (f.good() and getline(f, compat) and compat.find("adreno") != string::npos) {
+					return entry.path().string();
+				}
+			}
+			return "";
+		}
+
+		static string find_gpu_thermal() {
+			const fs::path thermal_dir = "/sys/class/thermal";
+			if (!fs::exists(thermal_dir)) return "";
+			for (const auto& entry : fs::directory_iterator(thermal_dir)) {
+				ifstream type_f(entry.path() / "type");
+				string type;
+				if (type_f.good() and getline(type_f, type) and type.find("gpu") != string::npos) {
+					return entry.path().string();
+				}
+			}
+			return "";
+		}
+
+		static string get_gpu_name() {
+			ifstream f(devfreq_path / "device" / "of_node" / "compatible");
+			string compat;
+			if (f.good() and getline(f, compat)) {
+				auto pos = compat.find("adreno-");
+				if (pos != string::npos) {
+					string ver = compat.substr(pos + 7);
+					auto end = ver.find_first_not_of("0123456789");
+					if (end != string::npos) ver = ver.substr(0, end);
+					return "Adreno " + ver;
+				}
+			}
+			return "Adreno GPU";
+		}
+
+		bool init() {
+			if (initialized) return false;
+
+			string df = find_gpu_devfreq();
+			if (df.empty()) {
+				Logger::debug("Adreno: No GPU devfreq device found");
+				return false;
+			}
+			devfreq_path = df;
+
+			// The devfreq device has a "device" symlink to the platform device
+			fs::path dev_link = fs::path(df) / "device";
+			if (fs::exists(dev_link / "power" / "runtime_active_time")) {
+				power_path = fs::canonical(dev_link) / "power";
+			}
+
+			string th = find_gpu_thermal();
+			if (!th.empty()) thermal_path = th;
+
+			device_count = 1;
+			gpus.resize(gpus.size() + device_count);
+			gpu_names.resize(gpus.size());
+			gpu_names[Nvml::device_count + Rsmi::device_count + Intel::device_count] = get_gpu_name();
+
+			initialized = true;
+
+			// Seed runtime PM counters
+			if (!power_path.empty()) {
+				prev_active = read_sysfs_ll(power_path / "runtime_active_time");
+				prev_suspended = read_sysfs_ll(power_path / "runtime_suspended_time");
+			}
+
+			Adreno::collect<1>(gpus.data() + Nvml::device_count + Rsmi::device_count + Intel::device_count);
+			return true;
+		}
+
+		bool shutdown() {
+			if (!initialized) return false;
+			initialized = false;
+			return true;
+		}
+
+		template <bool is_init> bool collect(gpu_info* gpus_slice) {
+			if (!initialized) return false;
+
+			if constexpr(is_init) {
+				gpus_slice->supported_functions = {
+					.gpu_utilization = !power_path.empty(),
+					.mem_utilization = false,
+					.gpu_clock = true,
+					.mem_clock = false,
+					.pwr_usage = false,
+					.pwr_state = false,
+					.temp_info = !thermal_path.empty(),
+					.mem_total = false,
+					.mem_used = false,
+					.pcie_txrx = false,
+					.encoder_utilization = false,
+					.decoder_utilization = false
+				};
+			}
+
+			//? GPU clock from devfreq (Hz -> MHz)
+			if (gpus_slice->supported_functions.gpu_clock) {
+				long long cur_freq = read_sysfs_ll(devfreq_path / "cur_freq");
+				if (cur_freq <= 0) {
+					if constexpr(is_init) {
+						Logger::warning("Adreno: Failed to read GPU clock frequency");
+						gpus_slice->supported_functions.gpu_clock = false;
+					}
+				} else {
+					gpus_slice->gpu_clock_speed = (unsigned int)(cur_freq / 1'000'000);
+				}
+			}
+
+			//? GPU utilization from runtime PM active/suspended time delta
+			if (gpus_slice->supported_functions.gpu_utilization) {
+				long long active = read_sysfs_ll(power_path / "runtime_active_time");
+				long long suspended = read_sysfs_ll(power_path / "runtime_suspended_time");
+				long long d_active = active - prev_active;
+				long long d_suspended = suspended - prev_suspended;
+				long long total = d_active + d_suspended;
+				long long util = (total > 0) ? clamp(d_active * 100 / total, 0ll, 100ll) : 0ll;
+				gpus_slice->gpu_percent.at("gpu-totals").push_back(util);
+				prev_active = active;
+				prev_suspended = suspended;
+			}
+
+			//? Temperature
+			if (gpus_slice->supported_functions.temp_info) {
+				long long temp = read_sysfs_ll(fs::path(thermal_path) / "temp");
+				if (temp <= 0) {
+					if constexpr(is_init) {
+						Logger::warning("Adreno: Failed to read GPU temperature");
+						gpus_slice->supported_functions.temp_info = false;
+					}
+				} else {
+					gpus_slice->temp.push_back(temp / 1000); // millidegrees -> degrees
+				}
+			}
+
+			return true;
+		}
+	}
+
 	//? Collect data from GPU-specific libraries
 	auto collect(bool no_update) -> vector<gpu_info>& {
 		if (Runner::stopping or (no_update and not gpus.empty())) return gpus;
@@ -2007,6 +2185,7 @@ namespace Gpu {
 		Nvml::collect<0>(gpus.data()); // raw pointer to vector data, size == Nvml::device_count
 		Rsmi::collect<0>(gpus.data() + Nvml::device_count); // size = Rsmi::device_count
 		Intel::collect<0>(gpus.data() + Nvml::device_count + Rsmi::device_count); // size = Intel::device_count
+		Adreno::collect<0>(gpus.data() + Nvml::device_count + Rsmi::device_count + Intel::device_count); // size = Adreno::device_count
 
 		//* Calculate average usage
 		long long avg = 0;

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -202,6 +202,8 @@ namespace Gpu {
 	//? Stub shutdown for backends not available on macOS
 	namespace Nvml { bool shutdown() { return false; } }
 	namespace Rsmi { bool shutdown() { return false; } }
+	namespace Intel { bool shutdown() { return false; } }
+	namespace Adreno { bool shutdown() { return false; } }
 
 	//? Apple Silicon GPU data collection via IOReport
 	namespace AppleSilicon {


### PR DESCRIPTION
Add GPU monitoring for Qualcomm Adreno GPUs via sysfs/devfreq interface.

Supported metrics:
- GPU utilization (via runtime PM active/suspended time)
- GPU clock frequency (via devfreq cur_freq)
- Temperature (via thermal zones)

The implementation follows the same pattern as existing GPU backends (Nvml, Rsmi, Intel) with proper init/shutdown lifecycle, is_init feature detection, and cross-platform stubs for macOS.

Configuration: add "adreno" to shown_gpus option.