### PR TITLE
Add vcmbox0 to list of common thermal sensors

### DIFF
--- a/src/netbsd/btop_collect.cpp
+++ b/src/netbsd/btop_collect.cpp
@@ -224,13 +224,14 @@ namespace Cpu {
 		prop_dictionary_t dict;
 		prop_object_t fields_array;
 		// List of common thermal sensors in NetBSD.
-		const string sensors[6] = {
+		const string sensors[7] = {
 			"coretemp0",
 			"acpitz0",
 			"thinkpad0",
 			"amdzentemp0",
 			"coretemp1",
-			"acpitz1"
+			"acpitz1",
+			"vcmbox0"
 		};
 
 		int fd = open(_PATH_SYSMON, O_RDONLY);


### PR DESCRIPTION
The thermal sensor vcmbox0 is present in the Raspberry Pi SBCs. This code has been compiled and tested on a Raspberry Pi B+ running NetBSD 10.1 (earmv6hf architecture).

<img width="595" height="312" alt="netbsd-btop" src="https://github.com/user-attachments/assets/31b3f060-ca03-4586-9a68-b0ab928348be" />
