### PR TITLE
[AI generated] Add native Intel Mac CPU and GPU monitoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(BTOP_LTO)
 endif()
 
 if(APPLE)
-  target_sources(libbtop PRIVATE src/osx/btop_collect.cpp src/osx/sensors.cpp src/osx/smc.cpp)
+  target_sources(libbtop PRIVATE src/osx/btop_collect.cpp src/osx/intel_mac.cpp src/osx/sensors.cpp src/osx/smc.cpp)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "MidnightBSD")
   target_sources(libbtop PRIVATE src/freebsd/btop_collect.cpp)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
@@ -202,9 +202,10 @@ if(APPLE)
   target_link_libraries(libbtop
       $<LINK_LIBRARY:FRAMEWORK,CoreFoundation> $<LINK_LIBRARY:FRAMEWORK,IOKit>
   )
-  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64" AND BTOP_GPU)
+  if(BTOP_GPU)
     target_compile_definitions(libbtop PUBLIC GPU_SUPPORT)
-
+  endif()
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64" AND BTOP_GPU)
     find_library(IOREPORT_LIB IOReport)
     if(IOREPORT_LIB)
       target_link_libraries(libbtop ${IOREPORT_LIB})

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,9 @@ endif
 ifeq ($(PLATFORM_LC)$(ARCH),macosarm64)
 	GPU_SUPPORT := true
 endif
+ifeq ($(PLATFORM_LC)$(ARCH),macosx86_64)
+	GPU_SUPPORT := true
+endif
 ifneq ($(GPU_SUPPORT),true)
 	GPU_SUPPORT := false
 endif
@@ -221,6 +224,7 @@ SRCDIR		:= src
 INCDIRS		:= include $(wildcard lib/**/include)
 BUILDDIR	:= obj
 TARGETDIR	:= bin
+FREQUENCY_HELPER := $(TARGETDIR)/btop-cpu-frequency
 SRCEXT		:= cpp
 DEPEXT		:= d
 OBJEXT		:= o
@@ -317,6 +321,9 @@ help:
 	@printf "  clean        Remove built objects\n"
 	@printf "  distclean    Remove built objects and binaries\n"
 	@printf "  install      Install btop++ to \$$PREFIX ($(PREFIX))\n"
+	@printf "  frequency-helper          Build the Intel Mac CPU frequency sampler\n"
+	@printf "  install-frequency-helper  Install and start the sampler (run with sudo)\n"
+	@printf "  uninstall-frequency-helper Remove the Intel Mac CPU frequency sampler\n"
 	@printf "  setcap       Set extended capabilities on binary (preferable to setuid)\n"
 	@printf "  setuid       Set installed binary owner/group to \$$SU_USER/\$$SU_GROUP ($(SU_USER)/$(SU_GROUP)) and set SUID bit\n"
 	@printf "  uninstall    Uninstall btop++ from \$$PREFIX\n"
@@ -381,6 +388,50 @@ ifneq ($(wildcard btop.1),)
 	@$(call green,Installing man page to: ,$(WHITE)$(DESTDIR)$(PREFIX)/share/man/man1/btop.1)
 	@mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
 	@cp -p btop.1 $(DESTDIR)$(PREFIX)/share/man/man1/btop.1
+endif
+
+frequency-helper: $(FREQUENCY_HELPER)
+
+$(FREQUENCY_HELPER): src/osx/helpers/cpu_frequency.cpp src/osx/intel_mac.hpp | directories
+ifeq ($(PLATFORM_LC)$(ARCH),macosx86_64)
+	@$(call green,Building Intel Mac CPU frequency helper,...)
+	@$(CXX) $(REQFLAGS) -O2 -Wall -Wextra -pedantic -o $@ $<
+else
+	@$(call red,The CPU frequency helper is only supported on Intel macOS.)
+	@false
+endif
+
+install-frequency-helper: frequency-helper
+ifeq ($(PLATFORM_LC)$(ARCH),macosx86_64)
+	@test "$$(id -u)" = "0" || { printf "install-frequency-helper must run with sudo\n"; exit 1; }
+	@plutil -lint src/osx/helpers/com.btop.cpu-frequency.plist
+	@install -o root -g wheel -m 755 $(FREQUENCY_HELPER) /Library/PrivilegedHelperTools/btop-cpu-frequency
+	@install -o root -g wheel -m 644 src/osx/helpers/com.btop.cpu-frequency.plist /Library/LaunchDaemons/com.btop.cpu-frequency.plist
+	@launchctl bootout system/com.btop.cpu-frequency >/dev/null 2>&1 || true
+	@for attempt in 1 2 3; do \
+		launchctl bootstrap system /Library/LaunchDaemons/com.btop.cpu-frequency.plist && break; \
+		test "$$attempt" = "3" && exit 1; \
+		sleep 1; \
+	done
+	@launchctl enable system/com.btop.cpu-frequency
+	@launchctl kickstart -k system/com.btop.cpu-frequency
+	@$(call green,Intel Mac CPU frequency helper installed and started.)
+else
+	@$(call red,The CPU frequency helper is only supported on Intel macOS.)
+	@false
+endif
+
+uninstall-frequency-helper:
+ifeq ($(PLATFORM_LC)$(ARCH),macosx86_64)
+	@test "$$(id -u)" = "0" || { printf "uninstall-frequency-helper must run with sudo\n"; exit 1; }
+	@launchctl bootout system/com.btop.cpu-frequency >/dev/null 2>&1 || true
+	@rm -f /Library/LaunchDaemons/com.btop.cpu-frequency.plist
+	@rm -f /Library/PrivilegedHelperTools/btop-cpu-frequency
+	@rm -f /var/run/btop-cpu-frequency-mhz /var/run/btop-cpu-frequency-mhz.tmp
+	@$(call green,Intel Mac CPU frequency helper removed.)
+else
+	@$(call red,The CPU frequency helper is only supported on Intel macOS.)
+	@false
 endif
 
 #? Set SUID bit for btop as $SU_USER in $SU_GROUP
@@ -479,4 +530,4 @@ $(BUILDDIR)/%.c.o: $(SRCDIR)/$(PLATFORM_DIR)/intel_gpu_top/%.c | directories
 
 
 #? Non-File Targets
-.PHONY: all config.h msg help pre
+.PHONY: all config.h msg help pre frequency-helper install-frequency-helper uninstall-frequency-helper

--- a/README.md
+++ b/README.md
@@ -299,7 +299,8 @@ Also necessary is a UTF8 locale and a font that includes:
 
 ### **Optional Dependencies (Needed for GPU monitoring)**
 
-GPU monitoring is supported on Linux and on macOS with Apple Silicon GPUs.
+GPU monitoring is supported on Linux and on macOS with Apple Silicon GPUs or Intel and AMD GPUs on
+Intel Macs.
 
 GPU monitoring also requires a btop binary built with GPU support (`GPU_SUPPORT=true` flag).
 
