### PR TITLE
fix: make background consistent in the `Terminal is too small` dialogue

### DIFF
--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -102,7 +102,7 @@ namespace Global {
 
 	string fg_white = "\x1b[1;97m";
 	string fg_green = "\x1b[1;92m";
-	string fg_red = "\x1b[0;91m";
+	string fg_red = "\x1b[1;91m";
 
 	uid_t real_uid, set_uid;
 

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -100,7 +100,6 @@ namespace Global {
 	string overlay;
 	string clock;
 
-	string bg_black = "\x1b[0;40m";
 	string fg_white = "\x1b[1;97m";
 	string fg_green = "\x1b[1;92m";
 	string fg_red = "\x1b[0;91m";
@@ -165,7 +164,7 @@ void term_resize(bool force) {
 					"{mv2} Width = {fg_width}{width} {fg_white}Height = {fg_height}{height}"
 					"{mv3}{fg_white}Needed for current config:"
 					"{mv4}Width = {minWidth} Height = {minHeight}",
-					"clear"_a = Term::clear, "bg_black"_a = Global::bg_black, "fg_white"_a = Global::fg_white,
+					"clear"_a = Term::clear, "fg_white"_a = Global::fg_white,
 					"mv1"_a = Mv::to((height / 2) - 2, (width / 2) - 11),
 					"mv2"_a = Mv::to((height / 2) - 1, (width / 2) - 10),
 						"fg_width"_a = (width < minWidth ? Global::fg_red : Global::fg_green),

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -160,7 +160,7 @@ void term_resize(bool force) {
 		sleep_ms(100);
 		if (Term::width < minWidth or Term::height < minHeight) {
 			int width = Term::width, height = Term::height;
-			cout << fmt::format("{clear}{bg_black}{fg_white}"
+			cout << fmt::format("{clear}{fg_white}"
 					"{mv1}Terminal size too small:"
 					"{mv2} Width = {fg_width}{width} {fg_white}Height = {fg_height}{height}"
 					"{mv3}{fg_white}Needed for current config:"


### PR DESCRIPTION
Closes #1750

The escape sequence for `fg_red` was `\x1b[0;91m`, which actually resets the style before updating it.
Changed to `\x1b[1;91m`.

Though the dialogue looks better without the background at all.
Removed `bg_black`.

<img width="2200" height="1836" alt="bitmap" src="https://github.com/user-attachments/assets/cccba47e-5fdb-413e-a6c0-1f29eaadfdac" />

