### PR TITLE
fix: apply --config file when config directory is unavailable

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -861,12 +861,19 @@ static auto configure_tty_mode(std::optional<bool> force_tty) {
 	Global::debug = cli.debug;
 
 	{
-		const auto config_dir = Config::get_config_dir();
+		//? A config file passed with --config must be honored even if the config directory
+		//? itself is missing/unwritable (e.g. unset or read-only XDG_CONFIG_HOME). In that case
+		//? suppress the config-dir warnings since the user explicitly provided a config file.
+		const bool have_cli_config = cli.config_file.has_value();
+		const auto config_dir = Config::get_config_dir(have_cli_config);
+
+		if (have_cli_config) {
+			Config::conf_file = cli.config_file.value();
+		}
+
 		if (config_dir.has_value()) {
 			Config::conf_dir = config_dir.value();
-			if (cli.config_file.has_value()) {
-				Config::conf_file = cli.config_file.value();
-			} else {
+			if (not have_cli_config) {
 				Config::conf_file = Config::conf_dir / "btop.conf";
 			}
 

--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -382,7 +382,7 @@ namespace Config {
 
 	// Returns a valid config dir or an empty optional
 	// The config dir might be read only, a warning is printed, but a path is returned anyway
-	[[nodiscard]] std::optional<fs::path> get_config_dir() noexcept {
+	[[nodiscard]] std::optional<fs::path> get_config_dir(bool quiet) noexcept {
 		fs::path config_dir;
 		{
 			std::error_code error;
@@ -396,7 +396,8 @@ namespace Config {
 					config_dir = fs::path(home) / ".config" / "btop";
 				}
 				if (error) {
-					fmt::print(stderr, "\033[0;31mWarning: \033[0m{} could not be accessed: {}\n", config_dir.string(), error.message());
+					if (not quiet)
+						fmt::print(stderr, "\033[0;31mWarning: \033[0m{} could not be accessed: {}\n", config_dir.string(), error.message());
 					config_dir = "";
 				}
 			}
@@ -414,28 +415,31 @@ namespace Config {
 						statvfs(config_dir.c_str(), &stats) == 0 and (stats.f_flag & ST_RDONLY) == 0) {
 						return config_dir;
 					} else {
-						fmt::print(stderr, "\033[0;31mWarning: \033[0m`{}` is not writable\n", fs::absolute(config_dir).string());
+						if (not quiet)
+							fmt::print(stderr, "\033[0;31mWarning: \033[0m`{}` is not writable\n", fs::absolute(config_dir).string());
 						// If the config is readable we can still use the provided config, but changes will not be persistent
 						if ((fs::status(config_dir, error).permissions() & fs::perms::owner_read) == fs::perms::owner_read) {
-							fmt::print(stderr, "\033[0;31mWarning: \033[0mLogging is disabled, config changes are not persistent\n");
+							if (not quiet)
+								fmt::print(stderr, "\033[0;31mWarning: \033[0mLogging is disabled, config changes are not persistent\n");
 							return config_dir;
 						}
 					}
-				} else {
+				} else if (not quiet) {
 					fmt::print(stderr, "\033[0;31mWarning: \033[0m`{}` is not a directory\n", fs::absolute(config_dir).string());
 				}
 			} else {
 				// Doesn't exist
 				if (fs::create_directories(config_dir, error)) {
 					return config_dir;
-				} else {
+				} else if (not quiet) {
 					fmt::print(stderr, "\033[0;31mWarning: \033[0m`{}` could not be created: {}\n", fs::absolute(config_dir).string(), error.message());
 				}
 			}
-		} else {
+		} else if (not quiet) {
 			fmt::print(stderr, "\033[0;31mWarning: \033[0mCould not determine config path: Make sure `$XDG_CONFIG_HOME` or `$HOME` is set\n");
 		}
-		fmt::print(stderr, "\033[0;31mWarning: \033[0mLogging is disabled, config changes are not persistent\n");
+		if (not quiet)
+			fmt::print(stderr, "\033[0;31mWarning: \033[0mLogging is disabled, config changes are not persistent\n");
 		return {};
 	}
 

--- a/src/btop_config.hpp
+++ b/src/btop_config.hpp
@@ -67,7 +67,10 @@ namespace Config {
 
 	constexpr int ONE_DAY_MILLIS = 1000 * 60 * 60 * 24;
 
-	[[nodiscard]] std::optional<std::filesystem::path> get_config_dir() noexcept;
+	//* Locate (and if needed create) the user config directory.
+	//* When <quiet> is true, warnings about a missing/unwritable config dir are suppressed
+	//* (used when a config file is explicitly passed on the command line).
+	[[nodiscard]] std::optional<std::filesystem::path> get_config_dir(bool quiet = false) noexcept;
 
 	//* Check if string only contains space separated valid names for boxes and set current_boxes
 	bool set_boxes(const string& boxes);


### PR DESCRIPTION
## Problem
Fixes #1714.

A config file passed with `--config` was only applied inside the
`if (config_dir.has_value())` branch in `btop_main`. When the config
directory can't be determined or created (unset/read-only `XDG_CONFIG_HOME`,
immutable systems like NixOS), `get_config_dir()` returns `nullopt`, so the
explicitly provided config file was silently ignored — and warnings were
printed even though the user supplied a valid config.

## Fix
- Set `Config::conf_file` from the `--config` argument unconditionally,
  independent of whether the config directory is available.
- Add a `quiet` parameter to `get_config_dir()` to suppress the
  config-dir warnings when a config file is explicitly passed on the
  command line (matches the "preferably with warnings silenced" request
  in the issue).

The `quiet` parameter defaults to `false`, so all existing behavior is
unchanged when no `--config` is given.

## Testing
- Builds clean (GCC), all unit tests pass (`ctest`).
- With a broken config dir + `--config`: config is now applied (verified
  in a PTY — `rounded_corners` from the passed file takes effect) and the
  config-dir warnings are suppressed.
- Without `--config`: warnings still shown as before; normal writable
  config dir still creates `~/.config/btop/{btop.conf,themes}`.

[description is AI generated]