@@ -706,7 +707,20 @@ See [GPU compatibility](#gpu-compatibility) section for more about compiling wit
 
    Notice! Only use "sudo" when installing to a NON user owned directory.
 
-5. **(Recommended) Set suid bit to make btop always run as root (or other user)**
+5. **(Optional, Intel Macs) Install the live CPU frequency helper**
+
+   Intel macOS reports only nominal CPU frequency to unprivileged processes. The optional helper
+   runs Apple's fixed `powermetrics` sampler command as a launch daemon and publishes the current
+   package-average active frequency for btop. All other Intel Mac CPU, SMC, and GPU metrics remain
+   unprivileged.
+
+   ```bash
+   sudo gmake install-frequency-helper
+   ```
+
+   Remove it with `sudo gmake uninstall-frequency-helper`.
+
+6. **(Recommended) Set suid bit to make btop always run as root (or other user)**
 
    ```bash
    sudo gmake setuid

--- a/src/btop.cpp
+++ b/src/btop.cpp
@@ -232,6 +232,7 @@ void clean_quit(int sig) {
 	Gpu::Asysfs::shutdown();
 	#ifdef __APPLE__
 	Gpu::AppleSilicon::shutdown();
+	Gpu::IntelMac::shutdown();
 	#endif
 #endif
 

--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -844,7 +844,7 @@ namespace Config {
 		}
 	}
 
-	static constexpr auto get_xdg_state_dir() -> std::optional<fs::path> {
+	static auto get_xdg_state_dir() -> std::optional<fs::path> {
 		std::optional<fs::path> xdg_state_home;
 
 		{

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -37,6 +37,10 @@ tab-size = 4
 #include "btop_theme.hpp"
 #include "btop_tools.hpp"
 
+#if defined(__APPLE__) && defined(__x86_64__)
+#include "osx/intel_mac.hpp"
+#endif
+
 using std::array;
 using std::clamp;
 using std::cmp_equal;
@@ -911,7 +915,16 @@ namespace Cpu {
 		//? Core text and graphs
 		int cx = 0, cy = 1, cc = 0, core_width = (b_column_size == 0 ? 2 : 3);
 		if (Shared::coreCount >= 100) core_width++;
-		for (const auto& n : iota(0, Shared::coreCount)) {
+		for (const auto& slot : iota(0, Shared::coreCount)) {
+			#if defined(__APPLE__) && defined(__x86_64__)
+			const auto n = static_cast<int>(::IntelMac::physical_core_for_layout_slot(
+				slot,
+				b_columns,
+				Shared::coreCount
+			));
+			#else
+			const auto n = slot;
+			#endif
 			auto enabled = is_cpu_enabled(n);
 			out += Mv::to(b_y + cy + 1, b_x + cx + 1) + Theme::c(enabled ? "main_fg" : "inactive_fg") + (Shared::coreCount < 100 ? Fx::b + 'C' + Fx::ub : "")
 				+ ljust(to_string(n), core_width);
@@ -951,7 +964,7 @@ namespace Cpu {
 
 			out += Theme::c("div_line") + Symbols::v_line;
 
-			if ((++cy > ceil((double)Shared::coreCount / b_columns) or cy == max_row) and n != Shared::coreCount - 1) {
+			if ((++cy > ceil((double)Shared::coreCount / b_columns) or cy == max_row) and slot != Shared::coreCount - 1) {
 				if (++cc >= b_columns) break;
 				cy = 1; cx = (b_width / b_columns) * cc;
 			}

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -194,6 +194,9 @@ namespace Gpu {
 	namespace AppleSilicon {
 		extern bool shutdown();
 	}
+	namespace IntelMac {
+		extern bool shutdown();
+	}
 	#endif
 
 	//* Collect gpu stats and temperatures

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -40,6 +40,7 @@ tab-size = 4
 #include <netinet/tcp_fsm.h>
 #include <pwd.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/statvfs.h>
 #include <sys/sysctl.h>
 #include <sys/types.h>
@@ -51,17 +52,23 @@ tab-size = 4
 #if __MAC_OS_X_VERSION_MIN_REQUIRED > 101504
 #include "sensors.hpp"
 #endif
+#include "intel_mac.hpp"
 #include "smc.hpp"
 #endif
 
 #include <cmath>
+#include <cstdlib>
+#include <ctime>
 #include <fstream>
 #include <future>
+#include <limits>
+#include <memory>
 #include <mutex>
 #include <numeric>
 #include <ranges>
 #include <regex>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 
 #include <fmt/format.h>
@@ -166,6 +173,7 @@ struct IORef {
 namespace Cpu {
 	vector<long long> core_old_totals;
 	vector<long long> core_old_idles;
+	vector<std::size_t> logical_to_physical;
 	vector<string> available_fields = {"Auto", "total"};
 	vector<string> available_sensors = {"Auto"};
 	cpu_info current_cpu;
@@ -177,6 +185,12 @@ namespace Cpu {
 
 	//* Get current cpu clock speed
 	string get_cpuHz();
+
+	//* Get current CPU package power
+	std::optional<float> get_cpuWatts();
+
+	//* Read the logical CPU to physical core mapping from the device-tree APIC topology
+	auto get_logical_to_physical_map(std::size_t logical_count, std::size_t physical_count) -> vector<std::size_t>;
 
 	//* Search /proc/cpuinfo for a cpu name
 	string get_cpuName();
@@ -208,6 +222,7 @@ namespace Gpu {
 	namespace Asysfs { bool shutdown() { return false; } }
 
 	//? Apple Silicon GPU data collection via IOReport
+	#if defined(__arm64__)
 	namespace AppleSilicon {
 		bool initialized = false;
 		unsigned int device_count = 0;
@@ -589,12 +604,21 @@ namespace Gpu {
 		template bool collect<true>(gpu_info*);
 		template bool collect<false>(gpu_info*);
 	} // namespace AppleSilicon
+	#else
+	namespace AppleSilicon {
+		bool shutdown() { return false; }
+	}
+	#endif
 
-	//? Collect data from Apple Silicon GPU
+	//? Collect data from the native macOS GPU backend
 	auto collect(bool no_update) -> vector<gpu_info>& {
 		if (Runner::stopping or (no_update and not gpus.empty())) return gpus;
 
+		#if defined(__arm64__)
 		AppleSilicon::collect<0>(gpus.data());
+		#elif defined(__x86_64__)
+		::IntelMac::Gpu::collect(gpus);
+		#endif
 
 		//* Calculate averages
 		long long avg = 0;
@@ -652,23 +676,30 @@ namespace Shared {
 
 	fs::path passwd_path;
 	uint64_t totalMem;
-	long pageSize, coreCount, clkTck, physicalCoreCount, arg_max;
+	long pageSize, coreCount, logicalCoreCount, clkTck, physicalCoreCount, arg_max;
 	double machTck;
 	int totalMem_len;
 
 	void init() {
 		//? Shared global variables init
 
-		coreCount = sysconf(_SC_NPROCESSORS_ONLN); // this returns all logical cores (threads)
-		if (coreCount < 1) {
-			coreCount = 1;
+		logicalCoreCount = sysconf(_SC_NPROCESSORS_ONLN);
+		if (logicalCoreCount < 1) {
+			logicalCoreCount = 1;
 			Logger::warning("Could not determine number of cores, defaulting to 1.");
 		}
 
 		size_t physicalCoreCountSize = sizeof(physicalCoreCount);
 		if (sysctlbyname("hw.physicalcpu", &physicalCoreCount, &physicalCoreCountSize, nullptr, 0) < 0) {
 			Logger::error("Could not get physical core count");
+			physicalCoreCount = logicalCoreCount;
 		}
+		#if defined(__x86_64__)
+		coreCount = physicalCoreCount > 0 ? physicalCoreCount : logicalCoreCount;
+		Cpu::logical_to_physical = Cpu::get_logical_to_physical_map(logicalCoreCount, coreCount);
+		#else
+		coreCount = logicalCoreCount;
+		#endif
 
 		pageSize = sysconf(_SC_PAGE_SIZE);
 		if (pageSize <= 0) {
@@ -703,8 +734,8 @@ namespace Shared {
 		//? Init for namespace Cpu
 		Cpu::current_cpu.core_percent.insert(Cpu::current_cpu.core_percent.begin(), Shared::coreCount, {});
 		Cpu::current_cpu.temp.insert(Cpu::current_cpu.temp.begin(), Shared::coreCount + 1, {});
-		Cpu::core_old_totals.insert(Cpu::core_old_totals.begin(), Shared::coreCount, 0);
-		Cpu::core_old_idles.insert(Cpu::core_old_idles.begin(), Shared::coreCount, 0);
+		Cpu::core_old_totals.insert(Cpu::core_old_totals.begin(), Shared::logicalCoreCount, 0);
+		Cpu::core_old_idles.insert(Cpu::core_old_idles.begin(), Shared::logicalCoreCount, 0);
 		Cpu::collect();
 		for (auto &[field, vec] : Cpu::current_cpu.cpu_percent) {
 			if (not vec.empty() and not v_contains(Cpu::available_fields, field)) Cpu::available_fields.push_back(field);
@@ -716,9 +747,13 @@ namespace Shared {
 		//? Init for namespace Gpu
 	#ifdef GPU_SUPPORT
 		auto shown_gpus = Config::getS("shown_gpus");
+		#if defined(__arm64__)
 		if (shown_gpus.contains("apple")) {
 			Gpu::AppleSilicon::init();
 		}
+		#elif defined(__x86_64__)
+		::IntelMac::Gpu::init(Gpu::gpus, shown_gpus);
+		#endif
 
 		if (not Gpu::gpu_names.empty()) {
 			for (auto const& [key, _] : Gpu::gpus[0].gpu_percent)
@@ -763,6 +798,60 @@ namespace Cpu {
 		{"idle", 0}
 	};
 
+	auto get_logical_to_physical_map(
+		const std::size_t logical_count,
+		const std::size_t physical_count
+	) -> vector<std::size_t> {
+		vector<unsigned int> apic_ids(logical_count, std::numeric_limits<unsigned int>::max());
+		io_iterator_t iterator = 0;
+		if (IORegistryCreateIterator(
+				kIOMainPortDefault,
+				kIODeviceTreePlane,
+				kIORegistryIterateRecursively,
+				&iterator
+			) == kIOReturnSuccess) {
+			io_registry_entry_t entry = 0;
+			while ((entry = IOIteratorNext(iterator)) != 0) {
+				io_name_t name{};
+				io_name_t location{};
+				if (IORegistryEntryGetNameInPlane(entry, kIODeviceTreePlane, name) == kIOReturnSuccess
+				and std::string_view{name}.starts_with("CPU")
+				and IORegistryEntryGetLocationInPlane(entry, kIODeviceTreePlane, location) == kIOReturnSuccess) {
+					char* logical_end = nullptr;
+					char* apic_end = nullptr;
+					const auto logical = std::strtoul(name + 3, &logical_end, 10);
+					const auto apic = std::strtoul(location, &apic_end, 16);
+					if (logical_end != name + 3 and *logical_end == '\0'
+					and apic_end != location and *apic_end == '\0'
+					and logical < apic_ids.size()
+					and apic <= std::numeric_limits<unsigned int>::max()) {
+						apic_ids[logical] = static_cast<unsigned int>(apic);
+					}
+				}
+				IOObjectRelease(entry);
+			}
+			IOObjectRelease(iterator);
+		}
+
+		if (std::ranges::find(apic_ids, std::numeric_limits<unsigned int>::max()) != apic_ids.end())
+			apic_ids.clear();
+		auto mapping = ::IntelMac::physical_core_map_from_apic_ids(apic_ids, physical_count);
+		if (mapping.empty()) {
+			Logger::warning("Intel Mac CPU: APIC topology unavailable, grouping adjacent XNU processor slots");
+			mapping = ::IntelMac::physical_core_map_from_xnu_order(logical_count, physical_count);
+			return mapping;
+		}
+
+		std::ranges::sort(apic_ids);
+		string topology;
+		for (std::size_t logical = 0; logical < mapping.size(); ++logical) {
+			if (not topology.empty()) topology += ", ";
+			topology += fmt::format("CPU{}(APIC {:X})->C{}", logical, apic_ids[logical], mapping[logical]);
+		}
+		Logger::info("Intel Mac CPU topology: {}", topology);
+		return mapping;
+	}
+
 	string get_cpuName() {
 		string name;
 		char buffer[1024];
@@ -771,7 +860,12 @@ namespace Cpu {
 			Logger::error("Failed to get CPU name");
 			return name;
 		}
-		return trim_name(string(buffer));
+		name = trim_name(string(buffer));
+		#if defined(__x86_64__)
+		return ::IntelMac::format_cpu_title(name, Shared::coreCount);
+		#else
+		return name;
+		#endif
 	}
 
 	bool get_sensors() {
@@ -838,10 +932,9 @@ namespace Cpu {
 #endif
 			} else {
 				SMCConnection smcCon;
-				int threadsPerCore = Shared::coreCount / Shared::physicalCoreCount;
 				result.package_temp = smcCon.getTemp(-1);
 				for (int core = 0; core < Shared::coreCount; core++) {
-					result.core_temps.push_back(smcCon.getTemp((core / threadsPerCore) + core_offset));
+					result.core_temps.push_back(smcCon.getTemp(core + core_offset));
 				}
 				result.valid = true;
 			}
@@ -892,6 +985,19 @@ namespace Cpu {
 	}
 
 	string get_cpuHz() {
+		#if defined(__x86_64__)
+		struct stat file_status {};
+		if (stat(::IntelMac::cpu_frequency_path, &file_status) != 0
+		or not ::IntelMac::cpu_frequency_sample_is_fresh(std::time(nullptr), file_status.st_mtime)) {
+			return ::IntelMac::format_cpu_frequency_ghz(0.0);
+		}
+
+		std::ifstream frequency_file(::IntelMac::cpu_frequency_path);
+		double frequency_mhz = 0.0;
+		if (not (frequency_file >> frequency_mhz) or frequency_mhz < 100.0 or frequency_mhz > 10'000.0)
+			return ::IntelMac::format_cpu_frequency_ghz(0.0);
+		return ::IntelMac::format_cpu_frequency_ghz(frequency_mhz);
+		#else
 		unsigned int freq = 1;
 		size_t size = sizeof(freq);
 
@@ -902,6 +1008,28 @@ namespace Cpu {
 			return "";
 		}
 		return std::to_string(freq / 1000.0 / 1000.0 / 1000.0).substr(0, 3);
+		#endif
+	}
+
+	std::optional<float> get_cpuWatts() {
+		static std::unique_ptr<SMCConnection> connection;
+		static bool attempted = false;
+		if (not attempted) {
+			attempted = true;
+			try {
+				connection = std::make_unique<SMCConnection>();
+			}
+			catch (const std::runtime_error& error) {
+				Logger::debug("CPU power SMC unavailable: {}", error.what());
+			}
+		}
+		if (not connection) return std::nullopt;
+
+		// PCPT is total CPU package power; PCPC excludes package graphics and system-agent power.
+		const auto watts = connection->getValue("PCPT");
+		if (not watts.has_value() or watts.value() < 0 or watts.value() > 1000)
+			return std::nullopt;
+		return static_cast<float>(watts.value());
 	}
 
 	auto get_core_mapping() -> std::unordered_map<int, int> {
@@ -918,7 +1046,7 @@ namespace Cpu {
 			Logger::error("Failed getting CPU info");
 			return core_map;
 		}
-		for (i = 0; i < cpu_count; i++) {
+		for (i = 0; i < std::min<natural_t>(cpu_count, Shared::coreCount); i++) {
 			core_map[i] = i;
 		}
 
@@ -1039,6 +1167,10 @@ namespace Cpu {
 		long long global_totals = 0;
 		long long global_idles = 0;
 		vector<long long> times_summed = {0, 0, 0, 0};
+		vector<long long> logical_total_deltas(cpu_count, 0);
+		vector<long long> logical_idle_deltas(cpu_count, 0);
+		if (core_old_totals.size() < cpu_count) core_old_totals.resize(cpu_count, 0);
+		if (core_old_idles.size() < cpu_count) core_old_idles.resize(cpu_count, 0);
 		for (i = 0; i < cpu_count; i++) {
 			vector<long long> times;
 			//? 0=user, 1=nice, 2=system, 3=idle
@@ -1048,32 +1180,27 @@ namespace Cpu {
 				times_summed.at(x++) += val;
 			}
 
-			try {
-				//? All values
-				const long long totals = std::accumulate(times.begin(), times.end(), 0ll);
+			//? All values
+			const long long totals = std::accumulate(times.begin(), times.end(), 0ll);
+			const long long idles = times.at(3);
 
-				//? Idle time
-				const long long idles = times.at(3);
+			global_totals += totals;
+			global_idles += idles;
+			logical_total_deltas.at(i) = max(0ll, totals - core_old_totals.at(i));
+			logical_idle_deltas.at(i) = max(0ll, idles - core_old_idles.at(i));
+			core_old_totals.at(i) = totals;
+			core_old_idles.at(i) = idles;
+		}
 
-				global_totals += totals;
-				global_idles += idles;
-
-				//? Calculate cpu total for each core
-				if (i > Shared::coreCount) break;
-				const long long calc_totals = max(0ll, totals - core_old_totals.at(i));
-				const long long calc_idles = max(0ll, idles - core_old_idles.at(i));
-				core_old_totals.at(i) = totals;
-				core_old_idles.at(i) = idles;
-
-				cpu.core_percent.at(i).push_back(clamp((long long)round((double)(calc_totals - calc_idles) * 100 / calc_totals), 0ll, 100ll));
-
-				//? Reduce size if there are more values than needed for graph
-				if (cpu.core_percent.at(i).size() > 40) cpu.core_percent.at(i).pop_front();
-
-			} catch (const std::exception &e) {
-				Logger::error("Cpu::collect() : {}", e.what());
-				throw std::runtime_error(fmt::format("collect() : {}", e.what()));
-			}
+		const auto physical_usage = ::IntelMac::aggregate_physical_usage(
+			logical_total_deltas,
+			logical_idle_deltas,
+			cpu.core_percent.size(),
+			logical_to_physical
+		);
+		for (std::size_t core = 0; core < physical_usage.size(); ++core) {
+			cpu.core_percent.at(core).push_back(physical_usage.at(core));
+			if (cpu.core_percent.at(core).size() > 40) cpu.core_percent.at(core).pop_front();
 		}
 
 		const long long calc_totals = max(1ll, global_totals - cpu_old.at("totals"));
@@ -1103,6 +1230,13 @@ namespace Cpu {
 			auto hz = get_cpuHz();
 			if (hz != "") {
 				cpuHz = hz;
+			}
+		}
+
+		if (Config::getB("show_cpu_watts")) {
+			if (const auto watts = get_cpuWatts(); watts.has_value()) {
+				supports_watts = true;
+				cpu.usage_watts = watts.value();
 			}
 		}
 
@@ -1696,7 +1830,7 @@ namespace Proc {
 		detailed.entry = *p_info;
 
 		//? Update cpu percent deque for process cpu graph
-		if (not Config::getB("proc_per_core")) detailed.entry.cpu_p *= Shared::coreCount;
+		if (not Config::getB("proc_per_core")) detailed.entry.cpu_p *= Shared::logicalCoreCount;
 		detailed.cpu_percent.push_back(clamp((long long)round(detailed.entry.cpu_p), 0ll, 100ll));
 		while (cmp_greater(detailed.cpu_percent.size(), width)) detailed.cpu_percent.pop_front();
 
@@ -1755,7 +1889,7 @@ namespace Proc {
 		}
 		if (tree_mode_change) is_tree_mode = tree;
 
-		const int cmult = (per_core) ? Shared::coreCount : 1;
+		const int cmult = (per_core) ? Shared::logicalCoreCount : 1;
 		bool got_detailed = false;
 
 		static vector<size_t> found;
@@ -1886,7 +2020,7 @@ namespace Proc {
 					}
 
 					//? Process cpu usage since last update
-					new_proc.cpu_p = clamp(round(((cpu_t - new_proc.cpu_t) * Shared::machTck) / ((cputimes - old_cputimes) * Shared::clkTck)) * cmult / 1000.0, 0.0, 100.0 * Shared::coreCount);
+					new_proc.cpu_p = clamp(round(((cpu_t - new_proc.cpu_t) * Shared::machTck) / ((cputimes - old_cputimes) * Shared::clkTck)) * cmult / 1000.0, 0.0, 100.0 * Shared::logicalCoreCount);
 
 					//? Process cumulative cpu usage since process start
 					new_proc.cpu_c = (double)(cpu_t * Shared::machTck) / (timeNow - new_proc.cpu_s);

--- a/src/osx/helpers/com.btop.cpu-frequency.plist
+++ b/src/osx/helpers/com.btop.cpu-frequency.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.btop.cpu-frequency</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Library/PrivilegedHelperTools/btop-cpu-frequency</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ThrottleInterval</key>
+	<integer>5</integer>
+</dict>
+</plist>

--- a/src/osx/helpers/cpu_frequency.cpp
+++ b/src/osx/helpers/cpu_frequency.cpp
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../intel_mac.hpp"
+
+#include <cerrno>
+#include <csignal>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <spawn.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+	constexpr auto temporary_path = "/var/run/btop-cpu-frequency-mhz.tmp";
+
+	volatile sig_atomic_t stopping = 0;
+	volatile sig_atomic_t child_pid = 0;
+
+	void stop(const int) {
+		stopping = 1;
+		if (child_pid > 0) kill(child_pid, SIGTERM);
+	}
+
+	auto publish_frequency(const double mhz) -> bool {
+		const auto output = open(
+			temporary_path,
+			O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC | O_NOFOLLOW,
+			0644
+		);
+		if (output < 0) return false;
+
+		const auto written = dprintf(output, "%.2f\n", mhz);
+		const auto close_result = close(output);
+		if (written <= 0 or close_result != 0) {
+			unlink(temporary_path);
+			return false;
+		}
+		if (rename(temporary_path, IntelMac::cpu_frequency_path) != 0) {
+			unlink(temporary_path);
+			return false;
+		}
+		return true;
+	}
+
+	auto spawn_powermetrics(int& output_fd) -> pid_t {
+		int pipe_fds[2]{};
+		if (pipe(pipe_fds) != 0) return -1;
+
+		posix_spawn_file_actions_t actions{};
+		if (posix_spawn_file_actions_init(&actions) != 0) {
+			close(pipe_fds[0]);
+			close(pipe_fds[1]);
+			return -1;
+		}
+		posix_spawn_file_actions_addclose(&actions, pipe_fds[0]);
+		posix_spawn_file_actions_adddup2(&actions, pipe_fds[1], STDOUT_FILENO);
+		posix_spawn_file_actions_addclose(&actions, pipe_fds[1]);
+		posix_spawn_file_actions_addopen(&actions, STDERR_FILENO, "/dev/null", O_WRONLY, 0);
+
+		char path[] = "/usr/bin/powermetrics";
+		char interval[] = "-i";
+		char interval_value[16]{};
+		std::snprintf(
+			interval_value,
+			sizeof(interval_value),
+			"%u",
+			IntelMac::cpu_frequency_sample_interval_ms
+		);
+		char buffer_size[] = "-b";
+		char line_buffered[] = "1";
+		char sampler[] = "-s";
+		char sampler_value[] = "cpu_power";
+		char pstates[] = "--show-pstates";
+		char* arguments[] = {
+			path,
+			interval,
+			interval_value,
+			buffer_size,
+			line_buffered,
+			sampler,
+			sampler_value,
+			pstates,
+			nullptr,
+		};
+		char* environment[] = {nullptr};
+
+		pid_t pid = -1;
+		const auto result = posix_spawn(&pid, path, &actions, nullptr, arguments, environment);
+		posix_spawn_file_actions_destroy(&actions);
+		close(pipe_fds[1]);
+		if (result != 0) {
+			close(pipe_fds[0]);
+			errno = result;
+			return -1;
+		}
+
+		output_fd = pipe_fds[0];
+		return pid;
+	}
+}
+
+int main() {
+	if (geteuid() != 0) {
+		std::fprintf(stderr, "btop CPU frequency helper must run as root\n");
+		return 1;
+	}
+
+	umask(022);
+	unlink(IntelMac::cpu_frequency_path);
+	unlink(temporary_path);
+	std::signal(SIGINT, stop);
+	std::signal(SIGTERM, stop);
+
+	int output_fd = -1;
+	const auto pid = spawn_powermetrics(output_fd);
+	if (pid < 0) {
+		std::fprintf(stderr, "failed to start powermetrics: %s\n", std::strerror(errno));
+		return 1;
+	}
+	child_pid = pid;
+
+	auto* output = fdopen(output_fd, "r");
+	if (output == nullptr) {
+		close(output_fd);
+		kill(pid, SIGTERM);
+		waitpid(pid, nullptr, 0);
+		return 1;
+	}
+
+	char* line = nullptr;
+	std::size_t capacity = 0;
+	while (not stopping and getline(&line, &capacity, output) >= 0) {
+		if (const auto mhz = IntelMac::parse_powermetrics_cpu_mhz(line); mhz.has_value()
+		and not publish_frequency(mhz.value())) {
+			std::fprintf(stderr, "failed to publish CPU frequency: %s\n", std::strerror(errno));
+			break;
+		}
+	}
+
+	free(line);
+	fclose(output);
+	if (not stopping) kill(pid, SIGTERM);
+	waitpid(pid, nullptr, 0);
+	child_pid = 0;
+	unlink(IntelMac::cpu_frequency_path);
+	unlink(temporary_path);
+	return stopping ? 0 : 1;
+}

--- a/src/osx/intel_mac.cpp
+++ b/src/osx/intel_mac.cpp
@@ -1,0 +1,458 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "intel_mac.hpp"
+
+#if defined(__APPLE__) && defined(GPU_SUPPORT) && defined(__x86_64__)
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOKitLib.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "../btop_log.hpp"
+#include "smc.hpp"
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 120000
+#define kIOMainPortDefault kIOMasterPortDefault
+#endif
+
+namespace IntelMac::Gpu {
+	namespace {
+		enum class Vendor {
+			Intel,
+			Amd,
+			Other,
+		};
+
+		struct Device {
+			io_registry_entry_t accelerator{};
+			std::size_t gpu_index{};
+			Vendor vendor{Vendor::Other};
+			std::string name;
+
+			Device() = default;
+			Device(const Device&) = delete;
+			auto operator=(const Device&) -> Device& = delete;
+			Device(Device&& other) noexcept
+				: accelerator(std::exchange(other.accelerator, 0)),
+				  gpu_index(other.gpu_index),
+				  vendor(other.vendor),
+				  name(std::move(other.name)) {}
+			auto operator=(Device&& other) noexcept -> Device& {
+				if (this != &other) {
+					if (accelerator) IOObjectRelease(accelerator);
+					accelerator = std::exchange(other.accelerator, 0);
+					gpu_index = other.gpu_index;
+					vendor = other.vendor;
+					name = std::move(other.name);
+				}
+				return *this;
+			}
+			~Device() {
+				if (accelerator) IOObjectRelease(accelerator);
+			}
+		};
+
+		std::vector<Device> devices;
+		std::unique_ptr<Cpu::SMCConnection> smc;
+		bool initialized = false;
+
+		template <typename T>
+		class CFRef {
+		   public:
+			explicit CFRef(T value = nullptr) : value(value) {}
+			~CFRef() {
+				if (value) CFRelease(value);
+			}
+			CFRef(const CFRef&) = delete;
+			auto operator=(const CFRef&) -> CFRef& = delete;
+			CFRef(CFRef&& other) noexcept : value(std::exchange(other.value, nullptr)) {}
+			auto operator=(CFRef&& other) noexcept -> CFRef& {
+				if (this != &other) {
+					if (value) CFRelease(value);
+					value = std::exchange(other.value, nullptr);
+				}
+				return *this;
+			}
+			auto get() const -> T { return value; }
+			operator bool() const { return value != nullptr; }
+
+		   private:
+			T value;
+		};
+
+		auto integer_value(CFTypeRef value) -> std::optional<int64_t> {
+			if (value == nullptr) return std::nullopt;
+			if (CFGetTypeID(value) == CFNumberGetTypeID()) {
+				int64_t result = 0;
+				if (CFNumberGetValue(static_cast<CFNumberRef>(value), kCFNumberSInt64Type, &result))
+					return result;
+			}
+			if (CFGetTypeID(value) == CFDataGetTypeID()) {
+				const auto data = static_cast<CFDataRef>(value);
+				const auto length = std::min<CFIndex>(CFDataGetLength(data), sizeof(uint64_t));
+				if (length <= 0) return std::nullopt;
+				uint64_t result = 0;
+				memcpy(&result, CFDataGetBytePtr(data), static_cast<std::size_t>(length));
+				if (result <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
+					return static_cast<int64_t>(result);
+			}
+			return std::nullopt;
+		}
+
+		auto dictionary_integer(CFDictionaryRef dictionary, CFStringRef key) -> std::optional<int64_t> {
+			return dictionary ? integer_value(CFDictionaryGetValue(dictionary, key)) : std::nullopt;
+		}
+
+		auto dictionary_has(CFDictionaryRef dictionary, CFStringRef key) -> bool {
+			return dictionary && CFDictionaryContainsKey(dictionary, key);
+		}
+
+		auto registry_property(io_registry_entry_t entry, CFStringRef key) -> CFTypeRef {
+			return IORegistryEntryCreateCFProperty(entry, key, kCFAllocatorDefault, 0);
+		}
+
+		auto inherited_property(io_registry_entry_t entry, CFStringRef key) -> CFTypeRef {
+			return IORegistryEntrySearchCFProperty(
+				entry,
+				kIOServicePlane,
+				key,
+				kCFAllocatorDefault,
+				kIORegistryIterateParents | kIORegistryIterateRecursively
+			);
+		}
+
+		auto string_value(CFTypeRef value) -> std::string {
+			if (value == nullptr) return {};
+			if (CFGetTypeID(value) == CFStringGetTypeID()) {
+				char buffer[256]{};
+				return CFStringGetCString(
+					static_cast<CFStringRef>(value),
+					buffer,
+					sizeof(buffer),
+					kCFStringEncodingUTF8
+				) ? std::string{buffer} : std::string{};
+			}
+			if (CFGetTypeID(value) == CFDataGetTypeID()) {
+				const auto data = static_cast<CFDataRef>(value);
+				const auto length = std::min<CFIndex>(CFDataGetLength(data), 255);
+				std::string result(
+					reinterpret_cast<const char*>(CFDataGetBytePtr(data)),
+					static_cast<std::size_t>(std::max<CFIndex>(length, 0))
+				);
+				if (const auto terminator = result.find('\0'); terminator != std::string::npos)
+					result.resize(terminator);
+				return result;
+			}
+			return {};
+		}
+
+		auto active_gpu_name() -> std::string {
+			const auto mux = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("AppleMuxControl"));
+			if (mux == 0) return {};
+			CFRef<CFTypeRef> value(registry_property(mux, CFSTR("ActiveGPU")));
+			IOObjectRelease(mux);
+			return string_value(value.get());
+		}
+
+		auto has_ancestor_named(const io_registry_entry_t entry, const std::string& target) -> bool {
+			if (target.empty()) return true;
+
+			io_registry_entry_t current = entry;
+			IOObjectRetain(current);
+			while (current != 0) {
+				io_name_t name{};
+				if (IORegistryEntryGetName(current, name) == kIOReturnSuccess and target == name) {
+					IOObjectRelease(current);
+					return true;
+				}
+
+				io_registry_entry_t parent = 0;
+				const auto result = IORegistryEntryGetParentEntry(current, kIOServicePlane, &parent);
+				IOObjectRelease(current);
+				if (result != kIOReturnSuccess) break;
+				current = parent;
+			}
+			return false;
+		}
+
+		auto detect_vendor(const std::string& match) -> Vendor {
+			if (match.find("8086") != std::string::npos) return Vendor::Intel;
+			if (match.find("1002") != std::string::npos) return Vendor::Amd;
+			return Vendor::Other;
+		}
+
+		auto vendor_enabled(const Vendor vendor, const std::string& shown_vendors) -> bool {
+			if (vendor == Vendor::Intel) return shown_vendors.find("intel") != std::string::npos;
+			if (vendor == Vendor::Amd) return shown_vendors.find("amd") != std::string::npos;
+			return false;
+		}
+
+		auto read_performance_statistics(io_registry_entry_t accelerator) -> CFRef<CFDictionaryRef> {
+			auto property = registry_property(accelerator, CFSTR("PerformanceStatistics"));
+			if (property == nullptr or CFGetTypeID(property) != CFDictionaryGetTypeID()) {
+				if (property) CFRelease(property);
+				return CFRef<CFDictionaryRef>{};
+			}
+			return CFRef<CFDictionaryRef>{static_cast<CFDictionaryRef>(property)};
+		}
+
+		auto read_memory_total(io_registry_entry_t accelerator) -> int64_t {
+			for (const auto key : {CFSTR("VRAM,totalMB"), CFSTR("vram,totalMB")}) {
+				CFRef<CFTypeRef> value(registry_property(accelerator, key));
+				if (not value) value = CFRef<CFTypeRef>{inherited_property(accelerator, key)};
+				if (const auto megabytes = integer_value(value.get()); megabytes.has_value() and megabytes.value() > 0)
+					return megabytes.value() * 1024 * 1024;
+			}
+
+			CFRef<CFTypeRef> bytes(inherited_property(accelerator, CFSTR("ATY,memsize")));
+			const auto value = integer_value(bytes.get());
+			return value.has_value() and value.value() > 0 ? value.value() : 0;
+		}
+
+		auto read_memory_used(CFDictionaryRef stats, const Vendor vendor, const int64_t total) -> int64_t {
+			const auto preferred = vendor == Vendor::Intel
+				? dictionary_integer(stats, CFSTR("gartUsedBytes"))
+				: dictionary_integer(stats, CFSTR("inUseVidMemoryBytes"));
+			if (preferred.has_value() and preferred.value() >= 0 and (total <= 0 or preferred.value() <= total))
+				return preferred.value();
+
+			const auto fallback = dictionary_integer(stats, CFSTR("inUseSysMemoryBytes"));
+			if (fallback.has_value() and fallback.value() >= 0 and (total <= 0 or fallback.value() <= total))
+				return fallback.value();
+			return 0;
+		}
+
+		auto read_utilization(CFDictionaryRef stats) -> std::optional<int64_t> {
+			auto value = dictionary_integer(stats, CFSTR("Device Utilization %"));
+			if (not value.has_value())
+				value = dictionary_integer(stats, CFSTR("GPU Activity(%)"));
+			if (not value.has_value()) return std::nullopt;
+			return std::clamp(value.value(), 0ll, 100ll);
+		}
+
+		auto smc_value(const char *key) -> std::optional<double> {
+			return smc ? smc->getValue(key) : std::nullopt;
+		}
+
+		void trim_name(std::string& name, const Vendor vendor) {
+			const std::string prefix = vendor == Vendor::Intel ? "Intel " : vendor == Vendor::Amd ? "AMD " : "";
+			if (not prefix.empty() and name.starts_with(prefix))
+				name.erase(0, prefix.size());
+		}
+	}
+
+	bool init(std::vector<::Gpu::gpu_info>& gpus, const std::string& shown_vendors) {
+		if (initialized) return false;
+
+		try {
+			smc = std::make_unique<Cpu::SMCConnection>();
+		}
+		catch (const std::runtime_error& error) {
+			Logger::debug("Intel Mac GPU: SMC unavailable: {}", error.what());
+		}
+
+		const auto active_gpu = active_gpu_name();
+		if (not active_gpu.empty())
+			Logger::info("Intel Mac GPU: AppleMuxControl active GPU is {}", active_gpu);
+
+		io_iterator_t iterator = 0;
+		auto matching = IOServiceMatching("IOAccelerator");
+		if (matching == nullptr
+		or IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator) != kIOReturnSuccess) {
+			Logger::warning("Intel Mac GPU: Failed to enumerate IOAccelerator devices");
+			return false;
+		}
+
+		io_registry_entry_t accelerator = 0;
+		while ((accelerator = IOIteratorNext(iterator)) != 0) {
+			if (not has_ancestor_named(accelerator, active_gpu)) {
+				IOObjectRelease(accelerator);
+				continue;
+			}
+
+			CFRef<CFTypeRef> primary_match(registry_property(accelerator, CFSTR("IOPCIPrimaryMatch")));
+			CFRef<CFTypeRef> pci_match(registry_property(accelerator, CFSTR("IOPCIMatch")));
+			const auto match = not string_value(primary_match.get()).empty()
+				? string_value(primary_match.get())
+				: string_value(pci_match.get());
+			const auto vendor = detect_vendor(match);
+			if (not vendor_enabled(vendor, shown_vendors)) {
+				IOObjectRelease(accelerator);
+				continue;
+			}
+
+			CFRef<CFTypeRef> model(inherited_property(accelerator, CFSTR("model")));
+			auto name = string_value(model.get());
+			if (name.empty())
+				name = vendor == Vendor::Intel ? "Intel GPU" : vendor == Vendor::Amd ? "AMD GPU" : "Intel Mac GPU";
+			trim_name(name, vendor);
+
+			auto stats = read_performance_statistics(accelerator);
+			if (not stats) {
+				Logger::debug("Intel Mac GPU: {} has no PerformanceStatistics", name);
+				IOObjectRelease(accelerator);
+				continue;
+			}
+
+			const auto gpu_index = gpus.size();
+			gpus.emplace_back();
+			::Gpu::gpu_names.push_back(name);
+			auto& gpu = gpus.back();
+			gpu.mem_total = read_memory_total(accelerator);
+
+			const auto has_usage = dictionary_has(stats.get(), CFSTR("Device Utilization %"))
+				or dictionary_has(stats.get(), CFSTR("GPU Activity(%)"));
+			const auto has_memory_used = dictionary_has(stats.get(), CFSTR("inUseVidMemoryBytes"))
+				or dictionary_has(stats.get(), CFSTR("inUseSysMemoryBytes"))
+				or dictionary_has(stats.get(), CFSTR("gartUsedBytes"));
+			const auto smc_power = vendor == Vendor::Intel ? smc_value("PCPG") : std::nullopt;
+			const auto smc_temp = vendor == Vendor::Intel ? smc_value("TCGC") : std::nullopt;
+			const auto has_power = dictionary_has(stats.get(), CFSTR("Total Power(W)")) or smc_power.has_value();
+			const auto has_temp = dictionary_has(stats.get(), CFSTR("Temperature(C)")) or smc_temp.has_value();
+
+			gpu.supported_functions = {
+				.gpu_utilization = has_usage,
+				.mem_utilization = gpu.mem_total > 0 and has_memory_used,
+				.gpu_clock = dictionary_has(stats.get(), CFSTR("Core Clock(MHz)")),
+				.mem_clock = dictionary_has(stats.get(), CFSTR("Memory Clock(MHz)")),
+				.pwr_usage = has_power,
+				.pwr_state = false,
+				.temp_info = has_temp,
+				.mem_total = gpu.mem_total > 0,
+				.mem_used = has_memory_used,
+				.pcie_txrx = false,
+				.encoder_utilization = false,
+				.decoder_utilization = false,
+			};
+			if (has_power) {
+				gpu.pwr_max_usage = 0;
+			}
+
+			Device device;
+			device.accelerator = accelerator;
+			device.gpu_index = gpu_index;
+			device.vendor = vendor;
+			device.name = name;
+			devices.push_back(std::move(device));
+			Logger::info("Intel Mac GPU: Found {} through IOAccelerator", name);
+		}
+		IOObjectRelease(iterator);
+
+		initialized = not devices.empty();
+		if (not initialized) smc.reset();
+		return initialized;
+	}
+
+	bool collect(std::vector<::Gpu::gpu_info>& gpus) {
+		if (not initialized) return false;
+
+		for (const auto& device : devices) {
+			if (device.gpu_index >= gpus.size()) continue;
+			auto stats = read_performance_statistics(device.accelerator);
+			if (not stats) continue;
+			auto& gpu = gpus[device.gpu_index];
+
+			if (gpu.supported_functions.gpu_utilization) {
+				if (const auto utilization = read_utilization(stats.get()); utilization.has_value())
+					gpu.gpu_percent.at("gpu-totals").push_back(utilization.value());
+			}
+
+			if (gpu.supported_functions.mem_used) {
+				gpu.mem_used = read_memory_used(stats.get(), device.vendor, gpu.mem_total);
+				if (gpu.mem_total > 0) {
+					const auto percent = std::clamp(
+						static_cast<long long>(std::llround(
+							static_cast<double>(gpu.mem_used) * 100.0 / static_cast<double>(gpu.mem_total)
+						)),
+						0ll,
+						100ll
+					);
+					gpu.mem_utilization_percent.push_back(percent);
+					gpu.gpu_percent.at("gpu-vram-totals").push_back(percent);
+				}
+			}
+
+			if (gpu.supported_functions.gpu_clock) {
+				if (const auto clock = dictionary_integer(stats.get(), CFSTR("Core Clock(MHz)"));
+				    clock.has_value() and clock.value() >= 0)
+					gpu.gpu_clock_speed = static_cast<unsigned int>(clock.value());
+			}
+			if (gpu.supported_functions.mem_clock) {
+				if (const auto clock = dictionary_integer(stats.get(), CFSTR("Memory Clock(MHz)"));
+				    clock.has_value() and clock.value() >= 0)
+					gpu.mem_clock_speed = clock.value();
+			}
+
+			if (gpu.supported_functions.pwr_usage) {
+				std::optional<double> power;
+				if (const auto watts = dictionary_integer(stats.get(), CFSTR("Total Power(W)")); watts.has_value())
+					power = static_cast<double>(watts.value());
+				else if (device.vendor == Vendor::Intel)
+					power = smc_value("PCPG");
+
+				if (power.has_value() and power.value() >= 0) {
+					gpu.pwr_usage = static_cast<long long>(std::llround(power.value() * 1000.0));
+					if (gpu.pwr_usage > gpu.pwr_max_usage) {
+						::Gpu::gpu_pwr_total_max += gpu.pwr_usage - gpu.pwr_max_usage;
+						gpu.pwr_max_usage = gpu.pwr_usage;
+					}
+					const auto power_scale = std::max(1ll, gpu.pwr_max_usage);
+					gpu.gpu_percent.at("gpu-pwr-totals").push_back(std::clamp(
+						static_cast<long long>(std::llround(
+							static_cast<double>(gpu.pwr_usage) * 100.0 / static_cast<double>(power_scale)
+						)),
+						0ll,
+						100ll
+					));
+				}
+			}
+
+			if (gpu.supported_functions.temp_info) {
+				std::optional<double> temperature;
+				if (const auto value = dictionary_integer(stats.get(), CFSTR("Temperature(C)")); value.has_value())
+					temperature = static_cast<double>(value.value());
+				else if (device.vendor == Vendor::Intel)
+					temperature = smc_value("TCGC");
+				if (temperature.has_value() and temperature.value() > 0 and temperature.value() < 150)
+					gpu.temp.push_back(static_cast<long long>(std::llround(temperature.value())));
+			}
+		}
+		return true;
+	}
+
+	bool shutdown() {
+		if (not initialized and devices.empty()) return false;
+		devices.clear();
+		smc.reset();
+		initialized = false;
+		return true;
+	}
+} // namespace IntelMac::Gpu
+
+#elif defined(__APPLE__) && defined(GPU_SUPPORT)
+
+namespace IntelMac::Gpu {
+	bool init(std::vector<::Gpu::gpu_info>&, const std::string&) { return false; }
+	bool collect(std::vector<::Gpu::gpu_info>&) { return false; }
+	bool shutdown() { return false; }
+}
+
+#endif
+
+#if defined(__APPLE__) && defined(GPU_SUPPORT)
+namespace Gpu::IntelMac {
+	bool shutdown() {
+		return ::IntelMac::Gpu::shutdown();
+	}
+}
+#endif

--- a/src/osx/intel_mac.hpp
+++ b/src/osx/intel_mac.hpp
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <optional>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#if defined(GPU_SUPPORT)
+#include "../btop_shared.hpp"
+#endif
+
+namespace IntelMac {
+
+	inline constexpr auto cpu_frequency_path = "/var/run/btop-cpu-frequency-mhz";
+	inline constexpr unsigned int cpu_frequency_sample_interval_ms = 1000;
+	inline constexpr unsigned int cpu_frequency_stale_intervals = 3;
+	inline constexpr std::array<std::string_view, 3> cpu_package_temperature_keys = {
+		"TC0F",
+		"TC0D",
+		"TC0E",
+	};
+
+	inline auto format_cpu_title(
+		const std::string_view name,
+		const std::size_t physical_count
+	) -> std::string {
+		return std::string{name} + " " + std::to_string(physical_count) + "C";
+	}
+
+	inline auto physical_core_map_from_apic_ids(
+		std::vector<unsigned int> apic_ids,
+		const std::size_t physical_count
+	) -> std::vector<std::size_t> {
+		if (physical_count == 0 or apic_ids.empty() or apic_ids.size() % physical_count != 0)
+			return {};
+
+		const auto threads_per_core = apic_ids.size() / physical_count;
+		if ((threads_per_core & (threads_per_core - 1)) != 0) return {};
+
+		// XNU numbers processor_array slots in ascending local APIC-ID order,
+		// regardless of the CPU0..CPUn device-tree node order.
+		std::ranges::sort(apic_ids);
+		if (std::ranges::unique(apic_ids).begin() != apic_ids.end()) return {};
+
+		// Intel reserves the low APIC-ID bits for SMT siblings. Compress the
+		// remaining, potentially sparse, core IDs into btop's C0..Cn labels.
+		std::vector<unsigned int> core_ids;
+		core_ids.reserve(apic_ids.size());
+		for (const auto apic_id : apic_ids)
+			core_ids.push_back(apic_id / threads_per_core);
+
+		auto unique_core_ids = core_ids;
+		std::ranges::sort(unique_core_ids);
+		const auto duplicate_start = std::ranges::unique(unique_core_ids).begin();
+		unique_core_ids.erase(duplicate_start, unique_core_ids.end());
+		if (unique_core_ids.size() != physical_count) return {};
+
+		std::vector<std::size_t> mapping;
+		mapping.reserve(core_ids.size());
+		std::vector<std::size_t> thread_counts(physical_count, 0);
+		for (const auto core_id : core_ids) {
+			const auto physical = static_cast<std::size_t>(
+				std::ranges::lower_bound(unique_core_ids, core_id) - unique_core_ids.begin()
+			);
+			mapping.push_back(physical);
+			++thread_counts[physical];
+		}
+		if (std::ranges::any_of(thread_counts, [threads_per_core](const auto count) {
+			return count != threads_per_core;
+		})) return {};
+		return mapping;
+	}
+
+	inline auto physical_core_map_from_xnu_order(
+		const std::size_t logical_count,
+		const std::size_t physical_count
+	) -> std::vector<std::size_t> {
+		if (physical_count == 0 or logical_count == 0 or logical_count % physical_count != 0)
+			return {};
+
+		const auto threads_per_core = logical_count / physical_count;
+		std::vector<std::size_t> mapping(logical_count);
+		for (std::size_t logical = 0; logical < logical_count; ++logical)
+			mapping[logical] = logical / threads_per_core;
+		return mapping;
+	}
+
+	inline auto physical_core_for_layout_slot(
+		const std::size_t slot,
+		const std::size_t column_count,
+		const std::size_t physical_count
+	) -> std::size_t {
+		if (column_count == 0 or physical_count == 0) return 0;
+		const auto row_count = (physical_count + column_count - 1) / column_count;
+		const auto populated_columns = (physical_count + row_count - 1) / row_count;
+		return (slot % row_count) * populated_columns + slot / row_count;
+	}
+
+	inline auto aggregate_physical_usage(
+		const std::vector<long long>& total_deltas,
+		const std::vector<long long>& idle_deltas,
+		const std::size_t physical_count,
+		const std::vector<std::size_t>& logical_to_physical = {}
+	) -> std::vector<long long> {
+		if (physical_count == 0) return {};
+
+		std::vector<long long> totals(physical_count, 0);
+		std::vector<long long> idles(physical_count, 0);
+		const auto count = std::min(total_deltas.size(), idle_deltas.size());
+		for (std::size_t logical = 0; logical < count; ++logical) {
+			const auto physical = logical < logical_to_physical.size()
+				? logical_to_physical[logical]
+				: logical % physical_count;
+			if (physical >= physical_count) continue;
+			totals[physical] += std::max(0ll, total_deltas[logical]);
+			idles[physical] += std::max(0ll, idle_deltas[logical]);
+		}
+
+		std::vector<long long> result(physical_count, 0);
+		for (std::size_t physical = 0; physical < physical_count; ++physical) {
+			if (totals[physical] > 0) {
+				result[physical] = std::clamp(
+					static_cast<long long>(std::llround(
+						static_cast<double>(totals[physical] - std::min(totals[physical], idles[physical]))
+						* 100.0 / static_cast<double>(totals[physical])
+					)),
+					0ll,
+					100ll
+				);
+			}
+		}
+		return result;
+	}
+
+	inline auto parse_powermetrics_cpu_mhz(const std::string_view line) -> std::optional<double> {
+		constexpr std::string_view prefix = "CPU Average frequency as fraction of nominal:";
+		const auto prefix_position = line.find(prefix);
+		if (prefix_position == std::string_view::npos) return std::nullopt;
+
+		const auto value_start = line.find('(', prefix_position + prefix.size());
+		const auto value_end = value_start == std::string_view::npos
+			? std::string_view::npos
+			: line.find(" Mhz)", value_start + 1);
+		if (value_start == std::string_view::npos or value_end == std::string_view::npos)
+			return std::nullopt;
+
+		const std::string value(line.substr(value_start + 1, value_end - value_start - 1));
+		char* parsed_end = nullptr;
+		const auto mhz = std::strtod(value.c_str(), &parsed_end);
+		if (parsed_end != value.c_str() + value.size() or not std::isfinite(mhz) or mhz <= 0.0)
+			return std::nullopt;
+		return mhz;
+	}
+
+	inline auto format_cpu_frequency_ghz(const double mhz) -> std::string {
+		if (not std::isfinite(mhz) or mhz <= 0.0) return "N/A GHz";
+		char output[16]{};
+		std::snprintf(output, sizeof(output), "%.2fGHz", mhz / 1000.0);
+		return output;
+	}
+
+	inline auto cpu_frequency_sample_is_fresh(
+		const std::time_t now,
+		const std::time_t modified
+	) -> bool {
+		constexpr auto max_age_seconds =
+			(cpu_frequency_sample_interval_ms * cpu_frequency_stale_intervals + 999) / 1000;
+		return modified <= now and now - modified <= max_age_seconds;
+	}
+
+#if defined(GPU_SUPPORT)
+	namespace Gpu {
+		bool init(std::vector<::Gpu::gpu_info>& gpus, const std::string& shown_vendors);
+		bool collect(std::vector<::Gpu::gpu_info>& gpus);
+		bool shutdown();
+	}
+#endif
+
+} // namespace IntelMac

--- a/src/osx/smc.cpp
+++ b/src/osx/smc.cpp
@@ -17,6 +17,10 @@ tab-size = 4
 */
 
 #include "smc.hpp"
+#include "intel_mac.hpp"
+
+#include <cmath>
+#include <cstring>
 
 static constexpr size_t MaxIndexCount = sizeof("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ") - 1;
 static constexpr const char *KeyIndexes = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -46,6 +50,21 @@ static void _ultostr(char *str, UInt32 val) {
 
 namespace Cpu {
 
+	static auto bytes_to_uint16(const SMCVal_t& val) -> uint16_t {
+		return static_cast<uint16_t>(
+			(static_cast<uint16_t>(static_cast<unsigned char>(val.bytes[0])) << 8)
+			| static_cast<unsigned char>(val.bytes[1])
+		);
+	}
+
+	static auto fixed_point_fraction_bits(const char type[5]) -> std::optional<int> {
+		if ((type[0] != 's' and type[0] != 'f') or type[1] != 'p') return std::nullopt;
+		const auto digit = type[3];
+		if (digit >= '0' and digit <= '9') return digit - '0';
+		if (digit >= 'a' and digit <= 'f') return digit - 'a' + 10;
+		return std::nullopt;
+	}
+
 	SMCConnection::SMCConnection() {
 		CFMutableDictionaryRef matchingDictionary = IOServiceMatching("AppleSMC");
 		result = IOServiceGetMatchingServices(0, matchingDictionary, &iterator);
@@ -69,20 +88,55 @@ namespace Cpu {
 		IOServiceClose(conn);
 	}
 
-	long long SMCConnection::getSMCTemp(char *key) {
-		SMCVal_t val;
-		kern_return_t result;
-		result = SMCReadKey(key, &val);
-		if (result == kIOReturnSuccess) {
-			if (val.dataSize > 0) {
-				if (strcmp(val.dataType, DATATYPE_SP78) == 0) {
-					// convert sp78 value to temperature
-					int intValue = val.bytes[0] * 256 + (unsigned char)val.bytes[1];
-					return static_cast<long long>(intValue / 256.0);
-				}
-			}
+	std::optional<double> SMCConnection::getValue(const char *key) {
+		if (key == nullptr or strlen(key) != 4) return std::nullopt;
+
+		UInt32Char_t mutable_key{};
+		memcpy(mutable_key, key, 4);
+		SMCVal_t val{};
+		if (SMCReadKey(mutable_key, &val) != kIOReturnSuccess or val.dataSize == 0)
+			return std::nullopt;
+
+		double value = 0;
+		if (strcmp(val.dataType, DATATYPE_FLT) == 0 and val.dataSize >= sizeof(float)) {
+			float raw = 0;
+			memcpy(&raw, val.bytes, sizeof(raw));
+			value = raw;
 		}
-		return -1;
+		else if (strcmp(val.dataType, DATATYPE_FPE2) == 0 and val.dataSize >= 2) {
+			value = static_cast<double>(bytes_to_uint16(val)) / 4.0;
+		}
+		else if (const auto fraction_bits = fixed_point_fraction_bits(val.dataType);
+		         fraction_bits.has_value() and val.dataSize >= 2) {
+			const auto divisor = static_cast<double>(uint64_t{1} << fraction_bits.value());
+			value = val.dataType[0] == 's'
+				? static_cast<double>(static_cast<int16_t>(bytes_to_uint16(val))) / divisor
+				: static_cast<double>(bytes_to_uint16(val)) / divisor;
+		}
+		else if (strcmp(val.dataType, DATATYPE_UINT8) == 0) {
+			value = static_cast<unsigned char>(val.bytes[0]);
+		}
+		else if (strcmp(val.dataType, DATATYPE_UINT16) == 0 and val.dataSize >= 2) {
+			value = bytes_to_uint16(val);
+		}
+		else if (strcmp(val.dataType, DATATYPE_UINT32) == 0 and val.dataSize >= 4) {
+			value = static_cast<double>(
+				(static_cast<uint32_t>(static_cast<unsigned char>(val.bytes[0])) << 24)
+				| (static_cast<uint32_t>(static_cast<unsigned char>(val.bytes[1])) << 16)
+				| (static_cast<uint32_t>(static_cast<unsigned char>(val.bytes[2])) << 8)
+				| static_cast<unsigned char>(val.bytes[3])
+			);
+		}
+		else {
+			return std::nullopt;
+		}
+
+		return std::isfinite(value) ? std::optional<double>{value} : std::nullopt;
+	}
+
+	long long SMCConnection::getSMCTemp(const char *key) {
+		const auto value = getValue(key);
+		return value.has_value() ? static_cast<long long>(std::llround(value.value())) : -1;
 	}
 
 	// core means physical core in SMC, while in core map it's cpu threads :-/ Only an issue on hackintosh?
@@ -91,17 +145,23 @@ namespace Cpu {
 	// no Mac models with more than 18 threads are released, so no problem so far
 	// according to VirtualSMC docs (hackintosh fake SMC) the enumeration follows with alphabetic chars - not implemented yet here (nor in VirtualSMC)
 	long long SMCConnection::getTemp(int core) {
-		char key[] = SMC_KEY_CPU_TEMP;
-		if (core >= 0) {
-			if ((size_t)core > MaxIndexCount) {
-				return -1;
+		if (core < 0) {
+			// TC0P is CPU proximity, not package temperature. Prefer the
+			// available PECI/die value and fail closed if none is published.
+			for (const auto key : ::IntelMac::cpu_package_temperature_keys) {
+				const auto result = getSMCTemp(key.data());
+				if (result != -1) return result;
 			}
-			snprintf(key, 5, "TC%1cc", KeyIndexes[core]);
+			return -1;
 		}
+
+		if ((size_t)core > MaxIndexCount) return -1;
+		char key[5]{};
+		snprintf(key, sizeof(key), "TC%1cc", KeyIndexes[core]);
 		long long result = getSMCTemp(key);
 		if (result == -1) {
 			// try again with C
-			snprintf(key, 5, "TC%1cC", KeyIndexes[core]);
+			snprintf(key, sizeof(key), "TC%1cC", KeyIndexes[core]);
 			result = getSMCTemp(key);
 		}
 		return result;

--- a/src/osx/smc.hpp
+++ b/src/osx/smc.hpp
@@ -24,6 +24,7 @@ tab-size = 4
 #include <IOKit/ps/IOPSKeys.h>
 #include <IOKit/ps/IOPowerSources.h>
 
+#include <optional>
 #include <stdexcept>
 
 #define VERSION "0.01"
@@ -42,13 +43,9 @@ tab-size = 4
 #define DATATYPE_UINT16 "ui16"
 #define DATATYPE_UINT32 "ui32"
 #define DATATYPE_SP78 "sp78"
+#define DATATYPE_FLT "flt "
 
 // key values
-#define SMC_KEY_CPU_TEMP "TC0P" // proximity temp?
-#define SMC_KEY_CPU_DIODE_TEMP "TC0D" // diode temp?
-#define SMC_KEY_CPU_DIE_TEMP "TC0F" // die temp?
-#define SMC_KEY_CPU1_TEMP "TC1C"
-#define SMC_KEY_CPU2_TEMP "TC2C"  // etc
 #define SMC_KEY_FAN0_RPM_CUR "F0Ac"
 
 typedef struct {
@@ -103,10 +100,11 @@ namespace Cpu {
 		virtual ~SMCConnection();
 
 		long long getTemp(int core);
+		std::optional<double> getValue(const char *key);
 
 	   private:
 		kern_return_t SMCReadKey(UInt32Char_t key, SMCVal_t *val);
-		long long getSMCTemp(char *key);
+		long long getSMCTemp(const char *key);
 		kern_return_t SMCCall(int index, SMCKeyData_t *inputStructure, SMCKeyData_t *outputStructure);
 
 		io_connect_t conn;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(libbtop_test)
 target_include_directories(libbtop_test PUBLIC ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries(libbtop_test libbtop GTest::gtest_main)
 
-add_executable(btop_test cpu_names.cpp tools.cpp)
+add_executable(btop_test cpu_names.cpp intel_mac.cpp tools.cpp)
 target_link_libraries(btop_test libbtop_test)
 
 include(GoogleTest)

--- a/tests/intel_mac.cpp
+++ b/tests/intel_mac.cpp
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "osx/intel_mac.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(intel_mac_cpu, selects_package_die_temperature_without_proximity_fallback) {
+	// Given Intel SMC temperature capabilities, when package keys are selected,
+	// then PECI/die sensors are preferred and TC0P proximity is never presented as package temperature.
+	EXPECT_EQ(IntelMac::cpu_package_temperature_keys.at(0), "TC0F");
+	EXPECT_EQ(IntelMac::cpu_package_temperature_keys.at(1), "TC0D");
+	EXPECT_EQ(IntelMac::cpu_package_temperature_keys.at(2), "TC0E");
+	EXPECT_EQ(
+		std::ranges::find(IntelMac::cpu_package_temperature_keys, "TC0P"),
+		IntelMac::cpu_package_temperature_keys.end()
+	);
+}
+
+TEST(intel_mac_cpu, titles_the_cpu_with_physical_cores_only) {
+	// Given runtime-discovered physical core counts, when the CPU title is built,
+	// then it reports cores without presenting logical threads as CPU units.
+	EXPECT_EQ(IntelMac::format_cpu_title("Intel CPU", 4), "Intel CPU 4C");
+	EXPECT_EQ(IntelMac::format_cpu_title("Intel CPU", 6), "Intel CPU 6C");
+}
+
+TEST(intel_mac_cpu, maps_xnu_processor_slots_from_sorted_apic_topology) {
+	// Given APIC IDs in device-tree or arbitrary enumeration order, when mapped to XNU processor slots,
+	// then adjacent APIC siblings land on the same physical core instead of becoming alternating rows.
+	EXPECT_EQ(
+		IntelMac::physical_core_map_from_apic_ids({0, 2, 4, 6, 1, 3, 5, 7}, 4),
+		(std::vector<std::size_t>{0, 0, 1, 1, 2, 2, 3, 3})
+	);
+	EXPECT_EQ(
+		IntelMac::physical_core_map_from_apic_ids({4, 0, 6, 2, 5, 1, 7, 3}, 4),
+		(std::vector<std::size_t>{0, 0, 1, 1, 2, 2, 3, 3})
+	);
+	EXPECT_TRUE(IntelMac::physical_core_map_from_apic_ids({0, 0, 0, 0}, 2).empty());
+}
+
+TEST(intel_mac_cpu, falls_back_to_adjacent_xnu_processor_slots) {
+	// Given an Intel Mac where device-tree APIC IDs are unavailable, when the fallback is built,
+	// then XNU-adjacent SMT siblings are grouped without a model-specific topology table.
+	EXPECT_EQ(
+		IntelMac::physical_core_map_from_xnu_order(8, 4),
+		(std::vector<std::size_t>{0, 0, 1, 1, 2, 2, 3, 3})
+	);
+	EXPECT_EQ(
+		IntelMac::physical_core_map_from_xnu_order(12, 6),
+		(std::vector<std::size_t>{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5})
+	);
+	EXPECT_TRUE(IntelMac::physical_core_map_from_xnu_order(7, 4).empty());
+}
+
+TEST(intel_mac_cpu, maps_other_intel_mac_core_counts_without_model_tables) {
+	// Given six-core SMT and non-SMT topologies, when mapped,
+	// then runtime counts and APIC IDs alone produce the physical-core labels.
+	EXPECT_EQ(
+		IntelMac::physical_core_map_from_apic_ids(
+			{0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11},
+			6
+		),
+		(std::vector<std::size_t>{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5})
+	);
+	EXPECT_EQ(
+		IntelMac::physical_core_map_from_apic_ids({0, 2, 4, 6, 8, 10}, 6),
+		(std::vector<std::size_t>{0, 1, 2, 3, 4, 5})
+	);
+}
+
+TEST(intel_mac_cpu, lays_out_four_physical_cores_in_reading_order) {
+	// Given a two-column CPU panel, when its column-major drawing slots are assigned,
+	// then the visible rows read C0/C1 followed by C2/C3.
+	EXPECT_EQ(IntelMac::physical_core_for_layout_slot(0, 2, 4), 0);
+	EXPECT_EQ(IntelMac::physical_core_for_layout_slot(1, 2, 4), 2);
+	EXPECT_EQ(IntelMac::physical_core_for_layout_slot(2, 2, 4), 1);
+	EXPECT_EQ(IntelMac::physical_core_for_layout_slot(3, 2, 4), 3);
+	EXPECT_EQ(IntelMac::physical_core_for_layout_slot(4, 4, 6), 2);
+	EXPECT_EQ(IntelMac::physical_core_for_layout_slot(5, 4, 6), 5);
+}
+
+TEST(intel_mac_cpu, aggregates_logical_cpu_ticks_into_physical_usage) {
+	// Given complementary load on each pair of SMT siblings,
+	// when usage is aggregated, then btop exposes four physical-core percentages.
+	const std::vector<long long> totals(8, 100);
+	const std::vector<long long> idles = {20, 80, 40, 60, 60, 40, 80, 20};
+
+	EXPECT_EQ(
+		IntelMac::aggregate_physical_usage(
+			totals,
+			idles,
+			4,
+			{0, 0, 1, 1, 2, 2, 3, 3}
+		),
+		(std::vector<long long>{50, 50, 50, 50})
+	);
+}
+
+TEST(intel_mac_cpu, handles_zero_tick_intervals_without_dividing_by_zero) {
+	// Given a scheduler interval with no tick movement,
+	// when usage is aggregated, then every physical core reports zero.
+	EXPECT_EQ(
+		IntelMac::aggregate_physical_usage({0, 0, 0, 0}, {0, 0, 0, 0}, 4),
+		(std::vector<long long>{0, 0, 0, 0})
+	);
+}
+
+TEST(intel_mac_cpu, parses_the_hardware_frequency_reported_by_powermetrics) {
+	// Given package and per-thread powermetrics output, when parsed,
+	// then only the package-average hardware frequency is accepted.
+	const auto package = IntelMac::parse_powermetrics_cpu_mhz(
+		"CPU Average frequency as fraction of nominal: 128.15% (3460.07 Mhz)"
+	);
+	EXPECT_TRUE(package.has_value());
+	EXPECT_DOUBLE_EQ(package.value(), 3460.07);
+	EXPECT_FALSE(IntelMac::parse_powermetrics_cpu_mhz(
+		"CPU 0 Average frequency as fraction of nominal: 131.00% (3537.00 Mhz)"
+	).has_value());
+}
+
+TEST(intel_mac_cpu, formats_frequency_in_ghz_without_claiming_a_false_value) {
+	// Given a valid hardware sample or no sample, when rendered,
+	// then the field carries the GHz unit and never falls back to a load-derived estimate.
+	EXPECT_EQ(IntelMac::format_cpu_frequency_ghz(3460.07), "3.46GHz");
+	EXPECT_EQ(IntelMac::format_cpu_frequency_ghz(0.0), "N/A GHz");
+}
+
+TEST(intel_mac_cpu, expires_frequency_samples_by_the_helper_sampling_interval) {
+	// Given the helper's production cadence, when sample age is checked,
+	// then three missed samples are tolerated without coupling freshness to btop's display interval.
+	const std::time_t now = 100;
+	EXPECT_TRUE(IntelMac::cpu_frequency_sample_is_fresh(now, now));
+	EXPECT_TRUE(IntelMac::cpu_frequency_sample_is_fresh(now, now - 3));
+	EXPECT_FALSE(IntelMac::cpu_frequency_sample_is_fresh(now, now - 4));
+	EXPECT_FALSE(IntelMac::cpu_frequency_sample_is_fresh(now, now + 1));
+}


### PR DESCRIPTION
Closes #1763.
Related to #692.

## Why

Intel macOS currently lacks native Intel/AMD GPU monitoring, presents scheduler slots without a physical-core topology mapping, and can only obtain nominal CPU frequency through the ordinary sysctl interface. These gaps lead to duplicate inactive-GPU rows, logical threads being presented as cores, and a fixed rather than current frequency.

## What changed

- Discover physical/logical CPU topology and APIC IDs at runtime, then aggregate scheduler ticks into physical-core rows.
- Report CPU package/die temperature and CPU package power from SMC values.
- Add an Intel Mac IOAccelerator collector for driver-published utilization, clocks, temperature, power, and memory values.
- Use `AppleMuxControl.ActiveGPU` to select the active adapter on switchable-GPU systems.
- Add an optional launch daemon that runs a fixed `powermetrics` command for package-average active frequency; btop displays `N/A GHz` when a sample is unavailable or stale.
- Enable GPU support for macOS x86_64 in Make and CMake builds.

## Portability and privacy

The collector contains no Mac model, board identifier, fixed core count, logical-CPU order, APIC topology, or GPU model table. Hardware topology and supported GPU fields are discovered from macOS at runtime. SMC keys, IOKit property names, and PCI vendor IDs in the implementation are protocol identifiers rather than machine-specific values.

## Privilege boundary

btop remains unprivileged. The optional frequency helper has a fixed executable and argument list, an empty environment, and atomically publishes a root-owned runtime sample using `O_NOFOLLOW`. The helper is installed separately and can be removed independently.

## Validation

- `make clean && make -j4`
- `make frequency-helper`
- `plutil -lint src/osx/helpers/com.btop.cpu-frequency.plist`
- Intel Mac unit suite: 11/11 passed
- `git diff --check`

CMake was not available in the local environment, so the CMake build is left to the pull-request checks.

## AI disclosure

Portions of this implementation were developed with AI assistance. The resulting code was reviewed, built, tested, and checked for model-specific assumptions and private machine data before submission.
