### PR TITLE
Fix possible thread deadlocks and power-event-based false stall detections

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -217,13 +217,11 @@ void clean_quit(int sig) {
 	#if defined __APPLE__ || defined __OpenBSD__ || defined __NetBSD__
 		if (pthread_join(Runner::runner_id, nullptr) != 0) {
 			Logger::warning("Failed to join _runner thread on exit!");
-			pthread_cancel(Runner::runner_id);
 		}
 	#else
 		constexpr struct timespec ts { .tv_sec = 5, .tv_nsec = 0 };
 		if (pthread_timedjoin_np(Runner::runner_id, nullptr, &ts) != 0) {
 			Logger::warning("Failed to join _runner thread on exit!");
-			pthread_cancel(Runner::runner_id);
 		}
 	#endif
 	}
@@ -468,9 +466,9 @@ namespace Runner {
 		//* ----------------------------------------------- THREAD LOOP -----------------------------------------------
 		while (not Global::quitting) {
 			thread_wait();
-			atomic_wait_for(active, true, 5000);
+			atomic_wait_for(active, true, 30'000);
 			if (active) {
-				Global::exit_error_msg = "Runner thread failed to get active lock!";
+				Global::exit_error_msg = "Runner thread failed to get active lock (30s)!";
 				Global::thread_exception = true;
 				Input::interrupt();
 				stopping = true;
@@ -731,24 +729,14 @@ namespace Runner {
 
 	//* Runs collect and draw in a secondary thread, unlocks and locks config to update cached values
 	void run(const string& box, bool no_update, bool force_redraw) {
-		atomic_wait_for(active, true, 5000);
+		atomic_wait_for(active, true, 10'000);
 		if (active) {
-			Logger::error("Stall in Runner thread, restarting!");
-			set_active(false);
-			// exit(1);
-			pthread_cancel(Runner::runner_id);
-
-			// Wait for the thread to actually terminate before creating a new one
-			void* thread_result;
-			int join_result = pthread_join(Runner::runner_id, &thread_result);
-			if (join_result != 0) {
-				Logger::warning("Failed to join cancelled thread: {}", strerror(join_result));
-			}
-
-			if (pthread_create(&Runner::runner_id, nullptr, &Runner::_runner, nullptr) != 0) {
-				Global::exit_error_msg = "Failed to re-create _runner thread!";
-				clean_quit(1);
-			}
+			Logger::warning("Runner thread slow (>10s), waiting up to 30s...");
+			atomic_wait_for(active, true, 20'000);
+		}
+		if (active) {
+			Global::exit_error_msg = "Runner thread stalled for 30s, exiting.";
+			clean_quit(1);
 		}
 		if (stopping or Global::resized) return;
 
@@ -793,14 +781,14 @@ namespace Runner {
 			Global::exit_error_msg = "Runner thread died unexpectedly!";
 			clean_quit(1);
 		} else if (is_runner_busy) {
-			atomic_wait_for(active, true, 5000);
+			atomic_wait_for(active, true, 30'000);
 			if (active) {
 				set_active(false);
 				if (Global::quitting) {
 					return;
 				}
 				else {
-					Global::exit_error_msg = "No response from Runner thread, quitting!";
+					Global::exit_error_msg = "No response from Runner thread (30s), quitting!";
 					clean_quit(1);
 				}
 			}

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -574,7 +574,13 @@ namespace Tools {
 
 	void atomic_waiting_lock::wait_for(bool old, uint64_t wait_ms) const noexcept {
 		std::unique_lock lock {mtx};
-		cv.wait_for(lock, std::chrono::milliseconds(wait_ms), [this, old] { return value != old; });
+		const auto start = uptime_micros();
+		const auto wait_us = wait_ms * 1'000ULL;
+		while (value == old) {
+			const auto elapsed = uptime_micros() - start;
+			if (elapsed >= wait_us) break;
+			cv.wait_for(lock, std::chrono::microseconds(wait_us - elapsed), [this, old] { return value != old; });
+		}
 	}
 
 	atomic_waiting_lock::guard atomic_waiting_lock::lock(bool wait) {

--- a/src/btop_tools.hpp
+++ b/src/btop_tools.hpp
@@ -28,6 +28,7 @@ tab-size = 4
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
+#include <ctime>
 #include <filesystem>
 #include <limits.h>
 #include <mutex>
@@ -248,6 +249,19 @@ namespace Tools {
 	//* Return current time since epoch in microseconds
 	inline uint64_t time_micros() {
 		return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+	}
+
+	//* Return uptime in microseconds, excluding time spent in system suspend
+	inline uint64_t uptime_micros() {
+		struct timespec ts{};
+#ifdef __APPLE__
+		if (clock_gettime(CLOCK_UPTIME_RAW, &ts) != 0) return 0;
+#elif defined(__FreeBSD__)
+		if (clock_gettime(CLOCK_UPTIME, &ts) != 0) return 0;
+#else
+		if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) return 0;
+#endif
+		return static_cast<uint64_t>(ts.tv_sec) * 1'000'000 + static_cast<uint64_t>(ts.tv_nsec) / 1000;
 	}
 
 	//* Check if a string is a valid bool value

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -49,6 +49,7 @@ tab-size = 4
 
 #include <cmath>
 #include <fstream>
+#include <future>
 #include <mutex>
 #include <numeric>
 #include <ranges>
@@ -817,38 +818,64 @@ namespace Cpu {
 		return got_sensors;
 	}
 
-	void update_sensors() {
-		current_cpu.temp_max = 95;  // we have no idea how to get the critical temp
+	struct SensorResult {
+		long long package_temp{};
+		std::vector<long long> core_temps;
+		bool valid{false};
+	};
+
+	static SensorResult collect_sensors() {
+		SensorResult result;
 		try {
 			if (macM1) {
 #if __MAC_OS_X_VERSION_MIN_REQUIRED > 101504
 				ThermalSensors sensors;
-				std::vector<long long> core_temps;
-				current_cpu.temp.at(0).push_back(sensors.getSensors(core_temps));
-				if (current_cpu.temp.at(0).size() > 20)
-					current_cpu.temp.at(0).pop_front();
-				cpu_temp_only = core_temps.empty();
-
-				if (Config::getB("show_coretemp") and not core_temps.empty()) {
-					for (int core = 0; core < Shared::coreCount; core++) {
-						size_t sensor_index = static_cast<size_t>(core) * core_temps.size() / Shared::coreCount;
-						long long temp = core_temps.at(sensor_index);
-						if (cmp_less(core + 1, current_cpu.temp.size())) {
-							current_cpu.temp.at(core + 1).push_back(temp);
-							if (current_cpu.temp.at(core + 1).size() > 20)
-								current_cpu.temp.at(core + 1).pop_front();
-						}
-					}
-				}
+				result.package_temp = sensors.getSensors(result.core_temps);
+				result.valid = true;
 #endif
 			} else {
 				SMCConnection smcCon;
 				int threadsPerCore = Shared::coreCount / Shared::physicalCoreCount;
-				long long packageT = smcCon.getTemp(-1); // -1 returns package T
-				current_cpu.temp.at(0).push_back(packageT);
-
+				result.package_temp = smcCon.getTemp(-1);
 				for (int core = 0; core < Shared::coreCount; core++) {
-					long long temp = smcCon.getTemp((core / threadsPerCore) + core_offset); // same temp for all threads of same physical core
+					result.core_temps.push_back(smcCon.getTemp((core / threadsPerCore) + core_offset));
+				}
+				result.valid = true;
+			}
+		} catch (std::runtime_error &e) {
+			Logger::error("failed getting CPU temp: {}", e.what());
+		}
+		return result;
+	}
+
+	void update_sensors() {
+		static std::future<SensorResult> sensor_future;
+		static SensorResult last_result{};
+
+		current_cpu.temp_max = 95;  // we have no idea how to get the critical temp
+
+		if (sensor_future.valid() and
+		    sensor_future.wait_for(std::chrono::seconds(0)) != std::future_status::timeout) {
+			last_result = sensor_future.get();
+			if (not last_result.valid) {
+				got_sensors = false;
+			}
+		}
+
+		if (last_result.valid) {
+			current_cpu.temp.at(0).push_back(last_result.package_temp);
+			if (current_cpu.temp.at(0).size() > 20)
+				current_cpu.temp.at(0).pop_front();
+
+			if (macM1) {
+				cpu_temp_only = last_result.core_temps.empty();
+			}
+
+			bool show_coretemp = macM1 ? Config::getB("show_coretemp") : true;
+			if (show_coretemp and not last_result.core_temps.empty()) {
+				for (int core = 0; core < Shared::coreCount; core++) {
+					size_t sensor_index = static_cast<size_t>(core) * last_result.core_temps.size() / Shared::coreCount;
+					long long temp = last_result.core_temps.at(sensor_index);
 					if (cmp_less(core + 1, current_cpu.temp.size())) {
 						current_cpu.temp.at(core + 1).push_back(temp);
 						if (current_cpu.temp.at(core + 1).size() > 20)
@@ -856,10 +883,9 @@ namespace Cpu {
 					}
 				}
 			}
-		} catch (std::runtime_error &e) {
-			got_sensors = false;
-			Logger::error("failed getting CPU temp");
 		}
+
+		sensor_future = std::async(std::launch::async, collect_sensors);
 	}
 
 	string get_cpuHz() {


### PR DESCRIPTION
Per discussion on #1647, the runner thread on macOS can stall due to slow IOKit sensor reads or timeout accounting across system suspend. If a stall triggers `pthread_cancel()`, C++ state is not portably cleaned up on macOS/BSDs, which can leave mutexes or synchronization primitives wedged.

This PR addresses those failure modes without relying on `pthread_cancel()`. See PR #1647 for the investigation and discussion.

## Changes

### Commit 1: Use futures for macOS sensor collection and remove `pthread_cancel()`

Move macOS thermal sensor reads off the runner's synchronous path by collecting them in a `std::async` future. Each collection cycle checks the previous future non-blockingly, uses the most recent completed result, and avoids launching over a still-pending future so the runner does not block by destroying a running `std::future`.

This keeps slow IOKit/SMC temperature reads from directly stalling the runner loop. Temperature display can lag by at most one completed collection cycle, which is acceptable for UI sensor data.

The runner stall-recovery path no longer uses `pthread_cancel()`. Instead, btop logs a warning after 10 seconds and exits cleanly after 30 seconds if the runner still has not recovered.

### Commit 2: Make `atomic_waiting_lock::wait_for()` suspend-aware

PR #1649 replaced the old atomic timeout helper with `atomic_waiting_lock::wait_for()` backed by a condition variable. This PR keeps that condition-variable locking model, but changes timeout accounting so system suspend time does not count as runner-stall time.

`atomic_waiting_lock::wait_for()` now uses `uptime_micros()` as the source of truth for elapsed time and treats `std::condition_variable::wait_for()` only as the wake/sleep primitive. If the machine sleeps while waiting, the condition variable may wake after its internal timeout expires, but the outer loop re-checks elapsed awake time before declaring timeout.

`uptime_micros()` uses the best available clock per platform:

- macOS: `CLOCK_UPTIME_RAW`
- FreeBSD: `CLOCK_UPTIME`
- Linux/OpenBSD/NetBSD: `CLOCK_MONOTONIC`

This prevents sleep, Deep Idle, or DarkWake intervals from causing false runner-stall detections immediately after resume.

Fixes #1349
