### PR TITLE
CPU frequency per core

### DIFF
--- a/src/btop_config.cpp
+++ b/src/btop_config.cpp
@@ -58,6 +58,7 @@ const vector<string> Config::valid_boxes = {
 const vector<string> Config::temp_scales = { "celsius", "fahrenheit", "kelvin", "rankine" };
 #ifdef __linux__
 const vector<string> Config::freq_modes = { "first", "range", "lowest", "highest", "average" };
+const vector<string> Config::show_core_freq_values = { "off", "value", "graph" };
 #endif
 #ifdef GPU_SUPPORT
 const vector<string> Config::show_gpu_values = { "Auto", "On", "Off" };
@@ -190,6 +191,7 @@ namespace Config {
 		{"show_cpu_freq", 		"#* Show CPU frequency."},
 	#ifdef __linux__
 		{"freq_mode",				"#* How to calculate CPU frequency, available values: \"first\", \"range\", \"lowest\", \"highest\" and \"average\"."},
+		{"show_core_freq",		"#* Show per-core CPU frequency, available values: \"off\", \"value\", \"graph\"."},
 	#endif
 		{"clock_format", 		"#* Draw a clock at top of screen, formatting according to strftime, empty string to disable.\n"
 								"#* Special formatting: /host = hostname | /user = username | /uptime = system uptime"},
@@ -290,6 +292,7 @@ namespace Config {
 		{"temp_scale", "celsius"},
 	#ifdef __linux__
 		{"freq_mode", "first"},
+		{"show_core_freq", "off"},
 	#endif
 		{"clock_format", "%X"},
 		{"custom_cpu_name", ""},

--- a/src/btop_config.hpp
+++ b/src/btop_config.hpp
@@ -48,6 +48,7 @@ namespace Config {
 	extern const vector<string> temp_scales;
 #ifdef __linux__
 	extern const vector<string> freq_modes;
+	extern const vector<string> show_core_freq_values;
 #endif
 #ifdef GPU_SUPPORT
 	extern const  vector<string> show_gpu_values;

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -563,6 +563,22 @@ namespace Cpu {
 	vector<Draw::Graph> temp_graphs;
 	vector<Draw::Graph> gpu_temp_graphs;
 	vector<Draw::Graph> gpu_mem_graphs;
+#ifdef __linux__
+	vector<Draw::Graph> freq_graphs;
+
+	static std::pair<string, char> format_frequency(const long long kHz, bool compact) {
+		double v; char prefix;
+		if (kHz >= 1e9)      { v = (double)kHz / 1e9; prefix = 'T'; }
+		else if (kHz >= 1e6) { v = (double)kHz / 1e6; prefix = 'G'; }
+		else                 { v = (double)kHz / 1e3; prefix = 'M'; }
+		const int dec = (v < 10 ? 2 :
+		                (v < 100 ? 1 : 0));
+		if (compact)
+			return {fmt::format("{:>3.{}f}", v, std::max(0, dec - 1)), prefix};
+		else
+			return {fmt::format("{:>4.{}f}", v, dec), prefix};
+	}
+#endif
 
     string draw(
 		const cpu_info& cpu,
@@ -602,6 +618,17 @@ namespace Cpu {
 		auto& temp_scale = Config::getS("temp_scale");
 		auto cpu_bottom = Config::getB("cpu_bottom");
 		const auto safe_cpu_temp_max = cpu.temp_max <= 0 ? 90 : cpu.temp_max;
+#ifdef __linux__
+		const string& freq_grad = (Theme::gradients.contains("freq") ? "freq" : "cpu");
+		const auto& core_freq_mode = Config::getS("show_core_freq");
+		const bool show_core_freq = (core_freq_mode != "off");
+		const bool core_freq_graph = (core_freq_mode == "graph");
+		const int freq_footprint = (not show_core_freq or b_column_size == 0 ? 0
+			: 6 + (core_freq_graph and b_column_size > 1 ? 6 : 0));
+#else
+		const int freq_footprint = 0;
+#endif
+		const int core_graph_width = 5 * b_column_size + extra_width - freq_footprint;
 
 		const string& title_left = Theme::c("cpu_box") + (cpu_bottom ? Symbols::title_left_down : Symbols::title_left);
 		const string& title_right = Theme::c("cpu_box") + (cpu_bottom ? Symbols::title_right_down : Symbols::title_right);
@@ -744,10 +771,10 @@ namespace Cpu {
 					+ Theme::c("main_fg") + graph_up_field + Mv::r(1) + "▲▼" + Mv::r(1) + graph_lo_field;
 			}
 
-			if (b_column_size > 0 or extra_width > 0) {
+			if (core_graph_width > 0) {
 				core_graphs.clear();
 				for (const auto& core_data : cpu.core_percent) {
-					core_graphs.emplace_back(5 * b_column_size + extra_width, 1, "cpu", core_data, graph_symbol);
+					core_graphs.emplace_back(core_graph_width, 1, "cpu", core_data, graph_symbol);
 				}
 			}
 
@@ -760,6 +787,17 @@ namespace Cpu {
 					}
 				}
 			}
+#ifdef __linux__
+			freq_graphs.clear();
+			if (show_core_freq and core_freq_graph and b_column_size > 1) {
+				for (const auto& n : iota(0, Shared::coreCount)) {
+					const auto fmin = safeVal(cpu.min_core_freq_kHz, n);
+					const auto fmax = safeVal(cpu.max_core_freq_kHz, n);
+					freq_graphs.emplace_back(5, 1, freq_grad, safeVal(cpu.core_freq_kHz, n),
+						graph_symbol, false, false, fmax - fmin, -fmin);
+				}
+			}
+#endif
 		}
 
 		//? Draw battery if enabled and present
@@ -915,12 +953,12 @@ namespace Cpu {
 			auto enabled = is_cpu_enabled(n);
 			out += Mv::to(b_y + cy + 1, b_x + cx + 1) + Theme::c(enabled ? "main_fg" : "inactive_fg") + (Shared::coreCount < 100 ? Fx::b + 'C' + Fx::ub : "")
 				+ ljust(to_string(n), core_width);
-			if ((b_column_size > 0 or extra_width > 0) and cmp_less(n, core_graphs.size()))
-				out += Theme::c("inactive_fg") + graph_bg * (5 * b_column_size + extra_width) + Mv::l(5 * b_column_size + extra_width)
+			if (core_graph_width > 0 and cmp_less(n, core_graphs.size()))
+				out += Theme::c("inactive_fg") + graph_bg * core_graph_width + Mv::l(core_graph_width)
 					+ core_graphs.at(n)(safeVal(cpu.core_percent, n), data_same or redraw);
 
 			out += enabled ? Theme::g("cpu").at(clamp(safeVal(cpu.core_percent, n).back(), 0ll, 100ll)) : Theme::c("inactive_fg");
-			out += rjust(to_string(safeVal(cpu.core_percent, n).back()), (b_column_size < 2 ? 3 : 4)) + Theme::c(enabled ? "main_fg" : "inactive_fg") + '%';
+			out += rjust(to_string(safeVal(cpu.core_percent, n).back()), (b_column_size < 2 || core_graph_width < 0 ? 3 : 4)) + Theme::c(enabled ? "main_fg" : "inactive_fg") + '%';
 
 			if (show_temps and not hide_cores) {
 				const auto core_temps = safeVal(cpu.temp, n + 1);
@@ -948,6 +986,39 @@ namespace Cpu {
 					);
 				}
 			}
+
+#ifdef __linux__
+			if (show_core_freq and b_column_size > 0) {
+				const auto freqs = safeVal(cpu.core_freq_kHz, n);
+				if (not freqs.empty()) {
+					const auto fmin = safeVal(cpu.min_core_freq_kHz, n);
+					const auto fmax = safeVal(cpu.max_core_freq_kHz, n);
+					const auto range = (fmax > fmin ? fmax - fmin : 1);
+					const auto last_freq = freqs.back();
+					const auto freq_color = enabled
+						? Theme::g(freq_grad).at(clamp((last_freq - fmin) * 100 / range, 0ll, 100ll))
+						: Theme::c("inactive_fg");
+					if (core_freq_graph and b_column_size > 1 and cmp_less(n, freq_graphs.size())) {
+						fmt::format_to(
+							std::back_inserter(out),
+							" {}{}{}{}", Theme::c("inactive_fg"),
+							graph_bg * 5, Mv::l(5),
+							freq_graphs.at(n)(freqs, data_same or redraw)
+						);
+					}
+					const auto [freq_val, freq_prefix] =
+						format_frequency(last_freq, not hide_cores and (core_freq_graph or b_column_size < 2));
+					fmt::format_to(
+						std::back_inserter(out),
+						" {}{}{}{}",
+						freq_color,
+						freq_val,
+						Theme::c(enabled ? "main_fg" : "inactive_fg"),
+						freq_prefix
+					);
+				}
+			}
+#endif
 
 			out += Theme::c("div_line") + Symbols::v_line;
 

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -1580,7 +1580,7 @@ static int optionsMenu(const string& key) {
 					else if (option == "base_10_bitrate") {
 						recollect = true;
 					}
-					else if (is_in(option, "proc_sorting", "cpu_sensor", "show_gpu_info") or option.starts_with("graph_symbol") or option.starts_with("cpu_graph_"))
+					else if (is_in(option, "proc_sorting", "cpu_sensor", "show_gpu_info", "show_core_freq") or option.starts_with("graph_symbol") or option.starts_with("cpu_graph_"))
 						screen_redraw = true;
 					else if (option == "disable_presets" and optList.at(i) != "Off") {
 						atomic_wait(Runner::active);

--- a/src/btop_menu.cpp
+++ b/src/btop_menu.cpp
@@ -554,6 +554,12 @@ namespace Menu {
 				"Highest, the highest frequency.",
 				"",
 				"Average, sum and divide."},
+			{"show_core_freq",
+				"How per-core CPU frequency will be displayed.",
+				"",
+				"\"off\" = per-core frequency disabled",
+				"\"value\" = only the latest value is shown",
+				"\"graph\" = shown as a history graph"},
 		#endif
 			{"custom_cpu_name",
 				"Custom cpu model name in cpu percentage box.",
@@ -1318,6 +1324,7 @@ static int optionsMenu(const string& key) {
 			{"temp_scale", std::cref(Config::temp_scales)},
 		#ifdef __linux__
 			{"freq_mode", std::cref(Config::freq_modes)},
+			{"show_core_freq", std::cref(Config::show_core_freq_values)},
 		#endif
 			{"proc_sorting", std::cref(Proc::sort_vector)},
 			{"graph_symbol", std::cref(Config::valid_graph_symbols)},

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -231,6 +231,9 @@ namespace Cpu {
 		};
 		vector<deque<long long>> core_percent;
 		vector<deque<long long>> temp;
+		vector<deque<long long>> core_freq_kHz;
+		vector<long long> min_core_freq_kHz;
+		vector<long long> max_core_freq_kHz;
 		long long temp_max = 0;
 		array<double, 3> load_avg;
 		float usage_watts = 0;

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -142,7 +142,6 @@ struct join_thread
 namespace Cpu {
 	vector<long long> core_old_totals;
 	vector<long long> core_old_idles;
-	vector<fs::path> core_freq;
 	vector<string> available_fields = {"Auto", "total"};
 	vector<string> available_sensors = {"Auto"};
 	cpu_info current_cpu;
@@ -169,6 +168,74 @@ namespace Cpu {
 	string cpu_sensor;
 	vector<string> core_sensors;
 	std::unordered_map<int, int> core_mapping;
+
+	struct CoreFrequency {
+		long long kHz;
+		long long default_kHz;
+		fs::path path;
+		int fail_count = 0;
+
+		CoreFrequency(fs::path path, long long default_kHz = 0) :
+			kHz(default_kHz),
+			default_kHz(default_kHz),
+			path(path)
+		{
+			if (not fs::exists(this->path) or access(this->path.c_str(), R_OK) == -1)
+				this->path.clear();
+		}
+
+		bool reading_failed() {
+			return this->fail_count >= 2 || this->path.empty();
+		}
+
+		double MHz() { return (double)this->kHz / 1000; }
+
+		void try_update() {
+			if (this->reading_failed())
+				return;
+
+			try {
+				long long new_kHz = stoll(readfile(this->path, "0"));
+				if (new_kHz >= 0) {
+					this->kHz = new_kHz;
+				} else {
+					this->kHz = this->default_kHz;
+					this->fail_count++;
+					Logger::warning("CoreFrequency::try_update() : Invalid frequency value {} [kHz] in {}", new_kHz, this->path);
+				}
+			} catch (const std::exception& e) {
+				this->kHz = this->default_kHz;
+				this->fail_count++;
+				Logger::warning("CoreFrequency::try_update() : {}", e.what());
+			}
+		}
+	};
+
+	struct CorePolicy {
+		fs::path policy_path;
+		CoreFrequency cur_freq;
+		CoreFrequency min_freq;
+		CoreFrequency max_freq;
+
+		CorePolicy(int cpu_index) :
+			// "/sys/devices/system/cpu/cpuX/cpufreq/*" specified in https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-system-cpu
+			policy_path("/sys/devices/system/cpu/cpu" + to_string(cpu_index) + "/cpufreq/"),
+			cur_freq(CoreFrequency(policy_path / "scaling_cur_freq")),
+			min_freq(CoreFrequency(policy_path / "scaling_min_freq")),
+			max_freq(CoreFrequency(policy_path / "scaling_max_freq", 10000))
+		{}
+
+		void try_update() {
+			this->cur_freq.try_update();
+			if (Config::getS("show_core_freq") != Config::show_core_freq_values[0])
+			{
+				this->min_freq.try_update();
+				this->max_freq.try_update();
+			}
+		}
+	};
+
+	vector<CorePolicy> core_policies;
 }
 
 #if defined(GPU_SUPPORT)
@@ -365,14 +432,14 @@ namespace Shared {
 		//? Init for namespace Cpu
 		Cpu::current_cpu.core_percent.insert(Cpu::current_cpu.core_percent.begin(), Shared::coreCount, {});
 		Cpu::current_cpu.temp.insert(Cpu::current_cpu.temp.begin(), Shared::coreCount + 1, {});
+		Cpu::current_cpu.core_freq_kHz.insert(Cpu::current_cpu.core_freq_kHz.begin(), Shared::coreCount, {});
+		Cpu::current_cpu.min_core_freq_kHz.insert(Cpu::current_cpu.min_core_freq_kHz.begin(), Shared::coreCount, 0);
+		Cpu::current_cpu.max_core_freq_kHz.insert(Cpu::current_cpu.max_core_freq_kHz.begin(), Shared::coreCount, 9'999'999);
 		Cpu::core_old_totals.insert(Cpu::core_old_totals.begin(), Shared::coreCount, 0);
 		Cpu::core_old_idles.insert(Cpu::core_old_idles.begin(), Shared::coreCount, 0);
 
 		for (int i = 0; i < Shared::coreCount; ++i) {
-			Cpu::core_freq.push_back("/sys/devices/system/cpu/cpufreq/policy" + to_string(i) + "/scaling_cur_freq");
-			if (not fs::exists(Cpu::core_freq.back()) or access(Cpu::core_freq.back().c_str(), R_OK) == -1) {
-				Cpu::core_freq.pop_back();
-			}
+			Cpu::core_policies.push_back(Cpu::CorePolicy(i));
 		}
 
 		Cpu::collect();
@@ -680,21 +747,27 @@ namespace Cpu {
 			double hz = 0.0;
 			// Read frequencies from all CPU cores
 			vector<double> frequencies;
-			for (auto it = Cpu::core_freq.begin(); it != Cpu::core_freq.end(); ) {
-    			if (it->empty()) {
-        			it = Cpu::core_freq.erase(it);
-        			continue;
-    			}
+			for (auto it = Cpu::core_policies.begin(); it != Cpu::core_policies.end(); it++) {
+				it->try_update();
 
-    			double core_hz = stod(readfile(*it, "0.0")) / 1000;
-    			if (core_hz <= 0.0 and ++failed >= 2) {
-        			it = Cpu::core_freq.erase(it);
-    			} else {
-        			frequencies.push_back(core_hz);
-        			if (freq_mode == "first") break;
-        			++it;
-    			}
- 			}
+				if (not it->cur_freq.reading_failed())
+					frequencies.push_back(it->cur_freq.MHz());
+			}
+
+			// Record per-core frequencies
+			if (Config::getS("show_core_freq") != Config::show_core_freq_values[0])
+			{
+				const size_t max_cores = std::min(Cpu::current_cpu.core_freq_kHz.size(), Cpu::core_policies.size());
+				for (size_t i = 0; i < max_cores; i++) {
+					const CorePolicy& core_policy = Cpu::core_policies.at(i);
+					Cpu::current_cpu.min_core_freq_kHz[i] = core_policy.min_freq.kHz;
+					Cpu::current_cpu.max_core_freq_kHz[i] = core_policy.max_freq.kHz;
+
+					deque<long long>& core_freq_kHz = Cpu::current_cpu.core_freq_kHz.at(i);
+					core_freq_kHz.push_back(core_policy.cur_freq.kHz);
+					if (core_freq_kHz.size() > 20) core_freq_kHz.pop_front();
+				}
+			}
 
 			if (not frequencies.empty()) {
 				if (freq_mode == "first") {
@@ -720,6 +793,7 @@ namespace Cpu {
 					return min_str + " - " + max_str;
 				}
 			}
+
 			//? If freq from /sys failed or is missing try to use /proc/cpuinfo
 			if (hz <= 0.0) {
 				ifstream cpufreq(Shared::procPath / "cpuinfo");
@@ -1219,10 +1293,17 @@ namespace Cpu {
 
 			//? Notify main thread to redraw screen if we found more cores than previously detected
 			if (cmp_greater(cpu.core_percent.size(), Shared::coreCount)) {
+				const int prev_core_count = Shared::coreCount;
 				Logger::debug("Changing CPU max corecount from {} to {}.", Shared::coreCount, cpu.core_percent.size());
 				Runner::coreNum_reset = true;
 				Shared::coreCount = cpu.core_percent.size();
 				while (cmp_less(current_cpu.temp.size(), cpu.core_percent.size() + 1)) current_cpu.temp.push_back({0});
+				while (cmp_less(current_cpu.core_freq_kHz.size(), Shared::coreCount)) current_cpu.core_freq_kHz.push_back({0});
+				while (cmp_less(current_cpu.min_core_freq_kHz.size(), Shared::coreCount)) current_cpu.min_core_freq_kHz.push_back(0);
+				while (cmp_less(current_cpu.max_core_freq_kHz.size(), Shared::coreCount)) current_cpu.max_core_freq_kHz.push_back(9'999'999);
+				for (int i = prev_core_count; i < Shared::coreCount; i++) {
+					Cpu::core_policies.push_back(Cpu::CorePolicy(i));
+				}
 			}
 
 		}


### PR DESCRIPTION
Implements https://github.com/aristocratos/btop/issues/190 as either a graph (similar to per-core temps) or a single value.

Linux-only - but someone who can test on other platforms can add support for their platform by:
- implementing per-core frequency collection into `core_freq_kHz`/`min_core_freq_kHz`/`max_core_freq_kHz` in the `cpu_info` struct, and
- changing the compile-time guards for options and drawing.

CPU frequency is now read from '/sys/devices/system/cpu/cpuX/cpufreq/', instead of '/sys/devices/system/cpu/cpufreq/policyY', which should be the correct behavior (as per the [kernel docs](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-system-cpu
)). I made this change here (and not a separate PR), because the CPU frequency collection needs to be changed to support per-core frequency collection. Note that this should have also prevented the crash described in https://github.com/aristocratos/btop/issues/1288 - on some architectures (like ARM), there aren't per-core policies, in which case 'cpuX/cpufreq/' still works, as they are symlinks to that core's policy, e.g.:
- 'cpu1/cpufreq/' -> 'cpufreq/policy1' 
- 'cpu2/cpufreq/' -> 'cpufreq/policy1' 
- ...

### Possible future improvements
- Per-core temps (and even per-core usage, actually) could have similar off/value/graph configuration options (I would personally prefer core usage graph + core temp value + core frequency graph). But this change turned out to be more difficult than expected (see next point), so I decided this would be out of scope for now.
- The `Cpu::draw` function in `btop_draw` is a bit of a mess, I found it very hard to understand and extend. For example, the (confusingly named) `b_column_size` variable seems to have the intention of indicating the number of per-core columns that would fit into the current terminal size, but there's still an `extra_width` hack on top of that for the core temp support. It should probably be rewritten with support for multiple dynamically added columns in mind... I resisted doing a major refactor to actually finish this, but the `btop_draw` implementation definitely could be better/less hacky.
- The kernel docs do not specify gapless sequential numbering for the cpu cores - so in some obscure systems, where this is not the case, enumerating '/sys/devices/system/cpu/cpuX/cpufreq/' over X in the range [0, CoreCount) will miss some cores and parsing '/sys/devices/system/cpu/present' (or 'cpu/online'?) may be required.

### Without per-core temps:
<img width="458" height="211" alt="image" src="https://github.com/user-attachments/assets/524d219d-5726-489e-84b9-9af92ca4a440" />
<img width="455" height="208" alt="image" src="https://github.com/user-attachments/assets/e32168fb-b42f-4d0d-a10c-9c7e9ea8472d" />
<br/>
<img width="707" height="102" alt="image" src="https://github.com/user-attachments/assets/73d6edd3-2435-469e-a400-137e0f40c0d6" />

### With per-core temps:
<img width="455" height="208" alt="image" src="https://github.com/user-attachments/assets/c823fd00-fa13-4dad-9c6b-d29ae83bb201" />

If "graph" mode is selected, then the core utilization graph is hidden to make space for the frequency graph:
<img width="456" height="209" alt="image" src="https://github.com/user-attachments/assets/6ef822af-ad2a-4c02-850c-5bf2be39bb34" />

<img width="710" height="102" alt="image" src="https://github.com/user-attachments/assets/cb03c7f5-6668-42e0-bac5-69c5e0099334" />

### Config
<img width="546" height="606" alt="image" src="https://github.com/user-attachments/assets/2aedb488-0ef5-43b2-82f7-29106b1b7410" />

