### PR TITLE
[AI generated] feat: allow GPU boxes to target any GPU

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -187,7 +187,7 @@ void term_resize(bool force) {
 				else if (key.size() == 1 and isint(key)) {
 					auto intKey = stoi(key);
 				#ifdef GPU_SUPPORT
-					if ((intKey == 0 and Gpu::count >= 5) or (intKey >= 5 and intKey - 4 <= Gpu::count)) {
+					if ((intKey == 0 and Gpu::count >= 6) or (intKey >= 5 and intKey - 4 <= Gpu::count)) {
 				#else
 					if (intKey > 0 and intKey < 5) {
 				#endif
@@ -517,9 +517,10 @@ namespace Runner {
 				);
 
 				vector<unsigned int> gpu_panels = {};
-				for (auto& box : conf.boxes)
-					if (box.starts_with("gpu"))
-						gpu_panels.push_back(box.back()-'0');
+				for (auto& box : conf.boxes) {
+					if (const auto gpu_index = Config::gpu_box_index(box); gpu_index.has_value())
+						gpu_panels.push_back(static_cast<unsigned int>(*gpu_index));
+				}
 
 				vector<Gpu::gpu_info> gpus;
 				if (gpu_in_cpu_panel or not gpu_panels.empty()) {

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -142,11 +142,7 @@ void term_resize(bool force) {
 		if (force and refreshed) force = false;
 	}
 	else return;
-#ifdef GPU_SUPPORT
-	static const array<string, 10> all_boxes = {"gpu5", "cpu", "mem", "net", "proc", "gpu0", "gpu1", "gpu2", "gpu3", "gpu4"};
-#else
 	static const array<string, 5> all_boxes = {"", "cpu", "mem", "net", "proc"};
-#endif
 	Global::resized = true;
 	if (Runner::active) Runner::stop();
 	Term::refresh();
@@ -187,10 +183,16 @@ void term_resize(bool force) {
 				else if (key.size() == 1 and isint(key)) {
 					auto intKey = stoi(key);
 				#ifdef GPU_SUPPORT
-					if ((intKey == 0 and Gpu::count >= 6) or (intKey >= 5 and intKey - 4 <= Gpu::count)) {
-				#else
-					if (intKey > 0 and intKey < 5) {
+					if (const auto gpu_panel_slot = Config::gpu_panel_slot_from_key(intKey); gpu_panel_slot.has_value()) {
+						if (Config::gpu_panel_slot_active(*gpu_panel_slot) or std::cmp_less(*gpu_panel_slot, Gpu::count)) {
+							Config::current_preset.reset();
+							Config::toggle_gpu_box(*gpu_panel_slot);
+							boxes = Config::getS("shown_boxes");
+						}
+					}
+					else
 				#endif
+					if (intKey > 0 and intKey < 5) {
 						const auto& box = all_boxes.at(intKey);
 						Config::current_preset.reset();
 						Config::toggle_box(box);

--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -452,10 +452,15 @@ namespace Config {
 	vector<string> available_batteries = {"Auto"};
 
 	vector<string> current_boxes;
+#ifdef GPU_SUPPORT
+	vector<size_t> current_gpu_panel_slots;
+#endif
 	vector<string> preset_list = {"cpu:0:default,mem:0:default,net:0:default,proc:0:default"};
 	std::optional<int> current_preset;
 
 #ifdef GPU_SUPPORT
+	static constexpr array<int, max_gpu_panels> gpu_panel_keys = {5, 6, 7, 8, 9, 0};
+
 	std::optional<size_t> gpu_box_index(std::string_view box) {
 		if (not box.starts_with("gpu") or box.size() <= 3) return {};
 
@@ -474,11 +479,77 @@ namespace Config {
 		return "gpu" + to_string(gpu_index);
 	}
 
+	std::optional<size_t> gpu_panel_slot_from_key(int key) {
+		for (size_t slot = 0; slot < gpu_panel_keys.size(); ++slot) {
+			if (gpu_panel_keys[slot] == key) return slot;
+		}
+		return {};
+	}
+
+	int gpu_panel_key(size_t panel_slot) {
+		return gpu_panel_keys.at(panel_slot);
+	}
+
+	std::optional<size_t> gpu_panel_slot(size_t panel_index) {
+		if (panel_index >= current_gpu_panel_slots.size()) return {};
+		return current_gpu_panel_slots[panel_index];
+	}
+
+	bool gpu_panel_slot_active(size_t panel_slot) {
+		return v_contains(current_gpu_panel_slots, panel_slot);
+	}
+
 	bool valid_box_name(const string& box, bool check_gpu_count = true) {
 		if (v_contains(valid_boxes, box)) return true;
 
 		const auto gpu_index = gpu_box_index(box);
 		return gpu_index.has_value() and (not check_gpu_count or std::cmp_less(*gpu_index, Gpu::count));
+	}
+
+	static void normalize_gpu_panel_order() {
+		vector<size_t> gpu_positions;
+		vector<string> gpu_boxes;
+		for (size_t i = 0; i < current_boxes.size(); ++i) {
+			if (gpu_box_index(current_boxes[i]).has_value()) {
+				gpu_positions.push_back(i);
+				gpu_boxes.push_back(current_boxes[i]);
+			}
+		}
+
+		auto slots_valid = [&]() {
+			if (current_gpu_panel_slots.size() != gpu_boxes.size()) return false;
+			vector<bool> used_slots(max_gpu_panels, false);
+			for (const size_t slot : current_gpu_panel_slots) {
+				if (slot >= max_gpu_panels or used_slots[slot]) return false;
+				used_slots[slot] = true;
+			}
+			return true;
+		};
+
+		if (not slots_valid()) {
+			current_gpu_panel_slots.clear();
+			for (size_t slot = 0; slot < gpu_boxes.size(); ++slot) {
+				current_gpu_panel_slots.push_back(slot);
+			}
+		}
+
+		vector<string> sorted_boxes;
+		vector<size_t> sorted_slots;
+		sorted_boxes.reserve(gpu_boxes.size());
+		sorted_slots.reserve(current_gpu_panel_slots.size());
+		for (size_t slot = 0; slot < max_gpu_panels; ++slot) {
+			for (size_t i = 0; i < current_gpu_panel_slots.size(); ++i) {
+				if (current_gpu_panel_slots[i] == slot) {
+					sorted_boxes.push_back(gpu_boxes[i]);
+					sorted_slots.push_back(slot);
+				}
+			}
+		}
+
+		for (size_t i = 0; i < gpu_positions.size(); ++i) {
+			current_boxes[gpu_positions[i]] = sorted_boxes[i];
+		}
+		current_gpu_panel_slots = std::move(sorted_slots);
 	}
 #else
 	bool valid_box_name(const string& box, bool check_gpu_count = true) {
@@ -759,23 +830,96 @@ namespace Config {
 			if (gpu_box_index(box).has_value() and ++gpu_panels > max_gpu_panels) {
 				return false;
 			}
-		#endif
+	#endif
 		}
 		current_boxes = std::move(new_boxes);
+	#ifdef GPU_SUPPORT
+		current_gpu_panel_slots.clear();
+		normalize_gpu_panel_order();
+	#endif
 		return true;
 	}
 
 #ifdef GPU_SUPPORT
-	bool switch_gpu_box(size_t panel_slot, int direction) {
+	static bool apply_current_boxes(const vector<string>& old_boxes, const vector<size_t>& old_slots) {
+		normalize_gpu_panel_order();
+
+		string new_boxes;
+		if (not current_boxes.empty()) {
+			for (const auto& b : current_boxes) new_boxes += b + ' ';
+			new_boxes.pop_back();
+		}
+
+		auto min_size = Term::get_min_size(new_boxes);
+		if (Term::width < min_size.at(0) or Term::height < min_size.at(1)) {
+			current_boxes = old_boxes;
+			current_gpu_panel_slots = old_slots;
+			return false;
+		}
+
+		Config::set("shown_boxes", new_boxes);
+		return true;
+	}
+
+	bool toggle_gpu_box(size_t panel_slot) {
+		if (panel_slot >= max_gpu_panels) return false;
+
+		auto old_boxes = current_boxes;
+		auto old_slots = current_gpu_panel_slots;
+		const auto slot_it = rng::find(current_gpu_panel_slots, panel_slot);
+		if (slot_it != current_gpu_panel_slots.end()) {
+			const size_t gpu_panel_index = static_cast<size_t>(rng::distance(current_gpu_panel_slots.begin(), slot_it));
+			size_t current_gpu_panel = 0;
+			for (auto box_it = current_boxes.begin(); box_it != current_boxes.end(); ++box_it) {
+				if (gpu_box_index(*box_it).has_value()) {
+					if (current_gpu_panel == gpu_panel_index) {
+						current_boxes.erase(box_it);
+						current_gpu_panel_slots.erase(slot_it);
+						return apply_current_boxes(old_boxes, old_slots);
+					}
+					++current_gpu_panel;
+				}
+			}
+			current_boxes = old_boxes;
+			current_gpu_panel_slots = old_slots;
+			return false;
+		}
+
+		if (std::cmp_greater_equal(panel_slot, Gpu::count)) return false;
+		if (current_gpu_panel_slots.size() >= max_gpu_panels) return false;
+
+		vector<bool> occupied(static_cast<size_t>(Gpu::count), false);
+		for (const auto& box : current_boxes) {
+			const auto gpu_index = gpu_box_index(box);
+			if (gpu_index.has_value()) {
+				if (*gpu_index < occupied.size()) occupied[*gpu_index] = true;
+			}
+		}
+
+		for (size_t step = 0; step < static_cast<size_t>(Gpu::count); ++step) {
+			const size_t gpu_index = (panel_slot + step) % static_cast<size_t>(Gpu::count);
+			if (not occupied[gpu_index]) {
+				current_boxes.push_back(gpu_box_name(gpu_index));
+				current_gpu_panel_slots.push_back(panel_slot);
+				return apply_current_boxes(old_boxes, old_slots);
+			}
+		}
+
+		current_boxes = old_boxes;
+		current_gpu_panel_slots = old_slots;
+		return false;
+	}
+
+	bool switch_gpu_box(size_t panel_index, int direction) {
 		if (Gpu::count <= 1) return false;
 
 		vector<size_t> gpu_positions;
 		for (size_t i = 0; i < current_boxes.size(); ++i) {
 			if (gpu_box_index(current_boxes[i]).has_value()) gpu_positions.push_back(i);
 		}
-		if (panel_slot >= gpu_positions.size()) return false;
+		if (panel_index >= gpu_positions.size()) return false;
 
-		const size_t box_pos = gpu_positions[panel_slot];
+		const size_t box_pos = gpu_positions[panel_index];
 		auto current_gpu = gpu_box_index(current_boxes[box_pos]);
 		if (not current_gpu.has_value()) return false;
 		const size_t original_gpu = *current_gpu;
@@ -792,20 +936,9 @@ namespace Config {
 			current_gpu = next_gpu;
 			if (next_gpu != original_gpu and not occupied[next_gpu]) {
 				auto old_boxes = current_boxes;
+				auto old_slots = current_gpu_panel_slots;
 				current_boxes[box_pos] = gpu_box_name(next_gpu);
-
-				string new_boxes;
-				for (const auto& box : current_boxes) new_boxes += box + ' ';
-				if (not new_boxes.empty()) new_boxes.pop_back();
-
-				auto min_size = Term::get_min_size(new_boxes);
-				if (Term::width < min_size.at(0) or Term::height < min_size.at(1)) {
-					current_boxes = std::move(old_boxes);
-					return false;
-				}
-
-				Config::set("shown_boxes", new_boxes);
-				return true;
+				return apply_current_boxes(old_boxes, old_slots);
 			}
 		}
 
@@ -815,6 +948,9 @@ namespace Config {
 
 	bool toggle_box(const string& box) {
 		auto old_boxes = current_boxes;
+	#ifdef GPU_SUPPORT
+		auto old_slots = current_gpu_panel_slots;
+	#endif
 		auto box_pos = rng::find(current_boxes, box);
 		if (box_pos == current_boxes.end())
 			current_boxes.push_back(box);
@@ -826,11 +962,15 @@ namespace Config {
 		for (const auto& current_box : current_boxes) {
 			if (gpu_box_index(current_box).has_value() and ++gpu_panels > max_gpu_panels) {
 				current_boxes = old_boxes;
+				current_gpu_panel_slots = old_slots;
 				return false;
 			}
 		}
 	#endif
 
+	#ifdef GPU_SUPPORT
+		return apply_current_boxes(old_boxes, old_slots);
+	#else
 		string new_boxes;
 		if (not current_boxes.empty()) {
 			for (const auto& b : current_boxes) new_boxes += b + ' ';
@@ -846,6 +986,7 @@ namespace Config {
 
 		Config::set("shown_boxes", new_boxes);
 		return true;
+	#endif
 	}
 
 	void load(const fs::path& conf_file, vector<string>& load_warnings) {

--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -100,7 +100,7 @@ namespace Config {
 
 		{"graph_symbol_proc", 	"# Graph symbol to use for graphs in cpu box, \"default\", \"braille\", \"block\" or \"tty\"."},
 
-		{"shown_boxes", 		"#* Manually set which boxes to show. Available values are \"cpu mem net proc\" and \"gpu0\" through \"gpu5\", separate values with whitespace."},
+		{"shown_boxes", 		"#* Manually set which boxes to show. Available values are \"cpu mem net proc\" and \"gpuN\" for GPU index N, separate values with whitespace. Up to 6 GPU boxes can be shown at once."},
 
 		{"update_ms", 			"#* Update time in milliseconds, recommended 2000 ms or above for better sample times for graphs."},
 
@@ -455,16 +455,55 @@ namespace Config {
 	vector<string> preset_list = {"cpu:0:default,mem:0:default,net:0:default,proc:0:default"};
 	std::optional<int> current_preset;
 
+#ifdef GPU_SUPPORT
+	std::optional<size_t> gpu_box_index(std::string_view box) {
+		if (not box.starts_with("gpu") or box.size() <= 3) return {};
+
+		const auto index = box.substr(3);
+		if (not isint(index)) return {};
+
+		try {
+			return stoul(string{index});
+		}
+		catch (...) {
+			return {};
+		}
+	}
+
+	string gpu_box_name(size_t gpu_index) {
+		return "gpu" + to_string(gpu_index);
+	}
+
+	bool valid_box_name(const string& box, bool check_gpu_count = true) {
+		if (v_contains(valid_boxes, box)) return true;
+
+		const auto gpu_index = gpu_box_index(box);
+		return gpu_index.has_value() and (not check_gpu_count or std::cmp_less(*gpu_index, Gpu::count));
+	}
+#else
+	bool valid_box_name(const string& box, bool check_gpu_count = true) {
+		(void)check_gpu_count;
+		return v_contains(valid_boxes, box);
+	}
+#endif
+
 	bool presetsValid(const string& presets) {
 		vector<string> new_presets = {preset_list.at(0)};
+		int max_preset_boxes = static_cast<int>(valid_boxes.size());
+	#ifdef GPU_SUPPORT
+		max_preset_boxes += static_cast<int>(max_gpu_panels);
+	#endif
 
 		for (int x = 0; const auto& preset : ssplit(presets)) {
 			if (++x > 9) {
 				validError = "Too many presets entered!";
 				return false;
 			}
+		#ifdef GPU_SUPPORT
+			size_t gpu_panels = 0;
+		#endif
 			for (int y = 0; const auto& box : ssplit(preset, ',')) {
-				if (++y > 4) {
+				if (++y > max_preset_boxes) {
 					validError = "Too many boxes entered for preset!";
 					return false;
 				}
@@ -473,10 +512,16 @@ namespace Config {
 					validError = "Malformatted preset in config value presets!";
 					return false;
 				}
-				if (not is_in(vals.at(0), "cpu", "mem", "net", "proc", "gpu0", "gpu1", "gpu2", "gpu3", "gpu4", "gpu5")) {
+				if (not valid_box_name(vals.at(0), false)) {
 					validError = "Invalid box name in config value presets!";
 					return false;
 				}
+			#ifdef GPU_SUPPORT
+				if (gpu_box_index(vals.at(0)).has_value() and ++gpu_panels > max_gpu_panels) {
+					validError = "Too many GPU boxes entered for preset!";
+					return false;
+				}
+			#endif
 				if (not is_in(vals.at(1), "0", "1")) {
 					validError = "Invalid position value in config value presets!";
 					return false;
@@ -705,18 +750,68 @@ namespace Config {
 
 	bool set_boxes(const string& boxes) {
 		auto new_boxes = ssplit(boxes);
+	#ifdef GPU_SUPPORT
+		size_t gpu_panels = 0;
+	#endif
 		for (auto& box : new_boxes) {
-			if (not v_contains(valid_boxes, box)) return false;
+			if (not valid_box_name(box)) return false;
 		#ifdef GPU_SUPPORT
-			if (box.starts_with("gpu")) {
-				int gpu_num = stoi(box.substr(3)) + 1;
-				if (gpu_num > Gpu::count) return false;
+			if (gpu_box_index(box).has_value() and ++gpu_panels > max_gpu_panels) {
+				return false;
 			}
 		#endif
 		}
 		current_boxes = std::move(new_boxes);
 		return true;
 	}
+
+#ifdef GPU_SUPPORT
+	bool switch_gpu_box(size_t panel_slot, int direction) {
+		if (Gpu::count <= 1) return false;
+
+		vector<size_t> gpu_positions;
+		for (size_t i = 0; i < current_boxes.size(); ++i) {
+			if (gpu_box_index(current_boxes[i]).has_value()) gpu_positions.push_back(i);
+		}
+		if (panel_slot >= gpu_positions.size()) return false;
+
+		const size_t box_pos = gpu_positions[panel_slot];
+		auto current_gpu = gpu_box_index(current_boxes[box_pos]);
+		if (not current_gpu.has_value()) return false;
+		const size_t original_gpu = *current_gpu;
+
+		vector<bool> occupied(static_cast<size_t>(Gpu::count), false);
+		for (size_t i = 0; i < current_boxes.size(); ++i) {
+			if (i == box_pos) continue;
+			const auto gpu_index = gpu_box_index(current_boxes[i]);
+			if (gpu_index.has_value() and *gpu_index < occupied.size()) occupied[*gpu_index] = true;
+		}
+
+		for (int step = 0; step < Gpu::count; ++step) {
+			const size_t next_gpu = (static_cast<int>(*current_gpu) + direction + Gpu::count) % Gpu::count;
+			current_gpu = next_gpu;
+			if (next_gpu != original_gpu and not occupied[next_gpu]) {
+				auto old_boxes = current_boxes;
+				current_boxes[box_pos] = gpu_box_name(next_gpu);
+
+				string new_boxes;
+				for (const auto& box : current_boxes) new_boxes += box + ' ';
+				if (not new_boxes.empty()) new_boxes.pop_back();
+
+				auto min_size = Term::get_min_size(new_boxes);
+				if (Term::width < min_size.at(0) or Term::height < min_size.at(1)) {
+					current_boxes = std::move(old_boxes);
+					return false;
+				}
+
+				Config::set("shown_boxes", new_boxes);
+				return true;
+			}
+		}
+
+		return false;
+	}
+#endif
 
 	bool toggle_box(const string& box) {
 		auto old_boxes = current_boxes;
@@ -725,6 +820,16 @@ namespace Config {
 			current_boxes.push_back(box);
 		else
 			current_boxes.erase(box_pos);
+
+	#ifdef GPU_SUPPORT
+		size_t gpu_panels = 0;
+		for (const auto& current_box : current_boxes) {
+			if (gpu_box_index(current_box).has_value() and ++gpu_panels > max_gpu_panels) {
+				current_boxes = old_boxes;
+				return false;
+			}
+		}
+	#endif
 
 		string new_boxes;
 		if (not current_boxes.empty()) {

--- a/src/btop_config.hpp
+++ b/src/btop_config.hpp
@@ -56,6 +56,9 @@ namespace Config {
 #endif
     const vector<string> base_10_bitrate_values = { "Auto", "True", "False" };
 	extern vector<string> current_boxes;
+#ifdef GPU_SUPPORT
+	extern vector<size_t> current_gpu_panel_slots;
+#endif
 	extern vector<string> preset_list;
 	const vector<string> disable_preset_options = { "Off", "Default", "Custom", "All" };
 	extern vector<string> available_batteries;
@@ -76,7 +79,12 @@ namespace Config {
 	//* Parse gpuN box names and switch an existing GPU panel to another GPU
 	std::optional<size_t> gpu_box_index(std::string_view box);
 	string gpu_box_name(size_t gpu_index);
-	bool switch_gpu_box(size_t panel_slot, int direction);
+	std::optional<size_t> gpu_panel_slot_from_key(int key);
+	int gpu_panel_key(size_t panel_slot);
+	std::optional<size_t> gpu_panel_slot(size_t panel_index);
+	bool gpu_panel_slot_active(size_t panel_slot);
+	bool toggle_gpu_box(size_t panel_slot);
+	bool switch_gpu_box(size_t panel_index, int direction);
 #endif
 
 	//* Toggle box and update config string shown_boxes

--- a/src/btop_config.hpp
+++ b/src/btop_config.hpp
@@ -18,9 +18,11 @@ tab-size = 4
 
 #pragma once
 
+#include <cstddef>
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <unordered_map>
@@ -43,18 +45,14 @@ namespace Config {
 
 	const vector<string> valid_graph_symbols = { "braille", "block", "tty" };
 	const vector<string> valid_graph_symbols_def = { "default", "braille", "block", "tty" };
-	const vector<string> valid_boxes = {
-		"cpu", "mem", "net", "proc"
-#ifdef GPU_SUPPORT
-		,"gpu0", "gpu1", "gpu2", "gpu3", "gpu4", "gpu5"
-#endif
-		};
+	const vector<string> valid_boxes = {"cpu", "mem", "net", "proc"};
 	const vector<string> temp_scales = { "celsius", "fahrenheit", "kelvin", "rankine" };
 #ifdef __linux__
 	const vector<string> freq_modes = { "first", "range", "lowest", "highest", "average" };
 #endif
 #ifdef GPU_SUPPORT
 	const vector<string> show_gpu_values = { "Auto", "On", "Off" };
+	constexpr size_t max_gpu_panels = 6;
 #endif
     const vector<string> base_10_bitrate_values = { "Auto", "True", "False" };
 	extern vector<string> current_boxes;
@@ -73,6 +71,13 @@ namespace Config {
 	bool set_boxes(const string& boxes);
 
 	bool validBoxSizes(const string& boxes);
+
+#ifdef GPU_SUPPORT
+	//* Parse gpuN box names and switch an existing GPU panel to another GPU
+	std::optional<size_t> gpu_box_index(std::string_view box);
+	string gpu_box_name(size_t gpu_index);
+	bool switch_gpu_box(size_t panel_slot, int direction);
+#endif
 
 	//* Toggle box and update config string shown_boxes
 	bool toggle_box(const string& box);

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -2384,7 +2384,11 @@ namespace Draw {
 				height += (height+Cpu::height == Term::height-1);
 				height = max(height, b_height_vec[i] + 2);
 				x_vec[i] = 1; y_vec[i] = 1 + total_height + (not Config::getB("cpu_bottom"))*Cpu::shown*Cpu::height;
-				box[i] = createBox(x_vec[i], y_vec[i], width, height, Theme::c("cpu_box"), true, "gpu", "", (i + 5) % 10);
+				int panel_key = Config::gpu_panel_key(i);
+				if (const auto slot = Config::gpu_panel_slot(i); slot.has_value()) {
+					panel_key = Config::gpu_panel_key(*slot);
+				}
+				box[i] = createBox(x_vec[i], y_vec[i], width, height, Theme::c("cpu_box"), true, "gpu", "", panel_key);
 				const string gpu_selector = Config::gpu_box_name(shown_panels[i]);
 				const int gpu_selector_label_width = static_cast<int>(ulen(gpu_selector));
 				const int gpu_selector_width = 6 + gpu_selector_label_width;

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -557,6 +557,15 @@ namespace Cpu {
 		const bool gpu_always = show_gpu_info == "On";
 		const bool gpu_auto = show_gpu_info == "Auto";
 		const bool show_gpu = (gpus.size() > 0 and (gpu_always or (gpu_auto and Gpu::shown < Gpu::count)));
+		auto gpu_hidden = [&](size_t gpu_index) {
+			return gpu_auto and v_contains(Gpu::shown_panels, gpu_index);
+		};
+		auto gpu_draw_count = [&]() {
+			int count = 0;
+			for (size_t i = 0; i < gpus.size(); ++i)
+				if (not gpu_hidden(i)) ++count;
+			return count;
+		};
 #endif // GPU_SUPPORT
 		auto graph_up_field = Config::getS("cpu_graph_upper");
 		if (graph_up_field == "Auto" or not v_contains(Cpu::available_fields, graph_up_field))
@@ -622,27 +631,22 @@ namespace Cpu {
 						gpu_temp_graphs.resize(gpus.size());
 						gpu_mem_graphs.resize(gpus.size());
 						gpu_meters.resize(gpus.size());
-						const int gpu_draw_count = gpu_always ? Gpu::count : Gpu::count - Gpu::shown;
-                                                // Fairly distribute graph_default_width across gpu_draw_count GPUs, leaving 1 col per separator.
-                                                // Clamp to >=1 to avoid degenerate/negative widths reaching Draw::Graph::_create (#1118, #1017).
-                                                const int gpu_drawable_width = graph_default_width - max(0, gpu_draw_count - 1);
-                                                graph_width = gpu_draw_count <= 0 ? graph_default_width : max(1, gpu_drawable_width / gpu_draw_count);
+						const int draw_count = gpu_draw_count();
+						// Fairly distribute graph_default_width across drawn GPUs, leaving 1 col per separator.
+						// Clamp to >=1 to avoid degenerate/negative widths reaching Draw::Graph::_create (#1118, #1017).
+						const int gpu_drawable_width = graph_default_width - max(0, draw_count - 1);
+						graph_width = draw_count <= 0 ? graph_default_width : max(1, gpu_drawable_width / draw_count);
+						int gpu_drawn = 0;
 						for (size_t i = 0; i < gpus.size(); i++) {
-							if (gpu_auto and v_contains(Gpu::shown_panels, i))
+							if (gpu_hidden(i))
 								continue;
 							auto& gpu = gpus[i]; auto& graph = graphs[i];
+							const bool last_gpu = (++gpu_drawn == draw_count);
+							const int gpu_graph_width = max(1, graph_width + (last_gpu and draw_count > 0 ? gpu_drawable_width % draw_count : 0));
 
 							//? GPU graphs
 							if (gpu.supported_functions.gpu_utilization) {
-								if (i + 1 < gpus.size()) {
-									graph = Draw::Graph{graph_width, graph_height, "cpu", safeVal(gpu.gpu_percent, graph_field), graph_symbol, invert, true};
-								}
-								else {
-									graph = Draw::Graph{
-                                                                                max(1, graph_width + (gpu_draw_count > 0 ? gpu_drawable_width % gpu_draw_count : 0)),
-										graph_height, "cpu", safeVal(gpu.gpu_percent, graph_field), graph_symbol, invert, true
-									};
-								}
+								graph = Draw::Graph{gpu_graph_width, graph_height, "cpu", safeVal(gpu.gpu_percent, graph_field), graph_symbol, invert, true};
 							}
 						}
 					} else {
@@ -661,9 +665,9 @@ namespace Cpu {
 			#endif
 			};
 
-            init_graphs(graphs_upper, graph_up_height, graph_up_width, graph_up_field, false);
-            if (not single_graph)
-            	init_graphs(graphs_lower, graph_low_height, graph_low_width, graph_lo_field, Config::getB("cpu_invert_lower"));
+			init_graphs(graphs_upper, graph_up_height, graph_up_width, graph_up_field, false);
+			if (not single_graph)
+				init_graphs(graphs_lower, graph_low_height, graph_low_width, graph_lo_field, Config::getB("cpu_invert_lower"));
 
 			#ifdef GPU_SUPPORT
 			if (show_gpu and b_columns > 1) {
@@ -782,8 +786,9 @@ namespace Cpu {
 				if (graph_field.starts_with("gpu"))
 					if (graph_field.ends_with("totals")) {
 						int gpu_drawn = 0;
+						const int draw_count = gpu_draw_count();
 						for (size_t i = 0; i < gpus.size(); i++) {
-							if (gpu_auto and v_contains(Gpu::shown_panels, i)) {
+							if (gpu_hidden(i)) {
 								continue;
 							}
 							try {
@@ -792,13 +797,13 @@ namespace Cpu {
 							} catch (std::out_of_range& /* unused */) {
 								continue;
 							}
-							if (Gpu::count - (gpu_auto ? Gpu::shown : 0) > 1) {
+							if (draw_count > 1) {
 								auto i_str = to_string(i);
 								out += Mv::l(max(0, graph_width-1)) + Mv::u(graph_height/2) + (graph_width > 5 ? "GPU" : "") + i_str
 									+ Mv::d(graph_height/2) + Mv::r(max(0, (int)(graph_width - 1 - (graph_width > 5)*3 - i_str.size())));
 							}
 
-							if (++gpu_drawn < Gpu::count - (gpu_auto ? Gpu::shown : 0))
+							if (++gpu_drawn < draw_count)
 								out += Theme::c("div_line") + (Symbols::v_line + Mv::l(1) + Mv::u(1))*graph_height + Mv::r(1) + Mv::d(1);
 						}
 					}
@@ -2254,8 +2259,8 @@ namespace Draw {
 			std::istringstream iss(boxes, std::istringstream::in);
 			string current;
 			while (iss >> current) {
-				if (current.starts_with("gpu"))
-					Gpu::shown_panels.push_back(current.back()-'0');
+				if (const auto gpu_index = Config::gpu_box_index(current); gpu_index.has_value())
+					Gpu::shown_panels.push_back(static_cast<int>(*gpu_index));
 			}
 		}
 		Gpu::shown = Gpu::shown_panels.size();
@@ -2379,7 +2384,18 @@ namespace Draw {
 				height += (height+Cpu::height == Term::height-1);
 				height = max(height, b_height_vec[i] + 2);
 				x_vec[i] = 1; y_vec[i] = 1 + total_height + (not Config::getB("cpu_bottom"))*Cpu::shown*Cpu::height;
-				box[i] = createBox(x_vec[i], y_vec[i], width, height, Theme::c("cpu_box"), true, std::string("gpu") + (char)(shown_panels[i]+'0'), "", (shown_panels[i]+5)%10); // TODO gpu_box
+				box[i] = createBox(x_vec[i], y_vec[i], width, height, Theme::c("cpu_box"), true, "gpu", "", (i + 5) % 10);
+				const string gpu_selector = Config::gpu_box_name(shown_panels[i]);
+				const int gpu_selector_label_width = static_cast<int>(ulen(gpu_selector));
+				const int gpu_selector_width = 6 + gpu_selector_label_width;
+				if (Gpu::count > 1 and width > gpu_selector_width + 10) {
+					const int gpu_selector_x = x_vec[i] + width - gpu_selector_width - 2;
+					box[i] += Mv::to(y_vec[i], gpu_selector_x) + Theme::c("cpu_box") + Symbols::title_left + Fx::b
+						+ Theme::c("title") + Symbols::left + " " + gpu_selector + " " + Symbols::right + Fx::ub
+						+ Theme::c("cpu_box") + Symbols::title_right;
+					Input::mouse_mappings["gpu_prev_" + to_string(i)] = {y_vec[i], gpu_selector_x + 1, 1, 1};
+					Input::mouse_mappings["gpu_next_" + to_string(i)] = {y_vec[i], gpu_selector_x + gpu_selector_label_width + 4, 1, 1};
+				}
 				b_width = clamp(width/2, min_width, 65);
 				total_height += height;
 
@@ -2387,7 +2403,9 @@ namespace Draw {
 				b_x_vec[i] = x_vec[i] + width - b_width - 1;
 				b_y_vec[i] = y_vec[i] + ceil((double)(height - 2 - b_height_vec[i]) / 2) + 1;
 
-				string name = Config::getS(std::string("custom_gpu_name") + (char)(shown_panels[i]+'0'));
+				const string custom_name_key = "custom_gpu_name" + to_string(shown_panels[i]);
+				const std::string_view custom_name_key_view{custom_name_key};
+				string name = Config::strings.contains(custom_name_key_view) ? Config::getS(custom_name_key_view) : "";
 				if (name.empty()) name = gpu_names[shown_panels[i]];
 
 				box[i] += createBox(b_x_vec[i], b_y_vec[i], b_width, b_height_vec[i], "", false, name.substr(0, b_width-5));

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -241,9 +241,9 @@ namespace Input {
 					const bool next = key.starts_with("gpu_next_");
 					const auto prefix_len = next ? std::string_view{"gpu_next_"}.size() : std::string_view{"gpu_prev_"}.size();
 					try {
-						const auto panel_slot = stoul(string{key.substr(prefix_len)});
+						const auto panel_index = stoul(string{key.substr(prefix_len)});
 						atomic_wait(Runner::active);
-						if (Config::switch_gpu_box(panel_slot, next ? 1 : -1)) {
+						if (Config::switch_gpu_box(panel_index, next ? 1 : -1)) {
 							Config::current_preset.reset();
 							Draw::calcSizes();
 							Draw::update_clock(true);
@@ -257,8 +257,23 @@ namespace Input {
 				else if (key.size() == 1 and isint(key)) {
 					auto intKey = std::atoi(key.data());
 				#ifdef GPU_SUPPORT
-					static const array<string, 10> boxes = {"gpu5", "cpu", "mem", "net", "proc", "gpu0", "gpu1", "gpu2", "gpu3", "gpu4"};
-					if ((intKey == 0 and Gpu::count < 6) or (intKey >= 5 and intKey - 4 > Gpu::count))
+					static const array<string, 5> boxes = {"", "cpu", "mem", "net", "proc"};
+					if (const auto gpu_panel_slot = Config::gpu_panel_slot_from_key(intKey); gpu_panel_slot.has_value()) {
+						if (not Config::gpu_panel_slot_active(*gpu_panel_slot) and std::cmp_greater_equal(*gpu_panel_slot, Gpu::count))
+							return;
+
+						atomic_wait(Runner::active);
+						if (not Config::toggle_gpu_box(*gpu_panel_slot)) {
+							Menu::show(Menu::Menus::SizeError);
+							return;
+						}
+						Config::current_preset.reset();
+						Draw::calcSizes();
+						Draw::update_clock(true);
+						Runner::run("all", false, true);
+						return;
+					}
+					if (intKey > 4)
 						return;
 				#else
 				static const array<string, 10> boxes = {"", "cpu", "mem", "net", "proc"};

--- a/src/btop_input.cpp
+++ b/src/btop_input.cpp
@@ -236,11 +236,29 @@ namespace Input {
 					Menu::show(Menu::Menus::Options);
 					return;
 				}
+			#ifdef GPU_SUPPORT
+				else if (key.starts_with("gpu_prev_") or key.starts_with("gpu_next_")) {
+					const bool next = key.starts_with("gpu_next_");
+					const auto prefix_len = next ? std::string_view{"gpu_next_"}.size() : std::string_view{"gpu_prev_"}.size();
+					try {
+						const auto panel_slot = stoul(string{key.substr(prefix_len)});
+						atomic_wait(Runner::active);
+						if (Config::switch_gpu_box(panel_slot, next ? 1 : -1)) {
+							Config::current_preset.reset();
+							Draw::calcSizes();
+							Draw::update_clock(true);
+							Runner::run("all", false, true);
+						}
+					}
+					catch (...) {}
+					return;
+				}
+			#endif
 				else if (key.size() == 1 and isint(key)) {
 					auto intKey = std::atoi(key.data());
 				#ifdef GPU_SUPPORT
 					static const array<string, 10> boxes = {"gpu5", "cpu", "mem", "net", "proc", "gpu0", "gpu1", "gpu2", "gpu3", "gpu4"};
-					if ((intKey == 0 and Gpu::count < 5) or (intKey >= 5 and intKey - 4 > Gpu::count))
+					if ((intKey == 0 and Gpu::count < 6) or (intKey >= 5 and intKey - 4 > Gpu::count))
 						return;
 				#else
 				static const array<string, 10> boxes = {"", "cpu", "mem", "net", "proc"};

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -298,7 +298,8 @@ namespace Menu {
 				"",
 				"Available values are \"cpu mem net proc\".",
 			#ifdef GPU_SUPPORT
-				"Or \"gpu0\" through \"gpu5\" for GPU boxes.",
+				"Or \"gpuN\" for GPU index N.",
+				"Up to 6 GPU boxes can be shown at once.",
 			#endif
 				"Separate values with whitespace.",
 				"",

--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -122,10 +122,17 @@ namespace Term {
         bool net = boxes.find("net") != string::npos;
         bool proc = boxes.find("proc") != string::npos;
 	#ifdef GPU_SUPPORT
-		int gpu = 0;
-        if (Gpu::count > 0)
-        	for (char i = '0'; i <= '5'; i++)
-        		gpu += (boxes.contains("gpu"s + i) ? 1 : 0);
+		vector<int> gpu_panels;
+        if (Gpu::count > 0) {
+			std::istringstream iss(boxes, std::istringstream::in);
+			string current;
+			while (iss >> current) {
+				if (const auto gpu_index = Config::gpu_box_index(current); gpu_index.has_value()) {
+					if (std::cmp_less(*gpu_index, Gpu::count))
+						gpu_panels.push_back(static_cast<int>(*gpu_index));
+				}
+			}
+		}
 	#endif
         int width = 0;
 		if (mem) width = Mem::min_width;
@@ -133,15 +140,18 @@ namespace Term {
 		width += (proc ? Proc::min_width : 0);
 		if (cpu and width < Cpu::min_width) width = Cpu::min_width;
 	#ifdef GPU_SUPPORT
-		if (gpu != 0 and width < Gpu::min_width) width = Gpu::min_width;
+		if (not gpu_panels.empty() and width < Gpu::min_width) width = Gpu::min_width;
 	#endif
 
 		int height = (cpu ? Cpu::min_height : 0);
 		if (proc) height += Proc::min_height;
 		else height += (mem ? Mem::min_height : 0) + (net ? Net::min_height : 0);
 	#ifdef GPU_SUPPORT
-		for (int i = 0; i < gpu; i++)
-			height += Gpu::gpu_b_height_offsets[i] + 4;
+		for (const int gpu_index : gpu_panels) {
+			height += std::cmp_less(gpu_index, Gpu::gpu_b_height_offsets.size())
+				? Gpu::gpu_b_height_offsets[gpu_index] + 4
+				: Gpu::min_height;
+		}
 	#endif
 
 		return { width, height };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(libbtop_test)
 target_include_directories(libbtop_test PUBLIC ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries(libbtop_test libbtop GTest::gtest_main)
 
-add_executable(btop_test cpu_names.cpp tools.cpp)
+add_executable(btop_test cpu_names.cpp gpu_boxes.cpp tools.cpp)
 target_link_libraries(btop_test libbtop_test)
 
 include(GoogleTest)

--- a/tests/gpu_boxes.cpp
+++ b/tests/gpu_boxes.cpp
@@ -12,6 +12,7 @@ namespace {
 
 struct GpuConfigState {
 	int count = Gpu::count;
+	vector<size_t> panel_slots = Config::current_gpu_panel_slots;
 	vector<string> boxes = Config::current_boxes;
 	vector<string> presets = Config::preset_list;
 	string shown_boxes = Config::strings.at("shown_boxes");
@@ -20,6 +21,7 @@ struct GpuConfigState {
 
 	~GpuConfigState() {
 		Gpu::count = count;
+		Config::current_gpu_panel_slots = panel_slots;
 		Config::current_boxes = boxes;
 		Config::preset_list = presets;
 		Config::strings.at("shown_boxes") = shown_boxes;
@@ -27,6 +29,25 @@ struct GpuConfigState {
 		Term::height = term_height;
 	}
 };
+
+testing::AssertionResult set_gpu_boxes(const string& boxes) {
+	if (not Config::set_boxes(boxes)) {
+		return testing::AssertionFailure() << "Config::set_boxes(\"" << boxes << "\") failed";
+	}
+	Config::set("shown_boxes", boxes);
+	return testing::AssertionSuccess();
+}
+
+void expect_gpu_state(const vector<string>& boxes, const vector<size_t>& slots, const string& shown_boxes) {
+	EXPECT_EQ(Config::current_boxes, boxes);
+	for (size_t i = 0; i < slots.size(); ++i) {
+		const auto slot = Config::gpu_panel_slot(i);
+		ASSERT_TRUE(slot.has_value()) << "missing GPU panel slot " << i;
+		EXPECT_EQ(*slot, slots[i]) << "GPU panel slot " << i;
+	}
+	EXPECT_FALSE(Config::gpu_panel_slot(slots.size()).has_value());
+	EXPECT_EQ(Config::getS("shown_boxes"), shown_boxes);
+}
 
 }
 
@@ -48,12 +69,12 @@ TEST(gpu_boxes, parse_gpu_box_index) {
 	EXPECT_FALSE(Config::gpu_box_index("cpu").has_value());
 }
 
-TEST(gpu_boxes, set_boxes_accepts_dynamic_gpu_indices) {
+TEST(gpu_boxes, set_boxes_validates_dynamic_gpu_panels) {
 	GpuConfigState state;
 	Gpu::count = 8;
 
-	EXPECT_TRUE(Config::set_boxes("cpu gpu6 gpu7"));
-	EXPECT_EQ(Config::current_boxes, (vector<string>{"cpu", "gpu6", "gpu7"}));
+	ASSERT_TRUE(set_gpu_boxes("cpu gpu6 gpu7"));
+	expect_gpu_state({"cpu", "gpu6", "gpu7"}, {0, 1}, "cpu gpu6 gpu7");
 
 	EXPECT_FALSE(Config::set_boxes("gpu8"));
 	EXPECT_FALSE(Config::set_boxes("gpu0 gpu1 gpu2 gpu3 gpu4 gpu5 gpu6"));
@@ -74,16 +95,13 @@ TEST(gpu_boxes, switch_gpu_box_wraps_and_skips_visible_gpus) {
 	Term::width = 200;
 	Term::height = 80;
 
-	ASSERT_TRUE(Config::set_boxes("cpu gpu0 gpu1 gpu2"));
-	Config::set("shown_boxes", string{"cpu gpu0 gpu1 gpu2"});
+	ASSERT_TRUE(set_gpu_boxes("cpu gpu0 gpu1 gpu2"));
 
 	EXPECT_TRUE(Config::switch_gpu_box(0, -1));
-	EXPECT_EQ(Config::current_boxes, (vector<string>{"cpu", "gpu7", "gpu1", "gpu2"}));
-	EXPECT_EQ(Config::getS("shown_boxes"), "cpu gpu7 gpu1 gpu2");
+	expect_gpu_state({"cpu", "gpu7", "gpu1", "gpu2"}, {0, 1, 2}, "cpu gpu7 gpu1 gpu2");
 
 	EXPECT_TRUE(Config::switch_gpu_box(1, 1));
-	EXPECT_EQ(Config::current_boxes, (vector<string>{"cpu", "gpu7", "gpu3", "gpu2"}));
-	EXPECT_EQ(Config::getS("shown_boxes"), "cpu gpu7 gpu3 gpu2");
+	expect_gpu_state({"cpu", "gpu7", "gpu3", "gpu2"}, {0, 1, 2}, "cpu gpu7 gpu3 gpu2");
 }
 
 TEST(gpu_boxes, switch_gpu_box_returns_false_when_all_other_gpus_are_visible) {
@@ -92,12 +110,70 @@ TEST(gpu_boxes, switch_gpu_box_returns_false_when_all_other_gpus_are_visible) {
 	Term::width = 200;
 	Term::height = 80;
 
-	ASSERT_TRUE(Config::set_boxes("gpu0 gpu1 gpu2"));
-	Config::set("shown_boxes", string{"gpu0 gpu1 gpu2"});
+	ASSERT_TRUE(set_gpu_boxes("gpu0 gpu1 gpu2"));
 
 	EXPECT_FALSE(Config::switch_gpu_box(0, 1));
-	EXPECT_EQ(Config::current_boxes, (vector<string>{"gpu0", "gpu1", "gpu2"}));
-	EXPECT_EQ(Config::getS("shown_boxes"), "gpu0 gpu1 gpu2");
+	expect_gpu_state({"gpu0", "gpu1", "gpu2"}, {0, 1, 2}, "gpu0 gpu1 gpu2");
+}
+
+TEST(gpu_boxes, toggle_gpu_box_closes_slot_after_target_switch) {
+	GpuConfigState state;
+	Gpu::count = 8;
+	Term::width = 200;
+	Term::height = 80;
+
+	ASSERT_TRUE(set_gpu_boxes("gpu0 gpu1"));
+	expect_gpu_state({"gpu0", "gpu1"}, {0, 1}, "gpu0 gpu1");
+
+	ASSERT_TRUE(Config::switch_gpu_box(1, -1));
+	expect_gpu_state({"gpu0", "gpu7"}, {0, 1}, "gpu0 gpu7");
+
+	EXPECT_TRUE(Config::toggle_gpu_box(1));
+	expect_gpu_state({"gpu0"}, {0}, "gpu0");
+}
+
+TEST(gpu_boxes, toggle_gpu_box_opens_requested_slot) {
+	GpuConfigState state;
+	Gpu::count = 8;
+	Term::width = 200;
+	Term::height = 80;
+
+	ASSERT_TRUE(set_gpu_boxes("gpu0"));
+	expect_gpu_state({"gpu0"}, {0}, "gpu0");
+
+	EXPECT_TRUE(Config::toggle_gpu_box(2));
+	expect_gpu_state({"gpu0", "gpu2"}, {0, 2}, "gpu0 gpu2");
+
+	EXPECT_TRUE(Config::toggle_gpu_box(1));
+	expect_gpu_state({"gpu0", "gpu1", "gpu2"}, {0, 1, 2}, "gpu0 gpu1 gpu2");
+}
+
+TEST(gpu_boxes, toggle_gpu_box_keeps_slot_order_when_opened_out_of_order) {
+	GpuConfigState state;
+	Gpu::count = 8;
+	Term::width = 200;
+	Term::height = 80;
+
+	ASSERT_TRUE(set_gpu_boxes(""));
+
+	EXPECT_TRUE(Config::toggle_gpu_box(2));
+	expect_gpu_state({"gpu2"}, {2}, "gpu2");
+
+	EXPECT_TRUE(Config::toggle_gpu_box(0));
+	expect_gpu_state({"gpu0", "gpu2"}, {0, 2}, "gpu0 gpu2");
+}
+
+TEST(gpu_boxes, toggle_gpu_box_removes_the_box_for_the_requested_slot) {
+	GpuConfigState state;
+	Gpu::count = 8;
+	Term::width = 200;
+	Term::height = 80;
+
+	ASSERT_TRUE(set_gpu_boxes("gpu0 gpu1 gpu2"));
+	expect_gpu_state({"gpu0", "gpu1", "gpu2"}, {0, 1, 2}, "gpu0 gpu1 gpu2");
+
+	EXPECT_TRUE(Config::toggle_gpu_box(1));
+	expect_gpu_state({"gpu0", "gpu2"}, {0, 2}, "gpu0 gpu2");
 }
 
 #endif

--- a/tests/gpu_boxes.cpp
+++ b/tests/gpu_boxes.cpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "btop_config.hpp"
+#include "btop_shared.hpp"
+#include "btop_tools.hpp"
+
+#ifdef GPU_SUPPORT
+
+namespace {
+
+struct GpuConfigState {
+	int count = Gpu::count;
+	vector<string> boxes = Config::current_boxes;
+	vector<string> presets = Config::preset_list;
+	string shown_boxes = Config::strings.at("shown_boxes");
+	int term_width = Term::width.load();
+	int term_height = Term::height.load();
+
+	~GpuConfigState() {
+		Gpu::count = count;
+		Config::current_boxes = boxes;
+		Config::preset_list = presets;
+		Config::strings.at("shown_boxes") = shown_boxes;
+		Term::width = term_width;
+		Term::height = term_height;
+	}
+};
+
+}
+
+TEST(gpu_boxes, parse_gpu_box_index) {
+	const auto gpu0 = Config::gpu_box_index("gpu0");
+	const auto gpu7 = Config::gpu_box_index("gpu7");
+	const auto gpu10 = Config::gpu_box_index("gpu10");
+
+	ASSERT_TRUE(gpu0.has_value());
+	ASSERT_TRUE(gpu7.has_value());
+	ASSERT_TRUE(gpu10.has_value());
+	EXPECT_EQ(*gpu0, 0u);
+	EXPECT_EQ(*gpu7, 7u);
+	EXPECT_EQ(*gpu10, 10u);
+
+	EXPECT_FALSE(Config::gpu_box_index("gpu").has_value());
+	EXPECT_FALSE(Config::gpu_box_index("gpu-1").has_value());
+	EXPECT_FALSE(Config::gpu_box_index("gpu1x").has_value());
+	EXPECT_FALSE(Config::gpu_box_index("cpu").has_value());
+}
+
+TEST(gpu_boxes, set_boxes_accepts_dynamic_gpu_indices) {
+	GpuConfigState state;
+	Gpu::count = 8;
+
+	EXPECT_TRUE(Config::set_boxes("cpu gpu6 gpu7"));
+	EXPECT_EQ(Config::current_boxes, (vector<string>{"cpu", "gpu6", "gpu7"}));
+
+	EXPECT_FALSE(Config::set_boxes("gpu8"));
+	EXPECT_FALSE(Config::set_boxes("gpu0 gpu1 gpu2 gpu3 gpu4 gpu5 gpu6"));
+}
+
+TEST(gpu_boxes, presets_reject_more_than_max_gpu_panels) {
+	GpuConfigState state;
+
+	EXPECT_TRUE(Config::presetsValid(
+		"gpu0:0:default,gpu1:0:default,gpu2:0:default,gpu3:0:default,gpu4:0:default,gpu5:0:default"));
+	EXPECT_FALSE(Config::presetsValid(
+		"gpu0:0:default,gpu1:0:default,gpu2:0:default,gpu3:0:default,gpu4:0:default,gpu5:0:default,gpu6:0:default"));
+}
+
+TEST(gpu_boxes, switch_gpu_box_wraps_and_skips_visible_gpus) {
+	GpuConfigState state;
+	Gpu::count = 8;
+	Term::width = 200;
+	Term::height = 80;
+
+	ASSERT_TRUE(Config::set_boxes("cpu gpu0 gpu1 gpu2"));
+	Config::set("shown_boxes", string{"cpu gpu0 gpu1 gpu2"});
+
+	EXPECT_TRUE(Config::switch_gpu_box(0, -1));
+	EXPECT_EQ(Config::current_boxes, (vector<string>{"cpu", "gpu7", "gpu1", "gpu2"}));
+	EXPECT_EQ(Config::getS("shown_boxes"), "cpu gpu7 gpu1 gpu2");
+
+	EXPECT_TRUE(Config::switch_gpu_box(1, 1));
+	EXPECT_EQ(Config::current_boxes, (vector<string>{"cpu", "gpu7", "gpu3", "gpu2"}));
+	EXPECT_EQ(Config::getS("shown_boxes"), "cpu gpu7 gpu3 gpu2");
+}
+
+TEST(gpu_boxes, switch_gpu_box_returns_false_when_all_other_gpus_are_visible) {
+	GpuConfigState state;
+	Gpu::count = 3;
+	Term::width = 200;
+	Term::height = 80;
+
+	ASSERT_TRUE(Config::set_boxes("gpu0 gpu1 gpu2"));
+	Config::set("shown_boxes", string{"gpu0 gpu1 gpu2"});
+
+	EXPECT_FALSE(Config::switch_gpu_box(0, 1));
+	EXPECT_EQ(Config::current_boxes, (vector<string>{"gpu0", "gpu1", "gpu2"}));
+	EXPECT_EQ(Config::getS("shown_boxes"), "gpu0 gpu1 gpu2");
+}
+
+#endif


### PR DESCRIPTION
This PR improves multi-GPU panel handling so GPU boxes are no longer permanently tied to their initial GPU index.

Each GPU box now has a stable panel slot, while the GPU target displayed inside that box can be switched independently. This allows users to open a limited number of GPU boxes and cycle each box through available GPUs, which works better on systems with more GPUs than the UI can reasonably show at once.

Key changes:
- Allow GPU boxes to target any detected GPU, instead of only matching fixed gpu0, gpu1, etc. boxes.
- Keep number-key toggles bound to stable GPU box slots, even after the displayed GPU target is changed.
- Preserve GPU box title numbers when removing boxes from the middle.
- Keep GPU boxes ordered by slot, so opening boxes out of order does not produce unstable layout order.
- Add mouse-selectable previous/next controls in GPU box titles for switching the displayed GPU.
- Add tests for GPU box parsing, dynamic GPU indices, target switching, slot toggling, stable ordering, and max panel validation.

The intent is to keep the existing GPU box model intact while making it usable on machines with larger GPU counts.

<img width="1066" height="624" alt="image" src="https://github.com/user-attachments/assets/f86c1280-81c9-473a-a577-b533ec3c5ff9" />