### PR TITLE
Unify CPU frequency formatting across platforms

### DIFF
--- a/src/btop_tools.cpp
+++ b/src/btop_tools.cpp
@@ -416,6 +416,27 @@ namespace Tools {
 		return out;
 	}
 
+	string format_frequency_mhz(double mhz) {
+		if (not std::isfinite(mhz) or mhz <= 0) return "";
+		string str;
+		if (mhz > 999'999) {
+			str = fmt::format("{:.1f}", mhz / 1'000'000);
+			str.resize(3);
+			if (str.back() == '.') str.pop_back();
+			str += " THz";
+		}
+		else if (mhz > 999) {
+			str = fmt::format("{:.1f}", mhz / 1'000);
+			str.resize(3);
+			if (str.back() == '.') str.pop_back();
+			str += " GHz";
+		}
+		else {
+			str = fmt::format("{:.0f} MHz", mhz);
+		}
+		return str;
+	}
+
 	string floating_humanizer(uint64_t value, bool shorten, size_t start, bool bit, bool per_second) {
 		string out;
 		const size_t mult = (bit) ? 8 : 1;

--- a/src/btop_tools.hpp
+++ b/src/btop_tools.hpp
@@ -321,6 +321,9 @@ namespace Tools {
 	//* Convert seconds to format "<days>d <hours>:<minutes>:<seconds>" and return string
 	string sec_to_dhms(size_t seconds, bool no_days = false, bool no_seconds = false);
 
+	//* Format a frequency in MHz with an appropriate unit
+	string format_frequency_mhz(double mhz);
+
 	//* Scales up in steps of 1024 to highest positive value unit and returns string with unit suffixed
 	//* bit=true or defaults to bytes
 	//* start=int to set 1024 multiplier starting unit

--- a/src/freebsd/btop_collect.cpp
+++ b/src/freebsd/btop_collect.cpp
@@ -284,7 +284,7 @@ namespace Cpu {
 		if (sysctlbyname("dev.cpu.0.freq", &freq, &size, nullptr, 0) < 0) {
 			return "";
 		}
-		return std::to_string(freq / 1000.0 ).substr(0, 3); // seems to be in MHz
+		return format_frequency_mhz(freq);
 	}
 
 	auto get_core_mapping() -> std::unordered_map<int, int> {
@@ -446,10 +446,7 @@ namespace Cpu {
 		while (cmp_greater(cpu.cpu_percent.at("total").size(), width * 2)) cpu.cpu_percent.at("total").pop_front();
 
 		if (Config::getB("show_cpu_freq")) {
-			auto hz = get_cpuHz();
-			if (hz != "") {
-				cpuHz = hz;
-			}
+			cpuHz = get_cpuHz();
 		}
 
 		if (Config::getB("check_temp") and got_sensors)

--- a/src/linux/btop_collect.cpp
+++ b/src/linux/btop_collect.cpp
@@ -646,26 +646,6 @@ namespace Cpu {
 		}
 	}
 
-	static string normalize_frequency(double hz) {
-		string str;
-		if (hz > 999999) {
-			str = fmt::format("{:.1f}", hz / 1'000'000);
-			str.resize(3);
-			if (str.back() == '.') str.pop_back();
-			str += " THz";
-		}
-		else if (hz > 999) {
-			str = fmt::format("{:.1f}", hz / 1'000);
-			str.resize(3);
-			if (str.back() == '.') str.pop_back();
-			str += " GHz";
-		}
-		else {
-			str = fmt::format("{:.0f} MHz", hz);
-		}
-		return str;
-	}
-
 	string get_cpuHz() {
 		static int failed{};
 
@@ -714,8 +694,8 @@ namespace Cpu {
 
 					// Format as range
 					string min_str, max_str;
-					min_str = normalize_frequency(*min_hz);
-					max_str = normalize_frequency(*max_hz);
+					min_str = format_frequency_mhz(*min_hz);
+					max_str = format_frequency_mhz(*max_hz);
 
 					return min_str + " - " + max_str;
 				}
@@ -742,7 +722,7 @@ namespace Cpu {
 			if (hz <= 1 or hz >= 999999999)
 				throw std::runtime_error("Failed to read /sys/devices/system/cpu/cpufreq/policy and /proc/cpuinfo.");
 
-			cpuhz = normalize_frequency(hz);
+			cpuhz = format_frequency_mhz(hz);
 
 		}
 		catch (const std::exception& e) {

--- a/src/netbsd/btop_collect.cpp
+++ b/src/netbsd/btop_collect.cpp
@@ -376,7 +376,7 @@ namespace Cpu {
 		if (sysctlbyname("hw.cpuspeed", &freq, &size, nullptr, 0) < 0) {
 			return "";
 		}
-		return std::to_string(freq / 1000.0 ).substr(0, 3); // seems to be in MHz
+		return format_frequency_mhz(freq);
 	}
 
 	auto get_core_mapping() -> std::unordered_map<int, int> {
@@ -609,10 +609,7 @@ namespace Cpu {
 		while (cmp_greater(cpu.cpu_percent.at("total").size(), width * 2)) cpu.cpu_percent.at("total").pop_front();
 
 		if (Config::getB("show_cpu_freq")) {
-			auto hz = get_cpuHz();
-			if (hz != "") {
-				cpuHz = hz;
-			}
+			cpuHz = get_cpuHz();
 		}
 
 		if (Config::getB("check_temp") and got_sensors)

--- a/src/openbsd/btop_collect.cpp
+++ b/src/openbsd/btop_collect.cpp
@@ -294,7 +294,7 @@ namespace Cpu {
 		if (sysctlbyname("hw.cpuspeed", &freq, &size, nullptr, 0) < 0) {
 			return "";
 		}
-		return std::to_string(freq / 1000.0 ).substr(0, 3); // seems to be in MHz
+		return format_frequency_mhz(freq);
 	}
 
 	auto get_core_mapping() -> std::unordered_map<int, int> {
@@ -494,10 +494,7 @@ namespace Cpu {
 		while (cmp_greater(cpu.cpu_percent.at("total").size(), width * 2)) cpu.cpu_percent.at("total").pop_front();
 
 		if (Config::getB("show_cpu_freq")) {
-			auto hz = get_cpuHz();
-			if (hz != "") {
-				cpuHz = hz;
-			}
+			cpuHz = get_cpuHz();
 		}
 
 		if (Config::getB("check_temp") and got_sensors)

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -901,7 +901,7 @@ namespace Cpu {
 			// this fails on Apple Silicon macs. Apparently you're not allowed to know
 			return "";
 		}
-		return std::to_string(freq / 1000.0 / 1000.0 / 1000.0).substr(0, 3);
+		return format_frequency_mhz(static_cast<double>(freq) / 1'000'000);
 	}
 
 	auto get_core_mapping() -> std::unordered_map<int, int> {
@@ -1100,10 +1100,7 @@ namespace Cpu {
 		while (cmp_greater(cpu.cpu_percent.at("total").size(), width * 2)) cpu.cpu_percent.at("total").pop_front();
 
 		if (Config::getB("show_cpu_freq")) {
-			auto hz = get_cpuHz();
-			if (hz != "") {
-				cpuHz = hz;
-			}
+			cpuHz = get_cpuHz();
 		}
 
 		if (Config::getB("check_temp") and got_sensors)


### PR DESCRIPTION
Bug #1568 noticed that the CPU frequency unit is not displayed at all on some platforms. This change uses the Linux formatter and unifies it as generic code.

I tested the code on FreeBSD, OpenBSD and Linux.