### PR TITLE
[AI generated] fix(osx): hide Time Machine snapshot mounts

### DIFF
--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1305,6 +1305,10 @@ namespace Mem {
 				std::error_code ec;
 				string mountpoint = stfs[i].f_mntonname;
 				string dev = stfs[i].f_mntfromname;
+
+				//? Skip synthetic Time Machine snapshot mounts
+				if (dev.starts_with("com.apple.TimeMachine.")) continue;
+
 				mapping[dev] = mountpoint;
 
 				if (string(stfs[i].f_fstypename) == "autofs") {


### PR DESCRIPTION
## Why

Fixes #1765.

macOS exposes every mounted Time Machine backup snapshot through `getmntinfo()`. btop currently treats each snapshot as a separate disk, so browsing an external Time Machine destination can add dozens of duplicate rows. A local snapshot also appears as a duplicate `Macintosh HD - Data` row.

These synthetic mounts consistently use an `f_mntfromname` beginning with `com.apple.TimeMachine.`, while the physical destination remains a normal `/dev/disk...` mount.

## Change

Skip devices in Apple's `com.apple.TimeMachine.` namespace in the macOS disk collector before adding them to the device-to-mountpoint map.

This hides external and local Time Machine snapshots while retaining the physical backup destination and the real data volume.

## Verification

- `make -j8` on macOS 26.6 arm64
- Ran the resulting `bin/btop` while both external backup snapshots and a local `Macintosh HD - Data` snapshot were mounted
- Verified the disk panel showed only the real `Data` volume and physical `Crucial X8` Time Machine destination
- `git diff --check`

## AI disclosure

This contribution contains AI-generated code and is marked `[AI generated]` in accordance with `CONTRIBUTING.md`. The change was reviewed and exercised against the live mount state described in #1765.
