### PR TITLE
freebsd: improving ram detection including ARC cache and fixing overflow bug

### DIFF
--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -599,34 +599,61 @@ namespace Mem {
 		auto &mem = current_mem;
 		static bool snapped = (getenv("BTOP_SNAPPED") != nullptr);
 
-		int mib[4];
-		u_int memActive, memWire, cachedMem, freeMem;
+		int mib[5];
+		u_int memActive = 0, memWire = 0, freeMem = 0;
+		uint64_t cachedBytes = 0;
 		size_t len;
 
+		// active
    		len = 4; sysctlnametomib("vm.stats.vm.v_active_count", mib, &len);
 		len = sizeof(memActive);
 		sysctl(mib, 4, &(memActive), &len, nullptr, 0);
-		memActive *= Shared::pageSize;
 
+		// wired
 		len = 4; sysctlnametomib("vm.stats.vm.v_wire_count", mib, &len);
 		len = sizeof(memWire);
 		sysctl(mib, 4, &(memWire), &len, nullptr, 0);
-		memWire *= Shared::pageSize;
 
-		mem.stats.at("used") = memWire + memActive;
-		mem.stats.at("available") = Shared::totalMem - memActive - memWire;
+		// cached
+		len = 2;
+		if (sysctlnametomib("vfs.bufspace", mib, &len) == 0) {
+			uint64_t bufSpace = 0;
+			len = sizeof(bufSpace);
+			if (sysctl(mib, 2, &bufSpace, &len, nullptr, 0) == 0) {
+				cachedBytes += bufSpace;
+			}
+		}
 
-		len = sizeof(cachedMem);
-   		len = 4; sysctlnametomib("vm.stats.vm.v_cache_count", mib, &len);
-   		sysctl(mib, 4, &(cachedMem), &len, nullptr, 0);
-   		cachedMem *= Shared::pageSize;
-   		mem.stats.at("cached") = cachedMem;
+		len = 5;
+		if (sysctlnametomib("kstat.zfs.misc.arcstats.size", mib, &len) == 0) {
+			uint64_t arcSize = 0;
+			len = sizeof(arcSize);
+			if (sysctl(mib, 5, &arcSize, &len, nullptr, 0) == 0) {
+				uint64_t arcMin = 0;
+				len = 5;
+				if (sysctlnametomib("kstat.zfs.misc.arcstats.c_min", mib, &len) == 0) {
+					len = sizeof(arcMin);
+					sysctl(mib, 5, &arcMin, &len, nullptr, 0);
+				}
+				cachedBytes += (arcSize > arcMin) ? (arcSize - arcMin) : 0;
+			}
+		}
 
-		len = sizeof(freeMem);
+		// free
    		len = 4; sysctlnametomib("vm.stats.vm.v_free_count", mib, &len);
+		len = sizeof(freeMem);
    		sysctl(mib, 4, &(freeMem), &len, nullptr, 0);
-   		freeMem *= Shared::pageSize;
-   		mem.stats.at("free") = freeMem;
+
+		uint64_t activeBytes = (uint64_t)memActive * Shared::pageSize;
+		uint64_t wireBytes   = (uint64_t)memWire   * Shared::pageSize;
+		uint64_t freeBytes   = (uint64_t)freeMem   * Shared::pageSize;
+		uint64_t rawUsed     = activeBytes + wireBytes;
+		uint64_t usedBytes   = (cachedBytes < rawUsed) ? rawUsed - cachedBytes : 0;
+
+		mem.stats.at("used") = usedBytes;
+		mem.stats.at("available") = Shared::totalMem - usedBytes;
+   		mem.stats.at("cached") = cachedBytes;
+   		mem.stats.at("free") = freeBytes;
 
 		if (show_swap) {
 			char buf[_POSIX2_LINE_MAX];


### PR DESCRIPTION
Hi everyone!

I initially noticed that cached memory wasn't displayed at all in FreeBSD. Tested in FreeBSD 15.1, 15.0, 14.3 and 13.5 in systems with both ZFS and UFS filesystems. 

**EDIT**: I wrote about the issues and my proposed solution [in my blog](https://crocidb.com/post/freebsd-ate-my-ram/).

This PR fixes:

## Disk cache is not being counted

That's because it's drawing information from `vm.stats.vm.v_cache_count`, but the kernel doesn't use cache pages since FreeBSD 12. It's still there for compatibility, but returns 0 all the time. 

My solution is using `vfs.bufspace`, which gets metadata buffer cache from the filesystem and the usage of the ARC cache. ARC is the caching system for ZFS, it completely bypasses the vfs buffers. The thing is that if you're running on ZFS, `vfs.bufspace` will be zero. If you're on UFS, ARC info will always be zero. But you could be running two drivers with different filesystems.

Another thing I change slightly how the _used_ memory is calculated. Following the behavior on Linux where it considers disk cache as available memory, so now I subtract the cache bytes from the used bytes, since cache is contained in `wired` pages. `htop` does it too.

In fact, I submitted a [similar PR](https://github.com/htop-dev/htop/pull/2033) to `htop` simplifying their cache view. After this PR, `btop` and `htop` still have different heuristic due to them considering `laundry` pages as used memory.

## Memory Values Overflow

During the tests I noticed some very weird behavior when usage would sometimes cycle to lower numbers after rising. It turns out that all the memory information was being processed in an `u_int`, which is 32bit precision. This caused overflows when values went above 4GiB, displaying a very low value instead. So I switched for `uint64_t`.

---

I made no usage of AI to generate code, although some AI is part of my research process to understand how FreeBSD manages their virtual memory.

Have a good day!
