### PR TITLE
Enable NVIDIA GPU support on Linux ARM (aarch64/arm64)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,12 +102,27 @@ endif
 ifeq ($(PLATFORM_LC)$(ARCH),macosarm64)
 	GPU_SUPPORT := true
 endif
+#? NVIDIA (NVML) GPU support also works on Linux ARM (e.g. Jetson, Grace, GB10 DGX Spark).
+#? Intel GPU support stays x86_64-only.
+ifeq ($(PLATFORM_LC)$(ARCH),linuxaarch64)
+	ifneq ($(STATIC),true)
+		GPU_SUPPORT := true
+	endif
+endif
+ifeq ($(PLATFORM_LC)$(ARCH),linuxarm64)
+	ifneq ($(STATIC),true)
+		GPU_SUPPORT := true
+	endif
+endif
 ifneq ($(GPU_SUPPORT),true)
 	GPU_SUPPORT := false
 endif
 
 ifeq ($(GPU_SUPPORT),true)
 	override ADDFLAGS += -DGPU_SUPPORT
+endif
+ifeq ($(INTEL_GPU_SUPPORT),true)
+	override ADDFLAGS += -DINTEL_GPU_SUPPORT
 endif
 
 #? Compiler and Linker

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -56,7 +56,7 @@ tab-size = 4
 #include "../btop_shared.hpp"
 #include "../btop_tools.hpp"
 
-#if defined(GPU_SUPPORT)
+#if defined(INTEL_GPU_SUPPORT)
 	// Redefining C++ keywords fortunately has a warning in clang, however it's unavoidable here
 	// since the C library uses "class" as a struct member and keywords are not allowed to be used
 	// as identifiers in C++.
@@ -284,6 +284,7 @@ namespace Gpu {
 
 
 	//? Intel data collection
+#if defined(INTEL_GPU_SUPPORT)
 	namespace Intel {
 		const char* device = "i915";
 		struct engines *engines = nullptr;
@@ -294,6 +295,7 @@ namespace Gpu {
 		template <bool is_init> bool collect(gpu_info* gpus_slice);
 		uint32_t device_count = 0;
 	}
+#endif // INTEL_GPU_SUPPORT
 
 	//? AMD sysfs (consumer GPU / iGPU) data collection — fallback when amd-smi/rocm-smi
 	//? cannot enumerate (e.g. APUs without /dev/kfd, or systems without ROCm libs installed).
@@ -401,9 +403,11 @@ namespace Shared {
 			Gpu::Asysfs::init(); //? self-skips when rocm-smi already enumerated devices
 		}
 
+#if defined(INTEL_GPU_SUPPORT)
 		if (shown_gpus.contains("intel")) {
 			Gpu::Intel::init();
 		}
+#endif // INTEL_GPU_SUPPORT
 
 		if (not Gpu::gpu_names.empty()) {
 			for (auto const& [key, _] : Gpu::gpus[0].gpu_percent)
@@ -1907,6 +1911,7 @@ namespace Gpu {
 		}
 	}
 
+#if defined(INTEL_GPU_SUPPORT)
 	namespace Intel {
 		bool init() {
 			if (initialized) return false;
@@ -2025,6 +2030,7 @@ namespace Gpu {
 			return true;
 		}
 	}
+#endif // INTEL_GPU_SUPPORT (Gpu::Intel)
 
 	namespace Asysfs {
 		//? Read a sysfs node containing a single integer; return fallback on missing/parse error.
@@ -2221,7 +2227,9 @@ namespace Gpu {
 		Nvml::collect<0>(gpus.data()); // raw pointer to vector data, size == Nvml::device_count
 		Rsmi::collect<0>(gpus.data() + Nvml::device_count); // size = Rsmi::device_count
 		Asysfs::collect<0>(gpus.data() + Nvml::device_count + Rsmi::device_count); // size = Asysfs::device_count
+#if defined(INTEL_GPU_SUPPORT)
 		Intel::collect<0>(gpus.data() + Nvml::device_count + Rsmi::device_count + Asysfs::device_count); // size = Intel::device_count
+#endif // INTEL_GPU_SUPPORT
 
 		//* Calculate average usage
 		long long avg = 0;


### PR DESCRIPTION
## What

Enable NVIDIA (NVML) GPU monitoring on **Linux ARM** (`aarch64` / `arm64`).

The NVML code already works on ARM, but the Makefile only auto-enabled `GPU_SUPPORT` for `linux x86_64`, so ARM builds (and distro packages) ship without any GPU box. This enables it for `linux aarch64` / `arm64` — NVIDIA/NVML only; Intel GPU support stays x86_64-only.

## Why the Intel guard is needed

The Intel GPU collection code (`namespace Gpu::Intel`) was compiled whenever `GPU_SUPPORT` is defined, but its implementation objects (`igt_perf` / `intel_gpu_top`) are only linked when `INTEL_GPU_SUPPORT` is set. So any `GPU_SUPPORT` build without Intel failed to link:

```
undefined reference to `pmu_sample' / `pmu_calc' / `free_engines' ...
```

This adds a `-DINTEL_GPU_SUPPORT` define and guards the Intel `#include`, namespace, `init()` call and `collect<0>` call behind it, so a NVIDIA-only GPU build links cleanly. x86_64 (which sets `INTEL_GPU_SUPPORT := true`) is unchanged.

## Testing

Built and run on an **NVIDIA GB10 (DGX Spark, aarch64)**, Ubuntu 24.04:
- default `make` now reports `GPU_SUPPORT :| true`
- links cleanly (no Intel objects pulled in)
- btop shows the GPU box with utilization / temp / power

🤖 Generated with [Claude Code](https://claude.com/claude-code)
