### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you are considering donating, please first consider donating to:
 
 ##### 22 March 2026
 
-Updated contributing guidlines for AI generated code:
+Updated contributing guidelines for AI generated code:
 
 * Submissions where any of the code is AI generated must be marked with [AI generated].
 
@@ -71,7 +71,7 @@ Updated contributing guidlines for AI generated code:
 
 ##### 4 December 2025
 
-Since there is a increasing amount of AI generated/assisted PR's, the following guidlines have been added to CONTRIBUTING.md:
+Since there is a increasing amount of AI generated/assisted PR's, the following guidelines have been added to CONTRIBUTING.md:
 
 * Submissions where the majority of the code is AI generated must be marked with [AI generated].
 


### PR DESCRIPTION
As the title implies; I fixed typos in the README.
guidlines -> guidelines [x2]: This was done twice so I fixed that.

Thanks!