### PR TITLE
Deduplicate vectors and strings.

### DIFF
--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -47,6 +47,24 @@ namespace rng = std::ranges;
 using namespace std::literals;
 using namespace Tools;
 
+const vector<string> Config::valid_graph_symbols = { "braille", "block", "tty" };
+const vector<string> Config::valid_graph_symbols_def = { "default", "braille", "block", "tty" };
+const vector<string> Config::valid_boxes = {
+	"cpu", "mem", "net", "proc"
+#ifdef GPU_SUPPORT
+	,"gpu0", "gpu1", "gpu2", "gpu3", "gpu4", "gpu5"
+#endif
+};
+const vector<string> Config::temp_scales = { "celsius", "fahrenheit", "kelvin", "rankine" };
+#ifdef __linux__
+const vector<string> Config::freq_modes = { "first", "range", "lowest", "highest", "average" };
+#endif
+#ifdef GPU_SUPPORT
+const vector<string> Config::show_gpu_values = { "Auto", "On", "Off" };
+#endif
+const vector<string> Config::base_10_bitrate_values = { "Auto", "True", "False" };
+const vector<string> Config::disable_preset_options = { "Off", "Default", "Custom", "All" };
+
 //* Functions and variables for reading and writing the btop config file
 namespace Config {
 

--- a/src/btop_config.hpp
+++ b/src/btop_config.hpp
@@ -41,25 +41,21 @@ namespace Config {
 	extern std::unordered_map<std::string_view, int> ints;
 	extern std::unordered_map<std::string_view, int> intsTmp;
 
-	const vector<string> valid_graph_symbols = { "braille", "block", "tty" };
-	const vector<string> valid_graph_symbols_def = { "default", "braille", "block", "tty" };
-	const vector<string> valid_boxes = {
-		"cpu", "mem", "net", "proc"
-#ifdef GPU_SUPPORT
-		,"gpu0", "gpu1", "gpu2", "gpu3", "gpu4", "gpu5"
-#endif
-		};
-	const vector<string> temp_scales = { "celsius", "fahrenheit", "kelvin", "rankine" };
+	extern const vector<string> valid_graph_symbols;
+	extern const vector<string> valid_graph_symbols_def;
+	extern const vector<string> valid_boxes;
+
+	extern const vector<string> temp_scales;
 #ifdef __linux__
-	const vector<string> freq_modes = { "first", "range", "lowest", "highest", "average" };
+	extern const vector<string> freq_modes;
 #endif
 #ifdef GPU_SUPPORT
-	const vector<string> show_gpu_values = { "Auto", "On", "Off" };
+	extern const  vector<string> show_gpu_values;
 #endif
-    const vector<string> base_10_bitrate_values = { "Auto", "True", "False" };
+    extern const vector<string> base_10_bitrate_values;
 	extern vector<string> current_boxes;
 	extern vector<string> preset_list;
-	const vector<string> disable_preset_options = { "Off", "Default", "Custom", "All" };
+	extern const vector<string> disable_preset_options;
 	extern vector<string> available_batteries;
 	extern std::optional<int> current_preset;
 

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -54,6 +54,33 @@ using namespace Tools;
 using namespace std::literals; // for operator""s
 namespace rng = std::ranges;
 
+const string Symbols::h_line				= "─";
+const string Symbols::v_line				= "│";
+const string Symbols::dotted_v_line		= "╎";
+const string Symbols::left_up			= "┌";
+const string Symbols::right_up			= "┐";
+const string Symbols::left_down			= "└";
+const string Symbols::right_down			= "┘";
+const string Symbols::round_left_up		= "╭";
+const string Symbols::round_right_up		= "╮";
+const string Symbols::round_left_down	= "╰";
+const string Symbols::round_right_down	= "╯";
+const string Symbols::title_left_down	= "┘";
+const string Symbols::title_right_down	= "└";
+const string Symbols::title_left			= "┐";
+const string Symbols::title_right		= "┌";
+const string Symbols::div_right			= "┤";
+const string Symbols::div_left			= "├";
+const string Symbols::div_up				= "┬";
+const string Symbols::div_down			= "┴";
+
+
+const string Symbols::up = "↑";
+const string Symbols::down = "↓";
+const string Symbols::left = "←";
+const string Symbols::right = "→";
+const string Symbols::enter = "↵";
+
 namespace Symbols {
 	const string meter = "■";
 

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -54,24 +54,24 @@ using namespace Tools;
 using namespace std::literals; // for operator""s
 namespace rng = std::ranges;
 
-const string Symbols::h_line				= "─";
-const string Symbols::v_line				= "│";
+const string Symbols::h_line			= "─";
+const string Symbols::v_line			= "│";
 const string Symbols::dotted_v_line		= "╎";
 const string Symbols::left_up			= "┌";
 const string Symbols::right_up			= "┐";
 const string Symbols::left_down			= "└";
-const string Symbols::right_down			= "┘";
+const string Symbols::right_down		= "┘";
 const string Symbols::round_left_up		= "╭";
-const string Symbols::round_right_up		= "╮";
+const string Symbols::round_right_up	= "╮";
 const string Symbols::round_left_down	= "╰";
 const string Symbols::round_right_down	= "╯";
 const string Symbols::title_left_down	= "┘";
 const string Symbols::title_right_down	= "└";
-const string Symbols::title_left			= "┐";
+const string Symbols::title_left		= "┐";
 const string Symbols::title_right		= "┌";
 const string Symbols::div_right			= "┤";
 const string Symbols::div_left			= "├";
-const string Symbols::div_up				= "┬";
+const string Symbols::div_up			= "┬";
 const string Symbols::div_down			= "┴";
 
 

--- a/src/btop_draw.hpp
+++ b/src/btop_draw.hpp
@@ -31,32 +31,32 @@ using std::string;
 using std::vector;
 
 namespace Symbols {
-	const string h_line				= "─";
-	const string v_line				= "│";
-	const string dotted_v_line		= "╎";
-	const string left_up			= "┌";
-	const string right_up			= "┐";
-	const string left_down			= "└";
-	const string right_down			= "┘";
-	const string round_left_up		= "╭";
-	const string round_right_up		= "╮";
-	const string round_left_down	= "╰";
-	const string round_right_down	= "╯";
-	const string title_left_down	= "┘";
-	const string title_right_down	= "└";
-	const string title_left			= "┐";
-	const string title_right		= "┌";
-	const string div_right			= "┤";
-	const string div_left			= "├";
-	const string div_up				= "┬";
-	const string div_down			= "┴";
+	extern const string h_line;
+	extern const string v_line;
+	extern const string dotted_v_line;
+	extern const string left_up;
+	extern const string right_up;
+	extern const string left_down;
+	extern const string right_down;
+	extern const string round_left_up;
+	extern const string round_right_up;
+	extern const string round_left_down;
+	extern const string round_right_down;
+	extern const string title_left_down;
+	extern const string title_right_down;
+	extern const string title_left;
+	extern const string title_right;
+	extern const string div_right;
+	extern const string div_left;
+	extern const string div_up;
+	extern const string div_down;
 
 
-	const string up = "↑";
-	const string down = "↓";
-	const string left = "←";
-	const string right = "→";
-	const string enter = "↵";
+	extern const string up;
+	extern const string down;
+	extern const string left;
+	extern const string right;
+	extern const string enter;
 }
 
 namespace Draw {

--- a/src/btop_log.cpp
+++ b/src/btop_log.cpp
@@ -156,3 +156,5 @@ namespace Logger {
 	} // namespace detail
 
 } // namespace Logger
+
+const std::vector<std::string> Logger::log_levels = { "DISABLED", "ERROR", "WARNING", "INFO", "DEBUG" };

--- a/src/btop_log.hpp
+++ b/src/btop_log.hpp
@@ -21,7 +21,7 @@ namespace Logger {
 		DEBUG = 4,
 	};
 
-	const std::vector<std::string> log_levels { "DISABLED", "ERROR", "WARNING", "INFO", "DEBUG" };
+	extern const std::vector<std::string> log_levels;
 
 	namespace detail {
 		auto is_enabled(Level level) -> bool;

--- a/src/btop_shared.cpp
+++ b/src/btop_shared.cpp
@@ -329,3 +329,32 @@ auto detect_container() -> std::optional<std::string> {
 
     return std::nullopt;
 }
+
+#if defined(GPU_SUPPORT)
+const array<string, 2> Gpu::mem_names { "used", "free" };
+#endif
+
+const vector<string> Proc::sort_vector = {
+	"pid",
+	"name",
+	"command",
+	"threads",
+	"user",
+	"memory",
+	"cpu direct",
+	"cpu lazy",
+};
+
+const std::unordered_map<char, string> Proc::proc_states = {
+	{'R', "Running"},
+	{'S', "Sleeping"},
+	{'D', "Waiting"},
+	{'Z', "Zombie"},
+	{'T', "Stopped"},
+	{'t', "Tracing"},
+	{'X', "Dead"},
+	{'x', "Dead"},
+	{'K', "Wakekill"},
+	{'W', "Unknown"},
+	{'P', "Parked"}
+};

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -124,7 +124,7 @@ namespace Gpu {
 
 	extern std::unordered_map<string, deque<long long>> shared_gpu_percent; // averages, power/vram total
 
-	const array mem_names { "used"s, "free"s };
+	extern const array<string, 2> mem_names;
 
 	//* Container for process information // TODO
 	/*struct proc_info {
@@ -373,31 +373,10 @@ namespace Proc {
 	extern atomic<bool> resized;
 
 	//? Contains the valid sorting options for processes
-	const vector<string> sort_vector = {
-		"pid",
-		"name",
-		"command",
-		"threads",
-		"user",
-		"memory",
-		"cpu direct",
-		"cpu lazy",
-	};
+	extern const vector<string> sort_vector;
 
 	//? Translation from process state char to explanative string
-	const std::unordered_map<char, string> proc_states = {
-		{'R', "Running"},
-		{'S', "Sleeping"},
-		{'D', "Waiting"},
-		{'Z', "Zombie"},
-		{'T', "Stopped"},
-		{'t', "Tracing"},
-		{'X', "Dead"},
-		{'x', "Dead"},
-		{'K', "Wakekill"},
-		{'W', "Unknown"},
-		{'P', "Parked"}
-	};
+	extern const std::unordered_map<char, string> proc_states;
 
 	//* Container for process information
 	struct proc_info {

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -730,3 +730,40 @@ namespace Tools {
 		return running;
 	}
 }
+
+const string Fx::e = "\x1b[";		//* Escape sequence start
+const string Fx::b = e + "1m";		//* Bold on/off
+const string Fx::ub = e + "22m";	//* Bold off
+const string Fx::d = e + "2m";		//* Dark on
+const string Fx::ud = e + "22m";	//* Dark off
+const string Fx::i = e + "3m";		//* Italic on
+const string Fx::ui = e + "23m";	//* Italic off
+const string Fx::ul = e + "4m";		//* Underline on
+const string Fx::uul = e + "24m";	//* Underline off
+const string Fx::bl = e + "5m";		//* Blink on
+const string Fx::ubl = e + "25m";	//* Blink off
+const string Fx::s = e + "9m";		//* Strike/crossed-out on
+const string Fx::us = e + "29m";	//* Strike/crossed-out on/off
+
+//* Reset foreground/background color and text effects
+const string Fx::reset_base = e + "0m";
+
+//* Regex for matching color, style and cursor move escape sequences
+const std::regex Fx::escape_regex("\033\\[\\d+;?\\d?;?\\d*;?\\d*;?\\d*(m|f|s|u|C|D|A|B){1}");
+
+//* Regex for matching only color and style escape sequences
+const std::regex Fx::color_regex("\033\\[\\d+;?\\d?;?\\d*;?\\d*;?\\d*(m){1}");
+
+const string Term::hide_cursor = Fx::e + "?25l";
+const string Term::show_cursor = Fx::e + "?25h";
+const string Term::alt_screen = Fx::e + "?1049h";
+const string Term::normal_screen = Fx::e + "?1049l";
+const string Term::clear = Fx::e + "2J" + Fx::e + "0;0f";
+const string Term::clear_end = Fx::e + "0J";
+const string Term::clear_begin = Fx::e + "1J";
+const string Term::mouse_on = Fx::e + "?1002h" + Fx::e + "?1015h" + Fx::e + "?1006h"; //? Enable reporting of mouse position on click and release
+const string Term::mouse_off = Fx::e + "?1002l" + Fx::e + "?1015l" + Fx::e + "?1006l";
+const string Term::mouse_direct_on = Fx::e + "?1003h"; //? Enable reporting of mouse position at any movement
+const string Term::mouse_direct_off = Fx::e + "?1003l";
+const string Term::sync_start = Fx::e + "?2026h"; //? Start of terminal synchronized output
+const string Term::sync_end = Fx::e + "?2026l"; //? End of terminal synchronized output

--- a/src/btop_tools.hpp
+++ b/src/btop_tools.hpp
@@ -69,31 +69,31 @@ using namespace fmt::literals;
 
 //* Collection of escape codes for text style and formatting
 namespace Fx {
-	const string e = "\x1b[";				//* Escape sequence start
-	const string b = e + "1m";				//* Bold on/off
-	const string ub = e + "22m";			//* Bold off
-	const string d = e + "2m";				//* Dark on
-	const string ud = e + "22m";			//* Dark off
-	const string i = e + "3m";				//* Italic on
-	const string ui = e + "23m";			//* Italic off
-	const string ul = e + "4m";				//* Underline on
-	const string uul = e + "24m";			//* Underline off
-	const string bl = e + "5m";				//* Blink on
-	const string ubl = e + "25m";			//* Blink off
-	const string s = e + "9m";				//* Strike/crossed-out on
-	const string us = e + "29m";			//* Strike/crossed-out on/off
+	extern const string e;	//* Escape sequence start
+	extern const string b;	//* Bold on/off
+	extern const string ub;	//* Bold off
+	extern const string d;	//* Dark on
+	extern const string ud;	//* Dark off
+	extern const string i;	//* Italic on
+	extern const string ui;	//* Italic off
+	extern const string ul;	//* Underline on
+	extern const string uul;//* Underline off
+	extern const string bl;	//* Blink on
+	extern const string ubl;//* Blink off
+	extern const string s;	//* Strike/crossed-out on
+	extern const string us;	//* Strike/crossed-out on/off
 
 	//* Reset foreground/background color and text effects
-	const string reset_base = e + "0m";
+	extern const string reset_base;
 
 	//* Reset text effects and restore theme foregrund and background color
 	extern string reset;
 
 	//* Regex for matching color, style and cursor move escape sequences
-	const std::regex escape_regex("\033\\[\\d+;?\\d?;?\\d*;?\\d*;?\\d*(m|f|s|u|C|D|A|B){1}");
+	extern const std::regex escape_regex;
 
 	//* Regex for matching only color and style escape sequences
-	const std::regex color_regex("\033\\[\\d+;?\\d?;?\\d*;?\\d*;?\\d*(m){1}");
+	extern const std::regex color_regex;
 
 	//* Return a string with all colors and text styling removed
 	inline string uncolor(const string& s) { return std::regex_replace(s, color_regex, ""); }
@@ -132,19 +132,19 @@ namespace Term {
 	extern atomic<int> height;
 	extern string fg, bg, current_tty;
 
-	const string hide_cursor = Fx::e + "?25l";
-	const string show_cursor = Fx::e + "?25h";
-	const string alt_screen = Fx::e + "?1049h";
-	const string normal_screen = Fx::e + "?1049l";
-	const string clear = Fx::e + "2J" + Fx::e + "0;0f";
-	const string clear_end = Fx::e + "0J";
-	const string clear_begin = Fx::e + "1J";
-	const string mouse_on = Fx::e + "?1002h" + Fx::e + "?1015h" + Fx::e + "?1006h"; //? Enable reporting of mouse position on click and release
-	const string mouse_off = Fx::e + "?1002l" + Fx::e + "?1015l" + Fx::e + "?1006l";
-	const string mouse_direct_on = Fx::e + "?1003h"; //? Enable reporting of mouse position at any movement
-	const string mouse_direct_off = Fx::e + "?1003l";
-	const string sync_start = Fx::e + "?2026h"; //? Start of terminal synchronized output
-	const string sync_end = Fx::e + "?2026l"; //? End of terminal synchronized output
+	extern const string hide_cursor;
+	extern const string show_cursor;
+	extern const string alt_screen;
+	extern const string normal_screen;
+	extern const string clear;
+	extern const string clear_end;
+	extern const string clear_begin;
+	extern const string mouse_on; //? Enable reporting of mouse position on click and release
+	extern const string mouse_off;
+	extern const string mouse_direct_on; //? Enable reporting of mouse position at any movement
+	extern const string mouse_direct_off;
+	extern const string sync_start; //? Start of terminal synchronized output
+	extern const string sync_end; //? End of terminal synchronized output
 
 	//* Returns true if terminal has been resized and updates width and height
 	bool refresh(bool only_check=false);


### PR DESCRIPTION
Namespace-scope `const` objects _defined_ in header files have static linkage. Every translation unit including such a header gets its own private copies of namespace-scope `const` objects _defined_ in the header.

This change deduplicates namespace-scope `const` `string` and `vector<string>` objects by moving their _definitions_ from the .hpp files into corresponding .cpp files.

---

When building on a laptop with latest KDE Neon (Ubuntu 24.04 LTS) using `make -j16 CXX=g++-14 CC=gcc-14`, this change results in:

* ~4.5% faster release-mode build time (0:23.65s before, 0:22.60s after),
* ~20% smaller object file size total (7.6M before, 6.1M after),
* ~16% fewer symbols in `btop` executable (3,538 before, 2,983 after),
* ~45% smaller `.data` section of `btop` executable (21,912 bytes before, 12,056 bytes after),
* ~2.75% smaller `btop` executable size (2,224,728 bytes before, 2,163,568 bytes after),
* ~5% smaller maximum resident set size for `btop -h` invocation (5,616kB before, 5,340kB after).

It ain't much, but honest work. 

---

A more capable and resourceful developer would further remove immutable heap-allocated `string` copies of string literals that have been mmap'ped from `.rodata` section  of `btop` executable.

And, ideally, replace `const vector<string>` objects with `const initializer_list<char const*>` objects to completely eliminate heap-allocated `vector<string>` copies of objects already present in the process virtual memory area that mmap's `.rodata` section  of `btop` executable. Copying `initializer_list<char const*>` objects does not copy its backing array. Unlike copying `array<char const*, N>` objects, which also require specifying the element count in header _declarations_ without _definitions_.
