### PR TITLE
fix: use ISO 8601 format for log timestamps [AI generated]

### DIFF
--- a/src/btop_log.cpp
+++ b/src/btop_log.cpp
@@ -134,7 +134,7 @@ namespace Logger {
 			auto seconds = std::chrono::time_point_cast<std::chrono::seconds>(now);
 			fmt::format_to(
 				std::back_inserter(buffer),
-				"{:%F (%T)} | {}: {}\n",
+				"{:%FT%T}Z | {}: {}\n",
 				seconds,
 				log_levels.at(std::to_underlying(level)),
 				msg


### PR DESCRIPTION
This PR is a  drive-by / minor suggestion that I came across while working on https://github.com/aristocratos/btop/pull/1662: clarify that the timestamps in the btop logs are UTC (not local time), so that it's unambiguous how to reconcile btop log timestamps against system logs.

-----

Change log timestamps from the custom format to ISO 8601 with UTC indicator:

  Before: `2026-05-14 (10:31:47) | DEBUG: ...`
  After:  `2026-05-14T10:31:47Z | DEBUG: ...`

The previous format used parentheses around the time and omitted any timezone indicator, making timestamps ambiguous. The logger uses `std::chrono::system_clock` which measures time since Unix epoch (UTC on all platforms), but the old format did not communicate this.

ISO 8601 with the Z suffix is an unambiguous, universally-recognized format parseable by standard functions across languages:

- C++ (C++20): `std::chrono::from_stream(ss, "%FT%TZ", tp)`
- C: `strptime(s, "%Y-%m-%dT%H:%M:%SZ", &tm)`
- Python: `datetime.fromisoformat("2026-05-14T10:31:47Z")`

This matters for correlating btop log events with system logs (e.g., macOS pmset power events) that use local time with explicit timezone offsets.