### PR TITLE
Fix static initialization order between Fx::reset and Fx::reset_base

### DIFF
--- a/src/btop_theme.cpp
+++ b/src/btop_theme.cpp
@@ -37,7 +37,13 @@ using namespace Tools;
 namespace fs = std::filesystem;
 
 string Term::fg, Term::bg;
-string Fx::reset = reset_base;
+
+//? Not initialized from Fx::reset_base, which is defined in another translation unit and
+//? is therefore not guaranteed to be constructed first. Reading it here is the static
+//? initialization order fiasco and crashes before main() on some toolchains. The literal is
+//? the value reset_base expands to, so this is constant initialized and ordering can't bite.
+//? Theme::setTheme() overwrites it with reset_base + the theme colors once config is loaded.
+constinit string Fx::reset = "\x1b[0m";
 
 namespace Theme {
 

--- a/src/btop_theme.cpp
+++ b/src/btop_theme.cpp
@@ -38,11 +38,6 @@ namespace fs = std::filesystem;
 
 string Term::fg, Term::bg;
 
-//? Not initialized from Fx::reset_base, which is defined in another translation unit and
-//? is therefore not guaranteed to be constructed first. Reading it here is the static
-//? initialization order fiasco and crashes before main() on some toolchains. The literal is
-//? the value reset_base expands to, so this is constant initialized and ordering can't bite.
-//? Theme::setTheme() overwrites it with reset_base + the theme colors once config is loaded.
 constinit string Fx::reset = "\x1b[0m";
 
 namespace Theme {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(libbtop_test)
 target_include_directories(libbtop_test PUBLIC ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries(libbtop_test libbtop GTest::gtest_main)
 
-add_executable(btop_test cpu_names.cpp tools.cpp)
+add_executable(btop_test cpu_names.cpp theme.cpp tools.cpp)
 target_link_libraries(btop_test libbtop_test)
 
 include(GoogleTest)

--- a/tests/theme.cpp
+++ b/tests/theme.cpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "btop_tools.hpp"
+
+//? Regression test for the static initialization order fiasco in issue #1748.
+//? Fx::reset lives in btop_theme.cpp and used to be initialized from Fx::reset_base,
+//? which is defined in btop_tools.cpp. Ordering between translation units is
+//? unspecified, so on some toolchains reset was constructed from an empty
+//? reset_base and btop crashed before main().
+TEST(theme, reset_matches_reset_base) {
+	//? Both are read here after static initialization has finished, so this only
+	//? catches a reset that was left empty or truncated, not the ordering itself.
+	EXPECT_FALSE(Fx::reset.empty());
+	EXPECT_FALSE(Fx::reset_base.empty());
+	EXPECT_EQ(Fx::reset, Fx::reset_base);
+	EXPECT_EQ(Fx::reset, Fx::e + "0m");
+}

--- a/tests/theme.cpp
+++ b/tests/theme.cpp
@@ -4,14 +4,15 @@
 
 #include "btop_tools.hpp"
 
-//? Regression test for the static initialization order fiasco in issue #1748.
-//? Fx::reset lives in btop_theme.cpp and used to be initialized from Fx::reset_base,
-//? which is defined in btop_tools.cpp. Ordering between translation units is
-//? unspecified, so on some toolchains reset was constructed from an empty
-//? reset_base and btop crashed before main().
+// Regression test for the static initialization order issue described in
+// https://github.com/aristocratos/btop/issues/1748.
+// Fx::reset lives in btop_theme.cpp and used to be initialized from Fx::reset_base,
+// which is defined in btop_tools.cpp. Ordering between translation units is
+// unspecified, so on some toolchains reset was constructed from an empty
+// reset_base and btop crashed before main().
 TEST(theme, reset_matches_reset_base) {
-	//? Both are read here after static initialization has finished, so this only
-	//? catches a reset that was left empty or truncated, not the ordering itself.
+	// Both are read here after static initialization has finished, so this only
+	// catches a reset that was left empty or truncated, not the ordering itself.
 	EXPECT_FALSE(Fx::reset.empty());
 	EXPECT_FALSE(Fx::reset_base.empty());
 	EXPECT_EQ(Fx::reset, Fx::reset_base);


### PR DESCRIPTION
[AI generated]

Fixes #1748.

## The bug

`Fx::reset` is defined in `src/btop_theme.cpp:40` and initialized from `Fx::reset_base`, which is defined in a different translation unit (`src/btop_tools.cpp:749`, declared `extern const string` in `src/btop_tools.hpp:87`). The order in which translation units run their dynamic initialization is unspecified, so `reset` can be constructed from a `reset_base` that has not been constructed yet. That is a static initialization order issue, and since it happens before `main()` it takes the whole binary down rather than degrading gracefully.

## The fix

`reset_base` is `Fx::e + "0m"`, and `Fx::e` is the fixed literal `"\x1b["`, so the initial value of `reset` is known at compile time. Initializing it from that literal makes it constant initialized, which is sequenced before any dynamic initialization and therefore cannot be affected by ordering.

I marked it `constinit` as well. It is not needed for correctness, but it makes the guarantee enforced by the compiler: if someone later changes this back to anything requiring dynamic initialization, it fails to build rather than silently reintroducing the UB.

`Theme::setTheme()` still assigns `Fx::reset = Fx::reset_base + Term::fg + Term::bg` once the config is loaded (`btop_theme.cpp:470`), so `reset` stays mutable and the runtime behaviour is unchanged. All 32 read sites are untouched.

## Verification

I could not reproduce the reporter's segfault directly: on macOS with Apple clang the main binary happens to get a benign link order, and `btop --version` runs fine both before and after. Rather than leave it at that, I pinned the invariant in a test, and in the test binary's link order the bug does reproduce on this machine.

Without the fix (`tests/theme.cpp`):

```
Expected equality of these values:
  Fx::reset
    Which is: ""
  Fx::reset_base
    Which is: "\x1B[0m"
```

`Fx::reset` is empty while `Fx::reset_base` is fully constructed — the ordering bug, observed, not inferred. With the fix, 4/4 tests pass.

I also confirmed the two initializer forms differ in kind rather than just in appearance, by asking the compiler:

```
constinit string bad = Fx::reset_base;   // error: variable does not have a constant initializer
constinit string good = "\x1b[0m";       // accepted
```

Other checks:

- Clean Debug build with clang++ (`cmake -B build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug -GNinja`): 0 errors, no new warnings in the touched files.
- `btop --version` output is byte-identical before and after, escape sequences included (`diff` over `od -c`).
- The test also fails if the literal here and `reset_base` in `btop_tools.cpp` ever drift apart — I verified that by temporarily changing `reset_base` to `e + "0;10m"` and watching the test catch it. That covers the one real cost of this approach, which is having the escape sequence written in two places.

One caveat on scope: my build was macOS, so the Linux and BSD collectors were not compiled. The change is in platform-independent code and touches one variable, but I have not built this on the reporter's Fedora + clang + mold setup.

Written with Claude Code (Claude Opus 5); I reviewed and tested everything before submitting.

