### PR TITLE
fix: avoid macOS swap disk crash [AI generated]

### DIFF
--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1198,9 +1198,8 @@ namespace Mem {
 							string mountpoint = mapping.at(device);
 							if (disks.contains(mountpoint)) {
 								auto& disk = disks.at(mountpoint);
-								CFDictionaryRef properties;
-								IORegistryEntryCreateCFProperties(volumeRef, (CFMutableDictionaryRef *)&properties, kCFAllocatorDefault, 0);
-								if (properties) {
+								CFDictionaryRef properties = nullptr;
+								if (IORegistryEntryCreateCFProperties(volumeRef, (CFMutableDictionaryRef *)&properties, kCFAllocatorDefault, 0) == KERN_SUCCESS and properties != nullptr) {
 									CFDictionaryRef statistics = (CFDictionaryRef)CFDictionaryGetValue(properties, CFSTR("Statistics"));
 									if (statistics) {
 										disk_ios++;
@@ -1227,8 +1226,8 @@ namespace Mem {
 											disk.io_activity.push_back(clamp((long)round((double)(disk.io_write.back() + disk.io_read.back()) / (1 << 20)), 0l, 100l));
 										while (cmp_greater(disk.io_activity.size(), width * 2)) disk.io_activity.pop_front();
 									}
+									CFRelease(properties);
 								}
-								CFRelease(properties);
 							}
 						}
 					}
@@ -1353,6 +1352,10 @@ namespace Mem {
 			static std::unordered_map<string, std::future<std::pair<disk_info, int>>> disks_stats_promises;
 			for (auto it = disks.begin(); it != disks.end(); ) {
 				auto &[mountpoint, disk] = *it;
+				if (mountpoint == "swap") {
+					++it;
+					continue;
+				}
 				if (auto promises_it = disks_stats_promises.find(mountpoint); promises_it != disks_stats_promises.end()) {
 					auto& promise = promises_it->second;
 					if (promise.valid() && promise.wait_for(std::chrono::seconds(0)) == std::future_status::timeout) {
@@ -1360,6 +1363,7 @@ namespace Mem {
 						continue;
 					}
 					auto promise_res = promises_it->second.get();
+					disks_stats_promises.erase(promises_it);
 					if (promise_res.second != -1) {
 						Logger::warning("Failed to get disk/partition stats with statvfs() for: {}", mountpoint);
 						++it;


### PR DESCRIPTION
This is one possible fix to https://github.com/aristocratos/btop/issues/1689.

I admit that I did not do nearly as deep a dive into this fix as I did for the recent deadlock-related fixes we did; my Claude analyzed the failure, we tested a few things (e.g., setting `swap_disk` to both `true` and `false` in the btop config to confirm the failure), and it suggested the following patch.  I did read over the code briefly, and at least on the surface, the fix looks appropriate to me.  That being said, I'm very open to someone else making a different, more-informed fix.

Claude also drive-by picked up a nearby-but-different minor fix of avoiding an unsafe `CFRelease()`.

-----

Skip the synthetic swap disk entry when collecting filesystem stats on macOS. The swap row is not a real mountpoint, so calling statvfs() on it fails and leaves the async disk-stat future in an error path.

Also release IOKit properties only when IORegistryEntryCreateCFProperties() succeeds and returns a valid object, avoiding an unsafe CFRelease() after failed property creation.