### PR TITLE
[AI generated]feat: add a experimental intel levelzero api based backend for gpu info collection.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(BTOP_STATIC "Link btop statically" OFF)
 option(BTOP_GPU "Enable GPU support" ON)
-option(BTOP_GPU_INTEL_USE_LEVELZERO "Use Level Zero instead of the legacy PMU backend for Intel GPUs" OFF)
+option(USE_LEVELZERO "Use Level Zero instead of the legacy PMU backend for Intel GPUs" OFF)
 cmake_dependent_option(BTOP_RSMI_STATIC "Link statically to ROCm SMI" OFF "BTOP_GPU" OFF)
 
 # Enable LTO in release builds by default
@@ -79,8 +79,8 @@ elseif(LINUX)
   target_sources(libbtop PRIVATE src/linux/btop_collect.cpp)
   if(BTOP_GPU)
     add_subdirectory(src/linux/intel_gpu_top)
-    if(BTOP_GPU_INTEL_USE_LEVELZERO)
-      target_compile_definitions(libbtop PRIVATE BTOP_GPU_INTEL_USE_LEVELZERO)
+    if(USE_LEVELZERO)
+      target_compile_definitions(libbtop PRIVATE USE_LEVELZERO)
       target_link_libraries(libbtop ze_loader)
     endif()
   endif()
