### PR TITLE
[AI generated] macOS: show battery power draw in watts and time remaining

### DIFF
--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -978,7 +978,9 @@ namespace Cpu {
 
 		uint32_t percent = -1;
 		long seconds = -1;
+		float watts = -1;
 		string status = "discharging";
+		bool on_battery = false;
 		IOPSInfo_Wrap ps_info{};
 		if (ps_info()) {
 			IOPSList_Wrap one_ps_descriptor(ps_info());
@@ -996,6 +998,8 @@ namespace Cpu {
 					if (charge) {
 						CFNumberGetValue(charge, kCFNumberSInt32Type, &percent);
 					}
+					CFStringRef power_state = (CFStringRef)CFDictionaryGetValue(one_ps, CFSTR(kIOPSPowerSourceStateKey));
+					on_battery = power_state and CFStringCompare(power_state, CFSTR(kIOPSBatteryPowerValue), 0) == kCFCompareEqualTo;
 					CFBooleanRef charging = (CFBooleanRef)CFDictionaryGetValue(one_ps, CFSTR(kIOPSIsChargingKey));
 					if (charging) {
 						bool isCharging = CFBooleanGetValue(charging);
@@ -1013,7 +1017,22 @@ namespace Cpu {
 				has_battery = false;
 			}
 		}
-		return {percent, -1, seconds, status};
+
+		//? Get power draw, only while running on battery. The SMC reports total system
+		//? power, which is what the battery is being drained at when nothing else feeds it.
+		if (on_battery) {
+			try {
+				SMCConnection smcCon;
+				const float power = smcCon.getSystemPower();
+				if (std::isfinite(power) and power >= 0.0f) {
+					watts = power;
+				}
+			} catch (std::runtime_error &e) {
+				Logger::debug("SMC system power unavailable: {}", e.what());
+			}
+		}
+
+		return {percent, watts, seconds, status};
 	}
 
 	auto collect(bool no_update) -> cpu_info & {

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -973,6 +973,40 @@ namespace Cpu {
 		~IOPSList_Wrap() { CFRelease(data); }
 	};
 
+	//? Read power draw from the battery's own gauge. Unlike the SMC this also works on
+	//? Intel Macs and while charging, but AppleSmartBatteryManager only refreshes it
+	//? about once a minute, so it is used as a fallback rather than the primary source.
+	auto get_battery_watts_iokit() -> float {
+		//? matching dictionary ownership is consumed by IOServiceGetMatchingService
+		IORef battery(IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("AppleSmartBattery")));
+		if (not battery.get()) return -1;
+
+		CFMutableDictionaryRef props_raw = nullptr;
+		if (IORegistryEntryCreateCFProperties(battery, &props_raw, kCFAllocatorDefault, 0) != kIOReturnSuccess or not props_raw)
+			return -1;
+		CFRef<CFMutableDictionaryRef> props(props_raw);
+
+		CFNumberRef amperage_ref = (CFNumberRef)CFDictionaryGetValue(props, CFSTR("InstantAmperage"));
+		if (not amperage_ref) amperage_ref = (CFNumberRef)CFDictionaryGetValue(props, CFSTR("Amperage"));
+		CFNumberRef voltage_ref = (CFNumberRef)CFDictionaryGetValue(props, CFSTR("Voltage"));
+		if (not amperage_ref or not voltage_ref) return -1;
+
+		long long amperage = 0, voltage = 0;
+		CFNumberGetValue(amperage_ref, kCFNumberLongLongType, &amperage);
+		CFNumberGetValue(voltage_ref, kCFNumberLongLongType, &voltage);
+
+		//? mA * mV gives uW. The sign of the current only says which way the charge is
+		//? flowing, and the drawing code has the charging status already.
+		const double watts = std::abs(static_cast<double>(amperage) * static_cast<double>(voltage)) / 1'000'000.0;
+
+		//? rdar://15394253 has the gauge sign extending the current to 16 bits instead of
+		//? 64, which turns a small drain into a reading of around 65000 mA. Nothing with a
+		//? laptop battery draws hundreds of watts, so discard rather than display that.
+		if (watts > 200.0) return -1;
+
+		return static_cast<float>(watts);
+	}
+
 	auto get_battery() -> tuple<int, float, long, string> {
 		if (not has_battery) return {0, 0, 0, ""};
 
@@ -1023,8 +1057,10 @@ namespace Cpu {
 			}
 		}
 
-		//? Get power draw, only while running on battery. The SMC reports total system
-		//? power, which is what the battery is being drained at when nothing else feeds it.
+		//? Get power draw. Prefer the SMC while running on battery: it reports total system
+		//? power, which is what the battery is being drained at when nothing else feeds the
+		//? machine, and it updates every refresh. On AC, or where the SMC key is missing,
+		//? fall back to the battery gauge.
 		if (on_battery) {
 			try {
 				SMCConnection smcCon;
@@ -1035,6 +1071,9 @@ namespace Cpu {
 			} catch (std::runtime_error &e) {
 				Logger::debug("SMC system power unavailable: {}", e.what());
 			}
+		}
+		if (watts < 0) {
+			watts = get_battery_watts_iokit();
 		}
 
 		return {percent, watts, seconds, status};

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -988,12 +988,6 @@ namespace Cpu {
 				if (CFArrayGetCount(one_ps_descriptor())) {
 					CFDictionaryRef one_ps = IOPSGetPowerSourceDescription(ps_info(), CFArrayGetValueAtIndex(one_ps_descriptor(), 0));
 					has_battery = true;
-					CFNumberRef remaining = (CFNumberRef)CFDictionaryGetValue(one_ps, CFSTR(kIOPSTimeToEmptyKey));
-					int32_t estimatedMinutesRemaining;
-					if (remaining) {
-						CFNumberGetValue(remaining, kCFNumberSInt32Type, &estimatedMinutesRemaining);
-						seconds = estimatedMinutesRemaining * 60;
-					}
 					CFNumberRef charge = (CFNumberRef)CFDictionaryGetValue(one_ps, CFSTR(kIOPSCurrentCapacityKey));
 					if (charge) {
 						CFNumberGetValue(charge, kCFNumberSInt32Type, &percent);
@@ -1009,6 +1003,17 @@ namespace Cpu {
 					}
 					if (percent == 100) {
 						status = "full";
+					}
+					//? macOS reports the estimate under a different key depending on which way
+					//? the battery is going, and -1 while it has not settled on one yet
+					const CFStringRef time_key = (status == "charging")
+						? CFSTR(kIOPSTimeToFullChargeKey)
+						: CFSTR(kIOPSTimeToEmptyKey);
+					CFNumberRef remaining = (CFNumberRef)CFDictionaryGetValue(one_ps, time_key);
+					if (remaining) {
+						int32_t mins;
+						CFNumberGetValue(remaining, kCFNumberSInt32Type, &mins);
+						if (mins > 0) seconds = mins * 60;
 					}
 				} else {
 					has_battery = false;

--- a/src/osx/smc.cpp
+++ b/src/osx/smc.cpp
@@ -107,6 +107,25 @@ namespace Cpu {
 		return result;
 	}
 
+	float SMCConnection::getSMCFloat(char *key) {
+		SMCVal_t val;
+		kern_return_t result = SMCReadKey(key, &val);
+		if (result == kIOReturnSuccess and val.dataSize == sizeof(float)) {
+			if (strcmp(val.dataType, DATATYPE_FLT) == 0) {
+				// the key holds a plain IEEE-754 single in host byte order
+				float value;
+				memcpy(&value, val.bytes, sizeof(value));
+				return value;
+			}
+		}
+		return -1.0f;
+	}
+
+	float SMCConnection::getSystemPower() {
+		char key[] = SMC_KEY_SYSTEM_TOTAL_POWER;
+		return getSMCFloat(key);
+	}
+
 	kern_return_t SMCConnection::SMCReadKey(UInt32Char_t key, SMCVal_t *val) {
 		kern_return_t result;
 		SMCKeyData_t inputStructure;

--- a/src/osx/smc.hpp
+++ b/src/osx/smc.hpp
@@ -42,6 +42,7 @@ tab-size = 4
 #define DATATYPE_UINT16 "ui16"
 #define DATATYPE_UINT32 "ui32"
 #define DATATYPE_SP78 "sp78"
+#define DATATYPE_FLT  "flt "
 
 // key values
 #define SMC_KEY_CPU_TEMP "TC0P" // proximity temp?
@@ -50,6 +51,7 @@ tab-size = 4
 #define SMC_KEY_CPU1_TEMP "TC1C"
 #define SMC_KEY_CPU2_TEMP "TC2C"  // etc
 #define SMC_KEY_FAN0_RPM_CUR "F0Ac"
+#define SMC_KEY_SYSTEM_TOTAL_POWER "PSTR" // total system power draw in watts, Apple Silicon only
 
 typedef struct {
 	char major;
@@ -103,10 +105,12 @@ namespace Cpu {
 		virtual ~SMCConnection();
 
 		long long getTemp(int core);
+		float getSystemPower();
 
 	   private:
 		kern_return_t SMCReadKey(UInt32Char_t key, SMCVal_t *val);
 		long long getSMCTemp(char *key);
+		float getSMCFloat(char *key);
 		kern_return_t SMCCall(int index, SMCKeyData_t *inputStructure, SMCKeyData_t *outputStructure);
 
 		io_connect_t conn;


### PR DESCRIPTION
## Why

btop already has a `show_battery_watts` option and already draws a time-remaining
estimate next to the battery indicator. Both are honoured by the Linux and BSD
collectors. On macOS neither worked:

* the watt reading was hard-coded to `-1`, so the option did nothing on a Mac
* the time estimate was always blank, and never appeared at all while charging

This brings the macOS collector up to the behaviour the other platforms already
have. No new options and no UI changes — the existing option and the existing
drawing code just get real numbers to work with.

This supersedes #1580, which I opened without having read CONTRIBUTING.md. That
was my mistake. This version is rebased on current `main`, split into reviewable
commits, marked as AI generated, and explains its reasoning.

## Relationship to #1676

#1676 also implements macOS battery wattage, by reading `InstantAmperage` and
`Voltage` from the `AppleSmartBattery` IORegistry node. **That approach is
correct, and this PR now uses it** — as a fallback, in the third commit, credited
in the commit message. If the maintainers prefer #1676, this PR's third commit is
essentially it and I'm happy for that one to land instead.

The reason it is the fallback rather than the primary source is refresh rate.
`AppleSmartBatteryManager` only repolls those properties about once a minute
([documented on the Apple developer forums](https://developer.apple.com/forums/thread/107914)),
which I confirmed by sampling both sources every 2 s on an M5:

```
   0.2s  PSTR=2.55W | AppleSmartBattery=2.73W (amp=-221 mA volt=12363 mV)
  20.2s  PSTR=4.67W | AppleSmartBattery=4.67W (amp=-378 mA volt=12349 mV)
  80.3s  PSTR=2.45W | AppleSmartBattery=2.45W (amp=-198 mA volt=12359 mV)
 140.3s  PSTR=2.12W | AppleSmartBattery=2.12W (amp=-171 mA volt=12379 mV)

gaps between AppleSmartBattery updates: 20s, 60s, 60s
```

Only the lines where the gauge changed are shown; `PSTR` moved continuously
throughout. At btop's default 2000 ms update interval the gauge alone would
display the same figure for thirty consecutive frames, which is not what a live
monitor should do. The two agree closely when sampled at the same moment, so this
is the same physical quantity at two different refresh rates, not two different
measurements.

## What

Three commits, each independently reviewable and each building on its own:

**1. `feat(osx): show battery power draw in watts`**

Reads the SMC `PSTR` key (total system power) via a new `getSMCFloat()` helper
next to the existing `getSMCTemp()`, decoding the `flt ` type.

Taken **only while the power source is the battery**, checked via
`kIOPSPowerSourceStateKey`. On battery, nothing else is feeding the machine, so
total system power is the rate the battery is draining at. On AC it is not:
measured on this M5 idling on AC, `PSTR` read **16–25 W** while only **5.07 W**
was actually moving through the battery. Showing `PSTR` there would put a number
next to the battery indicator that is several times too large.

**2. `fix(osx): show battery time remaining`**

Two separate causes for the blank estimate:

* `kIOPSTimeToEmptyKey` is `-1` whenever macOS has not settled on an estimate
  yet, which it does for a while after a wake or a power source change. That was
  being multiplied by 60 and passed on as `-60` seconds, which the drawing code
  cannot tell apart from a real reading. Only positive estimates are accepted now.
* While charging, macOS puts the estimate under `kIOPSTimeToFullChargeKey` and
  leaves `kIOPSTimeToEmptyKey` at `-1`. The key matching the current status is
  now read, so charging shows a time-to-full the way the Linux collector does.

**3. `feat(osx): fall back to the battery gauge when the SMC has no reading`**

The #1676 approach, used wherever `PSTR` can't be: on AC, while charging, and on
hardware without the key. Follows the `CFRef`/`IORef` RAII wrappers already in
this file.

One addition: readings above 200 W are discarded. rdar://15394253 has the gauge
sign-extending the current to 16 bits instead of 64, turning a small drain into a
reading of about 65000 mA — which, multiplied by voltage, renders as several
hundred watts. Nothing with a laptop battery draws that.

## Testing

Built and run on an M5 MacBook (macOS 27.0, arm64, `make`, no new warnings). Every
state was checked against `pmset -g batt` on real hardware:

| State | btop shows | `pmset` says |
|---|---|---|
| Discharging | `BAT▼ 76% ■■■■■■■■■■ 14:56 2.17W` | `76%; discharging; 14:56 remaining` |
| AC, not charging | `BAT▼ 76% ■■■■■■■■■■ 5.07W` | `76%; AC attached; not charging` |
| Charging | `BAT▲ 76% ■■■■■■■■■■ 00:53 36.52W` | `76%; charging; 0:53 remaining` |

Times match exactly in both directions. On battery the wattage updates every
refresh; on AC and while charging it comes from the gauge and steps once a
minute. The 41 W seen at the start of charging cross-checks against the gauge's
own figures (3219 mA × 12798 mV).

Each commit was built separately so the history stays bisectable.

**Not verified by me:** Intel Macs and VMs. I have no such hardware. Both take
the fallback paths — the SMC connection throwing, or `PSTR` being absent — and
land on the IORegistry gauge, which is the same code path #1676 exercises. I've
avoided asserting anything about `PSTR` availability on Intel since I can't test
it; the code doesn't depend on the answer either way.

---

> **[AI generated]** — the code and this description were written by Claude Code
> working interactively with me. Per CONTRIBUTING.md I'm flagging that up front.
> I've read the diff, I understand what each part does and why, and every number
> above was measured on my own machine rather than assumed. Ask me anything about
> it. If you'd rather not take AI-authored changes for this area at all, say so
> and I'll close it without argument — I'd rather not add noise to your queue.
