### PR TITLE
Fix -/+ key bindings

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -603,10 +603,10 @@ namespace Cpu {
 				+ (!Config::current_preset.has_value() ? "*" : to_string(Config::current_preset.value())) + Fx::ub + title_right;
 			Input::mouse_mappings["p"] = {button_y, x + 17, 1, 8};
 			const string update = to_string(Config::getI("update_ms")) + "ms";
-			out += fmt::format("{}{}{}", 
-				Mv::to(button_y, x + width - update.size() - 8) + title_left + Fx::b + Theme::c(is_proc_focused_and_in_tree ? "inactive_fg" : "hi_fg") + "- ",
-				Theme::c(is_proc_focused_and_in_tree ? "inactive_fg" : "title") + update,
-				Theme::c(is_proc_focused_and_in_tree ? "inactive_fg" : "hi_fg") + " +" + Fx::ub + title_right);
+			fmt::format_to(std::back_inserter(out), "{}{}{}{}{}{}{}{}{}{}{}",
+				Mv::to(button_y, x + width - update.size() - 8), title_left, Fx::b, Theme::c(is_proc_focused_and_in_tree ? "inactive_fg" : "hi_fg"), "- ",
+				Theme::c(is_proc_focused_and_in_tree ? "inactive_fg" : "title"), update,
+				Theme::c(is_proc_focused_and_in_tree ? "inactive_fg" : "hi_fg"), " +", Fx::ub, title_right);
 			Input::mouse_mappings["-"] = {button_y, x + width - (int)update.size() - 7, 1, 2};
 			Input::mouse_mappings["+"] = {button_y, x + width - 5, 1, 2};
 

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -592,7 +592,8 @@ namespace Cpu {
 			graph_up_height = (single_graph ? height - 2 : ceil((double)(height - 2) / 2) - (mid_line and height % 2 != 0));
 			graph_low_height = height - 2 - graph_up_height - mid_line;
 			const int button_y = cpu_bottom ? y + height - 1 : y;
-			const bool is_focused_on_proc = (Config::getB("follow_process") and Config::getI("followed_pid") == Config::getI("detailed_pid")) or Config::getI("proc_selected") > 0;
+			const bool is_proc_focused = (Config::getB("follow_process") and Config::getI("followed_pid") == Config::getI("detailed_pid")) or Config::getI("proc_selected") > 0;
+			const bool is_proc_focused_and_in_tree = is_proc_focused and Config::getB("proc_tree");
 			out += box;
 
 			//? Buttons on title
@@ -602,10 +603,13 @@ namespace Cpu {
 				+ (!Config::current_preset.has_value() ? "*" : to_string(Config::current_preset.value())) + Fx::ub + title_right;
 			Input::mouse_mappings["p"] = {button_y, x + 17, 1, 8};
 			const string update = to_string(Config::getI("update_ms")) + "ms";
-			out += Mv::to(button_y, x + width - update.size() - 8) + title_left + Fx::b + Theme::c(is_focused_on_proc and Config::getB("proc_tree") ? "inactive_fg" : "hi_fg") + "- " + Theme::c(is_focused_on_proc and Config::getB("proc_tree") ? "inactive_fg" : "title") + update
-				+ Theme::c(is_focused_on_proc and Config::getB("proc_tree") ? "inactive_fg" : "hi_fg") + " +" + Fx::ub + title_right;
+			out += fmt::format("{}{}{}", 
+				Mv::to(button_y, x + width - update.size() - 8) + title_left + Fx::b + Theme::c(is_proc_focused_and_in_tree ? "inactive_fg" : "hi_fg") + "- ",
+				Theme::c(is_proc_focused_and_in_tree ? "inactive_fg" : "title") + update,
+				Theme::c(is_proc_focused_and_in_tree ? "inactive_fg" : "hi_fg") + " +" + Fx::ub + title_right);
 			Input::mouse_mappings["-"] = {button_y, x + width - (int)update.size() - 7, 1, 2};
 			Input::mouse_mappings["+"] = {button_y, x + width - 5, 1, 2};
+
 			// Draw container engine name
 			if (Cpu::container_engine.has_value()) {
 				fmt::format_to(std::back_inserter(out), "{}{}{}{}{}", Mv::to(button_y, x + 28), title_left, Theme::c("title"), Cpu::container_engine.value(), title_right);

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -592,6 +592,7 @@ namespace Cpu {
 			graph_up_height = (single_graph ? height - 2 : ceil((double)(height - 2) / 2) - (mid_line and height % 2 != 0));
 			graph_low_height = height - 2 - graph_up_height - mid_line;
 			const int button_y = cpu_bottom ? y + height - 1 : y;
+			const bool is_focused_on_proc = (Config::getB("follow_process") and Config::getI("followed_pid") == Config::getI("detailed_pid")) or Config::getI("proc_selected") > 0;
 			out += box;
 
 			//? Buttons on title
@@ -601,11 +602,10 @@ namespace Cpu {
 				+ (!Config::current_preset.has_value() ? "*" : to_string(Config::current_preset.value())) + Fx::ub + title_right;
 			Input::mouse_mappings["p"] = {button_y, x + 17, 1, 8};
 			const string update = to_string(Config::getI("update_ms")) + "ms";
-			out += Mv::to(button_y, x + width - update.size() - 8) + title_left + Fx::b + Theme::c("hi_fg") + "- " + Theme::c("title") + update
-				+ Theme::c("hi_fg") + " +" + Fx::ub + title_right;
+			out += Mv::to(button_y, x + width - update.size() - 8) + title_left + Fx::b + Theme::c(is_focused_on_proc and Config::getB("proc_tree") ? "inactive_fg" : "hi_fg") + "- " + Theme::c(is_focused_on_proc and Config::getB("proc_tree") ? "inactive_fg" : "title") + update
+				+ Theme::c(is_focused_on_proc and Config::getB("proc_tree") ? "inactive_fg" : "hi_fg") + " +" + Fx::ub + title_right;
 			Input::mouse_mappings["-"] = {button_y, x + width - (int)update.size() - 7, 1, 2};
 			Input::mouse_mappings["+"] = {button_y, x + width - 5, 1, 2};
-
 			// Draw container engine name
 			if (Cpu::container_engine.has_value()) {
 				fmt::format_to(std::back_inserter(out), "{}{}{}{}{}", Mv::to(button_y, x + 28), title_left, Theme::c("title"), Cpu::container_engine.value(), title_right);

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -533,6 +533,7 @@ namespace Input {
 
 				if (not keep_going) {
 					Runner::run("proc", no_update, redraw);
+					Runner::run("cpu", no_update, redraw);
 					return;
 				}
 			}

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -498,6 +498,8 @@ namespace Input {
 						if (key == "C")	Proc::toggle_children = pid;
 						no_update = false;
 					}
+					else
+						keep_going = true;
 				}
 				else if (is_in(key, "t", kill_key) and (Config::getB("show_detailed") or Config::getI("selected_pid") > 0)) {
 					atomic_wait(Runner::active);


### PR DESCRIPTION
Fixes issue #1685 while applying the inactive theme when -/+ buttons are used for expanding or contracting trees. The latter can be removed if need be.