### PR TITLE
Remove -/+ symbols when proc_tree is true

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -601,8 +601,8 @@ namespace Cpu {
 				+ (!Config::current_preset.has_value() ? "*" : to_string(Config::current_preset.value())) + Fx::ub + title_right;
 			Input::mouse_mappings["p"] = {button_y, x + 17, 1, 8};
 			const string update = to_string(Config::getI("update_ms")) + "ms";
-			out += Mv::to(button_y, x + width - update.size() - 8) + title_left + Fx::b + Theme::c("hi_fg") + "- " + Theme::c("title") + update
-				+ Theme::c("hi_fg") + " +" + Fx::ub + title_right;
+			out += Mv::to(button_y, x + width - update.size() - 8) + title_left + Fx::b + Theme::c("hi_fg") + (Config::getB("proc_tree") ? "  " : "- ") + Theme::c("title") + update
+				+ Theme::c("hi_fg") + (Config::getB("proc_tree") ? "  " : " +") + Fx::ub + title_right;
 			Input::mouse_mappings["-"] = {button_y, x + width - (int)update.size() - 7, 1, 2};
 			Input::mouse_mappings["+"] = {button_y, x + width - 5, 1, 2};
 

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -347,6 +347,7 @@ namespace Input {
 					Config::flip("proc_tree");
 					no_update = false;
 					Config::set("update_following", true);
+					Runner::run("cpu", no_update, redraw);
 				}
 				else if (key == "E" and Config::getB("proc_tree")) {
 					atomic_wait(Runner::active);


### PR DESCRIPTION
This fixes a bug that implies the +/- keys can still be used to change the update time when proc_tree is true. This bug may have contributed to the problem described in #1685 