@@ -95,7 +95,7 @@ execute_process(
   OUTPUT_VARIABLE GIT_COMMIT
   OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
 set(CONFIGURE_COMMAND
-    "cmake -DBTOP_STATIC=${BTOP_STATIC} -DBTOP_GPU=${BTOP_GPU} -DBTOP_GPU_INTEL_USE_LEVELZERO=${BTOP_GPU_INTEL_USE_LEVELZERO}"
+    "cmake -DBTOP_STATIC=${BTOP_STATIC} -DBTOP_GPU=${BTOP_GPU} -DUSE_LEVELZERO=${USE_LEVELZERO}"
 )
 get_filename_component(CXX_COMPILER_BASENAME "${CMAKE_CXX_COMPILER}" NAME)
 set(COMPILER "${CXX_COMPILER_BASENAME}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(BTOP_STATIC "Link btop statically" OFF)
 option(BTOP_GPU "Enable GPU support" ON)
+option(BTOP_GPU_INTEL_USE_LEVELZERO "Use Level Zero instead of the legacy PMU backend for Intel GPUs" OFF)
 cmake_dependent_option(BTOP_RSMI_STATIC "Link statically to ROCm SMI" OFF "BTOP_GPU" OFF)
 
 # Enable LTO in release builds by default
@@ -78,6 +79,10 @@ elseif(LINUX)
   target_sources(libbtop PRIVATE src/linux/btop_collect.cpp)
   if(BTOP_GPU)
     add_subdirectory(src/linux/intel_gpu_top)
+    if(BTOP_GPU_INTEL_USE_LEVELZERO)
+      target_compile_definitions(libbtop PRIVATE BTOP_GPU_INTEL_USE_LEVELZERO)
+      target_link_libraries(libbtop ze_loader)
+    endif()
   endif()
 else()
   message(FATAL_ERROR "${CMAKE_SYSTEM_NAME} is not supported")
@@ -90,7 +95,7 @@ execute_process(
   OUTPUT_VARIABLE GIT_COMMIT
   OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
 set(CONFIGURE_COMMAND
-    "cmake -DBTOP_STATIC=${BTOP_STATIC} -DBTOP_GPU=${BTOP_GPU}"
+    "cmake -DBTOP_STATIC=${BTOP_STATIC} -DBTOP_GPU=${BTOP_GPU} -DBTOP_GPU_INTEL_USE_LEVELZERO=${BTOP_GPU_INTEL_USE_LEVELZERO}"
 )
 get_filename_component(CXX_COMPILER_BASENAME "${CMAKE_CXX_COMPILER}" NAME)
 set(COMPILER "${CXX_COMPILER_BASENAME}")

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,8 @@ endif
 override PLATFORM_LC := $(shell echo $(PLATFORM) | tr '[:upper:]' '[:lower:]')
 
 #? GPU Support
+BTOP_GPU_INTEL_USE_LEVELZERO ?= false
+
 ifeq ($(PLATFORM_LC)$(ARCH),linuxx86_64)
 	ifneq ($(STATIC),true)
 		GPU_SUPPORT := true
@@ -108,6 +110,9 @@ endif
 
 ifeq ($(GPU_SUPPORT),true)
 	override ADDFLAGS += -DGPU_SUPPORT
+endif
+ifeq ($(INTEL_GPU_SUPPORT)$(BTOP_GPU_INTEL_USE_LEVELZERO),truetrue)
+	override ADDFLAGS += -DBTOP_GPU_INTEL_USE_LEVELZERO
 endif
 
 #? Compiler and Linker
@@ -213,7 +218,7 @@ endif
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null || true)
 CONFIGURE_COMMAND := $(MAKE) STATIC=$(STATIC)
 ifeq ($(PLATFORM_LC),linux)
-	CONFIGURE_COMMAND +=  GPU_SUPPORT=$(GPU_SUPPORT) RSMI_STATIC=$(RSMI_STATIC)
+	CONFIGURE_COMMAND +=  GPU_SUPPORT=$(GPU_SUPPORT) RSMI_STATIC=$(RSMI_STATIC) BTOP_GPU_INTEL_USE_LEVELZERO=$(BTOP_GPU_INTEL_USE_LEVELZERO)
 endif
 
 #? The Directories, Source, Includes, Objects and Binary
@@ -253,6 +258,9 @@ ifeq ($(GPU_SUPPORT)$(INTEL_GPU_SUPPORT),truetrue)
 	OBJECTS += $(IGT_OBJECTS)
 	SHOW_CC_INFO = false
 	CC_VERSION := $(shell $(CC) -dumpfullversion -dumpversion || echo 0)
+	ifeq ($(BTOP_GPU_INTEL_USE_LEVELZERO),true)
+		override LDFLAGS += -lze_loader
+	endif
 else
 	SHOW_CC_INFO = true
 endif

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ endif
 override PLATFORM_LC := $(shell echo $(PLATFORM) | tr '[:upper:]' '[:lower:]')
 
 #? GPU Support
-BTOP_GPU_INTEL_USE_LEVELZERO ?= false
+USE_LEVELZERO ?= false
 
 ifeq ($(PLATFORM_LC)$(ARCH),linuxx86_64)
 	ifneq ($(STATIC),true)
@@ -111,8 +111,8 @@ endif
 ifeq ($(GPU_SUPPORT),true)
 	override ADDFLAGS += -DGPU_SUPPORT
 endif
-ifeq ($(INTEL_GPU_SUPPORT)$(BTOP_GPU_INTEL_USE_LEVELZERO),truetrue)
-	override ADDFLAGS += -DBTOP_GPU_INTEL_USE_LEVELZERO
+ifeq ($(INTEL_GPU_SUPPORT)$(USE_LEVELZERO),truetrue)
+	override ADDFLAGS += -DUSE_LEVELZERO
 endif
 
 #? Compiler and Linker
@@ -218,7 +218,7 @@ endif
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null || true)
 CONFIGURE_COMMAND := $(MAKE) STATIC=$(STATIC)
 ifeq ($(PLATFORM_LC),linux)
-	CONFIGURE_COMMAND +=  GPU_SUPPORT=$(GPU_SUPPORT) RSMI_STATIC=$(RSMI_STATIC) BTOP_GPU_INTEL_USE_LEVELZERO=$(BTOP_GPU_INTEL_USE_LEVELZERO)
+	CONFIGURE_COMMAND +=  GPU_SUPPORT=$(GPU_SUPPORT) RSMI_STATIC=$(RSMI_STATIC) USE_LEVELZERO=$(USE_LEVELZERO)
 endif
 
 #? The Directories, Source, Includes, Objects and Binary
@@ -258,7 +258,7 @@ ifeq ($(GPU_SUPPORT)$(INTEL_GPU_SUPPORT),truetrue)
 	OBJECTS += $(IGT_OBJECTS)
 	SHOW_CC_INFO = false
 	CC_VERSION := $(shell $(CC) -dumpfullversion -dumpversion || echo 0)
-	ifeq ($(BTOP_GPU_INTEL_USE_LEVELZERO),true)
+	ifeq ($(USE_LEVELZERO),true)
 		override LDFLAGS += -lze_loader
 	endif
 else

--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ See [GPU compatibility](#gpu-compatibility) section for more about compiling wit
    | `DEBUG=true`                    | Sets OPTFLAGS to `-O0 -g` and enables more verbose debug logging        |
    | `ARCH=<architecture>`           | To manually set the target architecture                                 |
    | `GPU_SUPPORT=<true\|false>`     | Enable/disable GPU support (Enabled by default on X86_64 Linux)         |
+   | `BTOP_GPU_INTEL_USE_LEVELZERO=true` | Use Level Zero instead of the legacy PMU backend for Intel GPUs     |
    | `RSMI_STATIC=true`              | To statically link the ROCm SMI library used for querying AMDGPU        |
    | `ADDFLAGS=<flags>`              | For appending flags to both compiler and linker                         |
    | `CXX=<compiler>`                | Manually set which compiler to use                                       |
@@ -620,6 +621,7 @@ See [GPU compatibility](#gpu-compatibility) section for more about compiling wit
    | `-DBTOP_STATIC=<ON\|OFF>`       | Enables static linking (OFF by default)                                 |
    | `-DBTOP_LTO=<ON\|OFF>`          | Enables link time optimization (ON by default)                          |
    | `-DBTOP_GPU=<ON\|OFF>`          | Enable GPU support (ON by default)                                      |
+   | `-DBTOP_GPU_INTEL_USE_LEVELZERO=<ON\|OFF>` | Use Level Zero instead of the legacy Intel PMU backend (OFF by default) |
    | `-DBTOP_RSMI_STATIC=<ON\|OFF>`  | Build and link the ROCm SMI library statically (OFF by default)         |
    | `-DCMAKE_INSTALL_PREFIX=<path>` | The installation prefix ('/usr/local' by default)                       |
 

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ See [GPU compatibility](#gpu-compatibility) section for more about compiling wit
    | `DEBUG=true`                    | Sets OPTFLAGS to `-O0 -g` and enables more verbose debug logging        |
    | `ARCH=<architecture>`           | To manually set the target architecture                                 |
    | `GPU_SUPPORT=<true\|false>`     | Enable/disable GPU support (Enabled by default on X86_64 Linux)         |
-   | `BTOP_GPU_INTEL_USE_LEVELZERO=true` | Use Level Zero instead of the legacy PMU backend for Intel GPUs     |
+   | `USE_LEVELZERO=true` | Use Level Zero instead of the legacy PMU backend for Intel GPUs     |
    | `RSMI_STATIC=true`              | To statically link the ROCm SMI library used for querying AMDGPU        |
    | `ADDFLAGS=<flags>`              | For appending flags to both compiler and linker                         |
    | `CXX=<compiler>`                | Manually set which compiler to use                                       |
@@ -621,7 +621,7 @@ See [GPU compatibility](#gpu-compatibility) section for more about compiling wit
    | `-DBTOP_STATIC=<ON\|OFF>`       | Enables static linking (OFF by default)                                 |
    | `-DBTOP_LTO=<ON\|OFF>`          | Enables link time optimization (ON by default)                          |
    | `-DBTOP_GPU=<ON\|OFF>`          | Enable GPU support (ON by default)                                      |
-   | `-DBTOP_GPU_INTEL_USE_LEVELZERO=<ON\|OFF>` | Use Level Zero instead of the legacy Intel PMU backend (OFF by default) |
+   | `-DUSE_LEVELZERO=<ON\|OFF>` | Use Level Zero instead of the legacy Intel PMU backend (OFF by default) |
    | `-DBTOP_RSMI_STATIC=<ON\|OFF>`  | Build and link the ROCm SMI library statically (OFF by default)         |
    | `-DCMAKE_INSTALL_PREFIX=<path>` | The installation prefix ('/usr/local' by default)                       |
 

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -74,6 +74,10 @@ extern "C" {
 	#if defined(__clang__)
 		#pragma clang diagnostic pop
 	#endif // __clang__
+
+	#if defined(BTOP_GPU_INTEL_USE_LEVELZERO)
+		#include <level_zero/zes_api.h>
+	#endif
 #endif
 
 using std::abs;
@@ -293,6 +297,38 @@ namespace Gpu {
 		bool shutdown();
 		template <bool is_init> bool collect(gpu_info* gpus_slice);
 		uint32_t device_count = 0;
+
+	#if defined(BTOP_GPU_INTEL_USE_LEVELZERO)
+		//? Intel Level Zero data collection
+		namespace LevelZero {
+			struct engine_info {
+				zes_engine_handle_t handle;
+				zes_engine_group_t type;
+				zes_engine_stats_t stats;
+			};
+
+			struct memory_info {
+				zes_mem_handle_t handle;
+				uint64_t physical_size;
+				uint64_t size;
+				uint64_t free;
+			};
+
+			zes_device_handle_t device = nullptr;
+			vector<engine_info> engines;
+			vector<memory_info> memory_modules;
+			zes_pwr_handle_t power_handle = nullptr;
+			zes_power_energy_counter_t power_stats{};
+			long long power_limit = 0;
+			zes_freq_handle_t frequency_handle = nullptr;
+
+			bool initialized = false;
+			bool init();
+			bool shutdown();
+			template <bool is_init> bool collect(gpu_info* gpus_slice);
+			uint32_t device_count = 0;
+		}
+	#endif
 	}
 
 	//? AMD sysfs (consumer GPU / iGPU) data collection — fallback when amd-smi/rocm-smi
@@ -402,7 +438,11 @@ namespace Shared {
 		}
 
 		if (shown_gpus.contains("intel")) {
+		#if defined(BTOP_GPU_INTEL_USE_LEVELZERO)
+			Gpu::Intel::LevelZero::init();
+		#else
 			Gpu::Intel::init();
+		#endif
 		}
 
 		if (not Gpu::gpu_names.empty()) {
@@ -1907,6 +1947,391 @@ namespace Gpu {
 		}
 	}
 
+	#if defined(BTOP_GPU_INTEL_USE_LEVELZERO)
+	namespace Intel::LevelZero {
+		bool init() {
+			if (initialized) return false;
+
+			const auto init_result = zesInit(0);
+			if (init_result != ZE_RESULT_SUCCESS) {
+				Logger::debug("Intel GPU: zesInit failed ({})", static_cast<uint32_t>(init_result));
+				return false;
+			}
+
+			const auto enumerate_handles = []<typename handle_t>(vector<handle_t>& handles, const auto& query) {
+				handles.clear();
+
+				uint32_t count{};
+				if (query(&count, nullptr) != ZE_RESULT_SUCCESS or count == 0)
+					return false;
+
+				handles.resize(count);
+				if (query(&count, handles.data()) != ZE_RESULT_SUCCESS) {
+					handles.clear();
+					return false;
+				}
+
+				handles.resize(count);
+				return true;
+			};
+
+			vector<zes_driver_handle_t> drivers;
+			if (not enumerate_handles(drivers, [](uint32_t* count, zes_driver_handle_t* handles) {
+					return zesDriverGet(count, handles);
+				})) {
+				Logger::debug("Intel GPU: Level Zero did not report any drivers");
+				return false;
+			}
+
+			zes_device_properties_t device_properties{};
+			const auto property_string = [](const auto& value) {
+				return string(std::begin(value), std::find(std::begin(value), std::end(value), '\0'));
+			};
+			vector<zes_device_handle_t> devices;
+			for (const auto driver : drivers) {
+				enumerate_handles(devices, [driver](uint32_t* count, zes_device_handle_t* handles) {
+					return zesDeviceGet(driver, count, handles);
+				});
+				for (const auto candidate : devices) {
+					zes_device_properties_t properties{};
+					properties.stype = ZES_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+					properties.core.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+					const auto properties_result = zesDeviceGetProperties(candidate, &properties);
+					if (properties_result != ZE_RESULT_SUCCESS) {
+						Logger::debug("Intel GPU Level Zero API: zesDeviceGetProperties failed ({})",
+							static_cast<uint32_t>(properties_result));
+						continue;
+					}
+
+					if (properties.core.type == ZE_DEVICE_TYPE_GPU
+						and properties.core.vendorId == 0x8086) {
+						device = candidate;
+						device_properties = properties;
+						break;
+					}
+				}
+				if (device != nullptr) break;
+			}
+			if (device == nullptr) {
+				Logger::debug("Intel GPU: Level Zero did not report an Intel GPU");
+				return false;
+			}
+
+			vector<zes_engine_handle_t> engine_handles;
+			enumerate_handles(engine_handles, [](uint32_t* count, zes_engine_handle_t* handles) {
+				return zesDeviceEnumEngineGroups(device, count, handles);
+			});
+			for (const auto handle : engine_handles) {
+				zes_engine_properties_t properties{};
+				properties.stype = ZES_STRUCTURE_TYPE_ENGINE_PROPERTIES;
+				const auto properties_result = zesEngineGetProperties(handle, &properties);
+				zes_engine_stats_t stats{};
+				const auto activity_result = zesEngineGetActivity(handle, &stats);
+				if (properties_result == ZE_RESULT_SUCCESS
+					and activity_result == ZE_RESULT_SUCCESS) {
+					engines.push_back({handle, properties.type, stats});
+				}
+			}
+
+			vector<zes_mem_handle_t> memory_handles;
+			enumerate_handles(memory_handles, [](uint32_t* count, zes_mem_handle_t* handles) {
+				return zesDeviceEnumMemoryModules(device, count, handles);
+			});
+			for (const auto handle : memory_handles) {
+				zes_mem_properties_t properties{};
+				properties.stype = ZES_STRUCTURE_TYPE_MEM_PROPERTIES;
+				zesMemoryGetProperties(handle, &properties);
+
+				zes_mem_state_t state{};
+				state.stype = ZES_STRUCTURE_TYPE_MEM_STATE;
+				const auto state_result = zesMemoryGetState(handle, &state);
+				const uint64_t total = state.size > 0 ? state.size : properties.physicalSize;
+
+				if (state_result == ZE_RESULT_SUCCESS and total > 0) {
+					memory_modules.push_back({
+						handle,
+						properties.physicalSize,
+						total,
+						min(state.free, total)
+					});
+				}
+			}
+
+			vector<zes_pwr_handle_t> power_handles;
+			enumerate_handles(power_handles, [](uint32_t* count, zes_pwr_handle_t* handles) {
+				return zesDeviceEnumPowerDomains(device, count, handles);
+			});
+			for (const auto handle : power_handles) {
+				zes_power_energy_counter_t stats{};
+				if (zesPowerGetEnergyCounter(handle, &stats) == ZE_RESULT_SUCCESS) {
+					zes_power_properties_t properties{};
+					properties.stype = ZES_STRUCTURE_TYPE_POWER_PROPERTIES;
+					const auto properties_result = zesPowerGetProperties(handle, &properties);
+
+					zes_power_sustained_limit_t sustained{};
+					const auto limits_result = zesPowerGetLimits(handle, &sustained, nullptr, nullptr);
+					if (limits_result == ZE_RESULT_SUCCESS and sustained.power > 0)
+						power_limit = sustained.power;
+					else if (properties_result == ZE_RESULT_SUCCESS and properties.defaultLimit > 0)
+						power_limit = properties.defaultLimit;
+
+					power_handle = handle;
+					power_stats = stats;
+					break;
+				}
+			}
+
+			vector<zes_freq_handle_t> frequency_handles;
+			enumerate_handles(frequency_handles, [](uint32_t* count, zes_freq_handle_t* handles) {
+				return zesDeviceEnumFrequencyDomains(device, count, handles);
+			});
+			for (const auto handle : frequency_handles) {
+				zes_freq_properties_t properties{};
+				properties.stype = ZES_STRUCTURE_TYPE_FREQ_PROPERTIES;
+				if (zesFrequencyGetProperties(handle, &properties) == ZE_RESULT_SUCCESS
+					and properties.type == ZES_FREQ_DOMAIN_GPU) {
+					frequency_handle = handle;
+					break;
+				}
+			}
+
+			if (engines.empty() and memory_modules.empty()
+				and power_handle == nullptr and frequency_handle == nullptr) {
+				Logger::debug("Intel GPU: Level Zero Sysman telemetry is unavailable");
+				device = nullptr;
+				return false;
+			}
+
+			device_count = 1;
+			gpus.resize(gpus.size() + device_count);
+			gpu_names.resize(gpus.size());
+			const auto gpu_index = Nvml::device_count + Rsmi::device_count + Asysfs::device_count;
+			const string core_name = property_string(device_properties.core.name);
+			const string model_name = property_string(device_properties.modelName);
+			const auto usable_name = [](const string& name) {
+				return not name.empty() and name != "unknown"
+					and name != "Unknown" and name != "(unknown)";
+			};
+
+			if (usable_name(model_name))
+				gpu_names[gpu_index] = model_name;
+			else if (usable_name(core_name))
+				gpu_names[gpu_index] = core_name;
+			else
+				gpu_names[gpu_index] = fmt::format("Intel GPU [0x{:04x}]", device_properties.core.deviceId);
+
+			uint64_t total_memory = 0;
+			for (const auto& memory : memory_modules)
+				total_memory += memory.size;
+
+			Logger::info(
+				"Intel GPU Level Zero initialized: core.name=\"{}\", modelName=\"{}\", "
+				"displayName=\"{}\", brandName=\"{}\", vendorName=\"{}\", "
+				"driverVersion=\"{}\", serialNumber=\"{}\", boardNumber=\"{}\", "
+				"vendorId=0x{:04x}, deviceId=0x{:04x}, integrated={}, "
+				"engines={}/{}, memoryModules={}/{}, memoryTotal={} bytes, "
+				"powerAvailable={}, powerLimit={}mW, frequencyAvailable={}",
+				core_name,
+				model_name,
+				gpu_names[gpu_index],
+				property_string(device_properties.brandName),
+				property_string(device_properties.vendorName),
+				property_string(device_properties.driverVersion),
+				property_string(device_properties.serialNumber),
+				property_string(device_properties.boardNumber),
+				device_properties.core.vendorId,
+				device_properties.core.deviceId,
+				(device_properties.core.flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED) != 0,
+				engines.size(),
+				engine_handles.size(),
+				memory_modules.size(),
+				memory_handles.size(),
+				total_memory,
+				power_handle != nullptr,
+				power_limit,
+				frequency_handle != nullptr);
+
+			initialized = true;
+			Intel::LevelZero::collect<1>(gpus.data() + gpu_index);
+
+			return true;
+		}
+
+		bool shutdown() {
+			if (!initialized) return false;
+			engines.clear();
+			memory_modules.clear();
+			power_handle = nullptr;
+			power_limit = 0;
+			frequency_handle = nullptr;
+			device = nullptr;
+			device_count = 0;
+			initialized = false;
+			return true;
+		}
+
+		template <bool is_init> bool collect(gpu_info* gpus_slice) {
+			if (!initialized) return false;
+
+			if constexpr(is_init) {
+				gpus_slice->supported_functions = {
+					.gpu_utilization = not engines.empty(),
+					.mem_utilization = false,
+					.gpu_clock = frequency_handle != nullptr,
+					.mem_clock = false,
+					.pwr_usage = power_handle != nullptr,
+					.pwr_state = false,
+					.temp_info = false,
+					.mem_total = not memory_modules.empty(),
+					.mem_used = not memory_modules.empty(),
+					.pcie_txrx = false,
+					.encoder_utilization = false,
+					.decoder_utilization = false
+				};
+
+				gpus_slice->gpu_clock_speed = 0;
+				gpus_slice->pwr_usage = 0;
+				if (power_limit > 0)
+					gpus_slice->pwr_max_usage = power_limit;
+				if (power_handle != nullptr)
+					gpu_pwr_total_max += gpus_slice->pwr_max_usage;
+			}
+
+			if (not engines.empty()) {
+				struct engine_sample {
+					zes_engine_group_t type;
+					double utilization;
+				};
+				vector<engine_sample> samples;
+				samples.reserve(engines.size());
+
+				for (auto& engine : engines) {
+					zes_engine_stats_t current{};
+					if (zesEngineGetActivity(engine.handle, &current) != ZE_RESULT_SUCCESS) continue;
+
+					if (current.timestamp > engine.stats.timestamp
+						and current.activeTime >= engine.stats.activeTime) {
+						const double active = current.activeTime - engine.stats.activeTime;
+						const double elapsed = current.timestamp - engine.stats.timestamp;
+						samples.push_back({
+							engine.type,
+							clamp(active * 100.0 / elapsed, 0.0, 100.0)
+						});
+						engine.stats = current;
+					} else if (current.timestamp < engine.stats.timestamp
+						or current.activeTime < engine.stats.activeTime) {
+						//? Counter reset: establish a new baseline without emitting a false 0% sample.
+						engine.stats = current;
+					}
+				}
+
+				const auto aggregate_priority = [](const zes_engine_group_t type) {
+					switch (type) {
+						case ZES_ENGINE_GROUP_ALL: return 3;
+						case ZES_ENGINE_GROUP_RENDER_ALL: return 2;
+						case ZES_ENGINE_GROUP_COMPUTE_ALL: return 1;
+						default: return 0;
+					}
+				};
+
+				std::optional<double> selected_utilization;
+				int selected_priority = 0;
+				for (const auto& sample : samples) {
+					const int priority = aggregate_priority(sample.type);
+					if (priority > selected_priority) {
+						selected_utilization = sample.utilization;
+						selected_priority = priority;
+					}
+				}
+
+				if (not selected_utilization) {
+					double maximum = -1.0;
+					for (const auto& sample : samples) {
+						switch (sample.type) {
+							case ZES_ENGINE_GROUP_COMPUTE_SINGLE:
+							case ZES_ENGINE_GROUP_RENDER_SINGLE:
+							case ZES_ENGINE_GROUP_COPY_SINGLE:
+							case ZES_ENGINE_GROUP_MEDIA_DECODE_SINGLE:
+							case ZES_ENGINE_GROUP_MEDIA_ENCODE_SINGLE:
+							case ZES_ENGINE_GROUP_MEDIA_ENHANCEMENT_SINGLE:
+							case ZES_ENGINE_GROUP_MEDIA_CODEC_SINGLE:
+							case ZES_ENGINE_GROUP_3D_SINGLE:
+								maximum = max(maximum, sample.utilization);
+								break;
+							default:
+								break;
+						}
+					}
+					if (maximum >= 0.0) selected_utilization = maximum;
+				}
+
+				if (selected_utilization) {
+					gpus_slice->gpu_percent.at("gpu-totals").push_back(
+						(long long)round(*selected_utilization));
+				} else if constexpr(is_init) {
+					//? Seed the graph for callers that expect a value immediately after init.
+					gpus_slice->gpu_percent.at("gpu-totals").push_back(0);
+				}
+			}
+
+			if (not memory_modules.empty()) {
+				uint64_t total_memory = 0;
+				uint64_t free_memory = 0;
+				bool has_memory_sample = false;
+
+				for (auto& memory : memory_modules) {
+					zes_mem_state_t state{};
+					state.stype = ZES_STRUCTURE_TYPE_MEM_STATE;
+					if (zesMemoryGetState(memory.handle, &state) == ZE_RESULT_SUCCESS) {
+						const uint64_t module_total = state.size > 0 ? state.size : memory.physical_size;
+						if (module_total > 0) {
+							memory.size = module_total;
+							memory.free = min(state.free, module_total);
+						}
+					}
+
+					total_memory += memory.size;
+					free_memory += memory.free;
+					has_memory_sample = true;
+				}
+
+				if (has_memory_sample and total_memory > 0) {
+					gpus_slice->mem_total = static_cast<long long>(total_memory);
+					gpus_slice->mem_used = static_cast<long long>(total_memory - free_memory);
+					gpus_slice->gpu_percent.at("gpu-vram-totals").push_back(
+						clamp((long long)round((double)gpus_slice->mem_used * 100.0
+							/ (double)gpus_slice->mem_total), 0ll, 100ll));
+				}
+			}
+
+			if (power_handle != nullptr) {
+				zes_power_energy_counter_t current{};
+				if (zesPowerGetEnergyCounter(power_handle, &current) == ZE_RESULT_SUCCESS) {
+					if (current.timestamp > power_stats.timestamp and current.energy >= power_stats.energy) {
+						//? microjoules / microseconds = watts
+						const double power = (double)(current.energy - power_stats.energy)
+							/ (double)(current.timestamp - power_stats.timestamp);
+						gpus_slice->pwr_usage = (long long)round(power * 1000);
+					}
+					power_stats = current;
+				}
+				gpus_slice->gpu_percent.at("gpu-pwr-totals").push_back(
+					clamp((long long)round((double)gpus_slice->pwr_usage * 100.0
+						/ (double)gpus_slice->pwr_max_usage), 0ll, 100ll));
+			}
+
+			if (frequency_handle != nullptr) {
+				zes_freq_state_t state{};
+				state.stype = ZES_STRUCTURE_TYPE_FREQ_STATE;
+				if (zesFrequencyGetState(frequency_handle, &state) == ZE_RESULT_SUCCESS and state.actual >= 0)
+					gpus_slice->gpu_clock_speed = (unsigned int)round(state.actual);
+			}
+
+			return true;
+		}
+	}
+	#endif
+
 	namespace Intel {
 		bool init() {
 			if (initialized) return false;
@@ -2221,7 +2646,11 @@ namespace Gpu {
 		Nvml::collect<0>(gpus.data()); // raw pointer to vector data, size == Nvml::device_count
 		Rsmi::collect<0>(gpus.data() + Nvml::device_count); // size = Rsmi::device_count
 		Asysfs::collect<0>(gpus.data() + Nvml::device_count + Rsmi::device_count); // size = Asysfs::device_count
+	#if defined(BTOP_GPU_INTEL_USE_LEVELZERO)
+		Intel::LevelZero::collect<0>(gpus.data() + Nvml::device_count + Rsmi::device_count + Asysfs::device_count); // size = Intel::LevelZero::device_count
+	#else
 		Intel::collect<0>(gpus.data() + Nvml::device_count + Rsmi::device_count + Asysfs::device_count); // size = Intel::device_count
+	#endif
 
 		//* Calculate average usage
 		long long avg = 0;

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -75,7 +75,7 @@ extern "C" {
 		#pragma clang diagnostic pop
 	#endif // __clang__
 
-	#if defined(BTOP_GPU_INTEL_USE_LEVELZERO)
+	#if defined(USE_LEVELZERO)
 		#include <level_zero/zes_api.h>
 	#endif
 #endif
@@ -298,7 +298,7 @@ namespace Gpu {
 		template <bool is_init> bool collect(gpu_info* gpus_slice);
 		uint32_t device_count = 0;
 
-	#if defined(BTOP_GPU_INTEL_USE_LEVELZERO)
+	#if defined(USE_LEVELZERO)
 		//? Intel Level Zero data collection
 		namespace LevelZero {
 			struct engine_info {
@@ -438,7 +438,7 @@ namespace Shared {
 		}
 
 		if (shown_gpus.contains("intel")) {
-		#if defined(BTOP_GPU_INTEL_USE_LEVELZERO)
+		#if defined(USE_LEVELZERO)
 			Gpu::Intel::LevelZero::init();
 		#else
 			Gpu::Intel::init();
@@ -1947,7 +1947,7 @@ namespace Gpu {
 		}
 	}
 
-	#if defined(BTOP_GPU_INTEL_USE_LEVELZERO)
+	#if defined(USE_LEVELZERO)
 	namespace Intel::LevelZero {
 		bool init() {
 			if (initialized) return false;
@@ -2646,7 +2646,7 @@ namespace Gpu {
 		Nvml::collect<0>(gpus.data()); // raw pointer to vector data, size == Nvml::device_count
 		Rsmi::collect<0>(gpus.data() + Nvml::device_count); // size = Rsmi::device_count
 		Asysfs::collect<0>(gpus.data() + Nvml::device_count + Rsmi::device_count); // size = Asysfs::device_count
-	#if defined(BTOP_GPU_INTEL_USE_LEVELZERO)
+	#if defined(USE_LEVELZERO)
 		Intel::LevelZero::collect<0>(gpus.data() + Nvml::device_count + Rsmi::device_count + Asysfs::device_count); // size = Intel::LevelZero::device_count
 	#else
 		Intel::collect<0>(gpus.data() + Nvml::device_count + Rsmi::device_count + Asysfs::device_count); // size = Intel::device_count


### PR DESCRIPTION
# Motivation
I found btop cant work on newer Intel GPU (like Arc Gaming Cards B580, Xe Arch IGPU in Ultra265K). Current method of Intel's GPU info collection is out-of-dated. Every newer Intel GPU user would have levelzero lib installed if they followed the [official doc ](https://dgpu-docs.intel.com/installation-guides/installing-packages-from-the-intel-ppa.html)
# How to
After some search, i noticed that project like xpumanager use levelzero api in intel open compute runtime to monitor gpu. So i wanted to add a levelzero based backend of Intel GPU. 
In this PR, I added a namespace "Intel::LevelZero", all levelzero based method like `init()` and `collect()` was in there. Also added a macro `USE_LEVELZERO` to control the compilation-time choice bewteen legacy backend and levelzero backended.
# Problem & Risk
1. The stable version of levelzero lib needs root permission to access device data. But this problem fixed in main branch.
https://github.com/oneapi-src/level-zero/issues/434
2. Levelzero api dont support too old device like skylake. So we default set `USE_LEVELZERO=off`. It should be a experimental feature which wont crack in release version.
reference: https://github.com/intel/compute-runtime/blob/master/README.md
# Result
Before, I cant get a correct gpu info on my Arc B580,like this:
<img width="1459" height="886" alt="image" src="https://github.com/user-attachments/assets/aab1f032-26ff-4fa7-b7a9-b02a600e157a" />

It just works! On my Arc B580 GPU,  this PR works very well, VRAM, Temp, Volatile, Power could align with `xpu-smi` in XPUMANGER
```bash
sudo xpu-smi
[sudo: authenticate] 密码：
+----------------------------------------------+----------------------------+------------------------+
|            Intel XPU-SMI v2.0    Driver: 85B7CA089405934276CBAD3    Level Zero: 1.28.6             |
+----------------------------------------------+----------------------------+------------------------+
| GPU  Name                    Persistence-M   | Bus-Id            Disp.A   |   Volatile Uncorr. ECC |
| Fan              Temp  Pwr:Usage/Cap         | Memory-Usage               |   GPU-Util  Compute M. |
+----------------------------------------------+----------------------------+------------------------+
|   0  Intel(R) Arc(TM) B580   Off             | 0000:03:00.0      Off      |               Disabled |
|      Graphics                                |                            |                        |
| N/A               N/A  44W / 190W            | 285MiB / 12216MiB          |      0%        Default |
+----------------------------------------------+----------------------------+------------------------+

+-------+--------+--------+-----------------------------------+--------------------------------------+
| Processes:                                                                                         |
|   GPU      PID    Type    Process Name                                            GPU Memory Usage |
+-------+--------+--------+-----------------------------------+--------------------------------------+
|     0        1     C      /usr/lib/systemd/systemd                                         184 MiB |
|     0     2181     C      /usr/lib/systemd/systemd-logind                                  184 MiB |
|     0     5174     C      /usr/bin/gnome-shell                                             922 MiB |
|     0     6520     G      ptyxis                                                            71 MiB |
+-------+--------+--------+-----------------------------------+--------------------------------------+
```

<img width="1462" height="872" alt="截屏2026-08-01 22 14 15" src="https://github.com/user-attachments/assets/0ab8c954-a924-4f12-a738-5b3ac8b96515" />
<img width="1461" height="868" alt="截屏2026-08-01 22 14 23" src="https://github.com/user-attachments/assets/39ad1721-fb6d-47a2-b980-9093269f8d3c" />

# Next
btop dont support multiple intel gpu prof. I want to add a levelzero based support for this problem.

# AI Usage
AI generated code had been reviewed in detail by myself.

Fixes #1772 .