### PR TITLE
[AI generated] macOS: Implement battery wattage collection using IOKit

### DIFF
--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -949,6 +949,7 @@ namespace Cpu {
 
 		uint32_t percent = -1;
 		long seconds = -1;
+		float watts = -1;
 		string status = "discharging";
 		IOPSInfo_Wrap ps_info{};
 		if (ps_info()) {
@@ -977,6 +978,28 @@ namespace Cpu {
 					if (percent == 100) {
 						status = "full";
 					}
+
+					CFMutableDictionaryRef matchingDict = IOServiceMatching("AppleSmartBattery");
+					if (matchingDict) {
+						io_service_t service = IOServiceGetMatchingService(0, matchingDict);
+						if (service) {
+							CFMutableDictionaryRef properties = NULL;
+							if (IORegistryEntryCreateCFProperties(service, &properties, kCFAllocatorDefault, 0) == KERN_SUCCESS and properties) {
+								long long amperage = 0;
+								long long voltage = 0;
+								CFNumberRef ampref = (CFNumberRef)CFDictionaryGetValue(properties, CFSTR("InstantAmperage"));
+								if (not ampref) ampref = (CFNumberRef)CFDictionaryGetValue(properties, CFSTR("Amperage"));
+								if (ampref) CFNumberGetValue(ampref, kCFNumberLongLongType, &amperage);
+								CFNumberRef voltref = (CFNumberRef)CFDictionaryGetValue(properties, CFSTR("Voltage"));
+								if (voltref) CFNumberGetValue(voltref, kCFNumberLongLongType, &voltage);
+								if (voltage != 0) {
+									watts = std::abs(static_cast<float>(amperage) * voltage) / 1000000.0f;
+								}
+								CFRelease(properties);
+							}
+							IOObjectRelease(service);
+						}
+					}
 				} else {
 					has_battery = false;
 				}
@@ -984,7 +1007,7 @@ namespace Cpu {
 				has_battery = false;
 			}
 		}
-		return {percent, -1, seconds, status};
+		return {percent, watts, seconds, status};
 	}
 
 	auto collect(bool no_update) -> cpu_info & {


### PR DESCRIPTION
[AI generated] macOS: Implement battery wattage collection using IOKit

  DESCRIPTION:
  Description
  This PR implements battery wattage collection for macOS. 
  Currently, the macOS implementation of get_battery() returns -1 for the wattage value, leaving the battery power display empty in the UI.

  Changes
   - Added IOKit calls to access AppleSmartBattery service via IORegistry.
   - Implemented calculation of power usage using InstantAmperage (or Amperage) and Voltage.
   - Calculation: abs(amperage * voltage) / 1,000,000 to get Watts.

  Verification
   - Verified on Apple Silicon Mac: battery wattage is now correctly displayed in the top-right corner next to the battery percentage.
   - The project builds successfully with make.

  [AI generated]
