### PR TITLE
fix: defer SIGWINCH resize handling [AI generated]

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -310,7 +310,8 @@ static void _signal_handler(const int sig) {
 			_resume();
 			break;
 		case SIGWINCH:
-			term_resize();
+			Global::resized = true;
+			Input::interrupt();
 			break;
 		case SIGUSR1:
 			// Input::poll interrupt


### PR DESCRIPTION
While testing the proposed macOS deadlock fixes in https://github.com/aristocratos/btop/pull/1662 (and using the handy https://github.com/aristocratos/btop/pull/1663 timestamp disambiguator), I ran across another deadlock that does not seem to be related to the others we have been discussing: the SIGWINCH handler is not re-entrant safe.  

The tl;dr is that while in the main-thread-invoked `term_resize()`, macOS sent a SIGWINCH which then *also* invoked `term_resize()`.  This caused a deadlock because the 2nd invocation tried to obtain an atomic lock that it already had locked.

The main evidence is a stack trace captured from the deadlocked btop process:

```
  main
    btop_main(...) btop.cpp:1175
      term_resize(bool) btop.cpp:162
        sleep_ms(...) btop_tools.hpp:311
          ...
            _signal_handler(int) btop.cpp:313
              term_resize(bool) btop.cpp:142
                Tools::atomic_lock::atomic_lock(...) btop_tools.cpp:548/551
                  compare_exchange_strong(...)
```

(line numbers are a little different than the tip of `main` because I have a bunch of additional logging lines sprinkled throughout the code to help with #1662)

-----

Avoid running the full terminal resize path from the signal handler so resize notifications cannot reenter term_resize() while it already holds its guard.