### PR TITLE
[AI generated] fix(osx): count compressed memory as used and show it as its own row

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -1262,11 +1262,14 @@ namespace Mem {
 
 			//? Mem graphs and meters
 			for (const auto& name : mem_names) {
+				if (name == "compressed" and not has_compressed) continue;
+				//? No compressed_start/_mid/_end theme colors exist, borrow the "used" gradient like the swap rows do
+				const string& gradient = (name == "compressed" ? "used"s : name);
 
 				if (use_graphs)
-					mem_graphs[name] = Draw::Graph{mem_meter, graph_height, name, safeVal(mem.percent, name), graph_symbol};
+					mem_graphs[name] = Draw::Graph{mem_meter, graph_height, gradient, safeVal(mem.percent, name), graph_symbol};
 				else
-					mem_meters[name] = Draw::Meter{mem_meter, name};
+					mem_meters[name] = Draw::Meter{mem_meter, gradient};
 			}
 			if (show_swap and has_swap) {
 				for (const auto& name : swap_names) {
@@ -1350,7 +1353,11 @@ namespace Mem {
 		bool big_mem = mem_width > 21;
 
 		out += Mv::to(y + 1, x + 2) + Theme::c("title") + Fx::b + "Total:" + rjust(floating_humanizer(totalMem), mem_width - 9) + Fx::ub + Theme::c("main_fg");
-		vector<string> comb_names (mem_names.begin(), mem_names.end());
+		vector<string> comb_names;
+		for (const auto& name : mem_names) {
+			if (name == "compressed" and not has_compressed) continue;
+			comb_names.push_back(name);
+		}
 		if (show_swap and has_swap and not swap_disk) comb_names.insert(comb_names.end(), swap_names.begin(), swap_names.end());
 		for (const auto& name : comb_names) {
 			if (cy > height - 4) break;
@@ -2461,7 +2468,8 @@ namespace Draw {
 			else
 				mem_width = width - 1;
 
-			item_height = has_swap and not swap_disk ? 6 : 4;
+			//? One row per drawn mem_name plus the swap rows when shown here
+			item_height = (has_compressed ? 5 : 4) + (has_swap and not swap_disk ? 2 : 0);
 			if (height - (has_swap and not swap_disk ? 3 : 2) > 2 * item_height)
 				mem_size = 3;
 			else if (mem_width > 25)

--- a/src/btop_shared.hpp
+++ b/src/btop_shared.hpp
@@ -266,7 +266,9 @@ namespace Mem {
 	extern string box;
 	extern int x, y, width, height, min_width, min_height;
 	extern bool has_swap, shown, redraw;
-	const array mem_names { "used"s, "available"s, "cached"s, "free"s };
+	//? Set by collectors on platforms with a compressed memory pool, "compressed" row is skipped when false
+	inline bool has_compressed = false;
+	const array mem_names { "used"s, "compressed"s, "available"s, "cached"s, "free"s };
 	const array swap_names { "swap_used"s, "swap_free"s };
 	extern int disk_ios;
 
@@ -289,10 +291,10 @@ namespace Mem {
 
 	struct mem_info {
 		std::unordered_map<string, uint64_t> stats =
-			{{"used", 0}, {"available", 0}, {"cached", 0}, {"free", 0},
+			{{"used", 0}, {"compressed", 0}, {"available", 0}, {"cached", 0}, {"free", 0},
 			{"swap_total", 0}, {"swap_used", 0}, {"swap_free", 0}};
 		std::unordered_map<string, deque<long long>> percent =
-			{{"used", {}}, {"available", {}}, {"cached", {}}, {"free", {}},
+			{{"used", {}}, {"compressed", {}}, {"available", {}}, {"cached", {}}, {"free", {}},
 			{"swap_total", {}}, {"swap_used", {}}, {"swap_free", {}}};
 		std::unordered_map<string, disk_info> disks;
 		vector<string> disks_order;

--- a/src/osx/btop_collect.cpp
+++ b/src/osx/btop_collect.cpp
@@ -1249,10 +1249,16 @@ namespace Mem {
 		vm_statistics64 p;
 		mach_msg_type_number_t info_size = HOST_VM_INFO64_COUNT;
 		if (host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t)&p, &info_size) == 0) {
+			//? Compressed pages occupy physical RAM and can't be handed out without decompressing, so they count as used
+			const uint64_t compressed = static_cast<uint64_t>(p.compressor_page_count) * Shared::pageSize;
 			mem.stats.at("free") = p.free_count * Shared::pageSize;
 			mem.stats.at("cached") = p.external_page_count * Shared::pageSize;
-			mem.stats.at("used") = (p.active_count + p.wire_count) * Shared::pageSize;
-			mem.stats.at("available") = Shared::totalMem - mem.stats.at("used");
+			mem.stats.at("compressed") = compressed;
+			mem.stats.at("used") = static_cast<uint64_t>(p.active_count + p.wire_count) * Shared::pageSize + compressed;
+			//? Saturate, page counts are sampled separately from hw.memsize so used can briefly exceed it
+			mem.stats.at("available") = (Shared::totalMem > mem.stats.at("used"))
+				? Shared::totalMem - mem.stats.at("used") : 0;
+			has_compressed = true;
 		}
 
 		int mib[2] = {CTL_VM, VM_SWAPUSAGE};


### PR DESCRIPTION
## [AI generated]

Per CONTRIBUTING.md: **the code in this PR was written by an LLM (Claude) through direct prompting**, not autocomplete. The investigation below — locating the cause, checking it against `vm_stat`, and deciding the scope — was done in that same session. Flagging it plainly so it can be judged accordingly; happy to walk through any part of it or rework the approach.

## Why

Fixes the macOS half of #845, and adds data to #291.

`Mem::collect()` in `src/osx/btop_collect.cpp` never reads `compressor_page_count`:

```cpp
mem.stats.at("used")      = (p.active_count + p.wire_count) * Shared::pageSize;
mem.stats.at("available") = Shared::totalMem - mem.stats.at("used");
```

Compressed pages occupy physical RAM. They cannot be handed to a new allocation without first being decompressed, so counting them toward `available` overstates what a process can actually get. Because `available` is derived from `used`, the error lands in both.

It is not a rounding-level discrepancy. On this machine, with btop and `vm_stat` sampled at the same instant:

| | btop before | actual |
|---|---|---|
| Available | 8.57 GiB | 0.56 GiB free |
| Compressor | not shown | 3.06 GiB, holding 15.32 GiB (5.0x) |

btop reported a comfortable 46%-used machine while it was swapping ~3.9 GB. Same symptom as #845 ("btop says 8.87 GB in use, Activity Monitor says 20.73 GB") and as @tri5m's question at the end of #291 about used memory versus system memory pressure.

## How the candidate formulas actually compare

@jhmaster2000's analysis in [#845](https://github.com/aristocratos/btop/issues/845#issuecomment-2759769309) sets out two fuller formulas. I implemented all of them and measured on one 16 GiB M1 Pro at a single instant:

| formula | used | |
|---|---|---|
| btop today (`active+wired`) | 6.57 GiB | 41% |
| **this PR** (`active+wired+compressor`) | **11.24 GiB** | 70% |
| jhmaster2000 #2 (App+Wired+Compressed) | 12.34 GiB | 77% |
| jhmaster2000 #1 (Activity Monitor) | 13.33 GiB | 83% |

A 6.8 GiB spread on a 16 GiB machine, which I think supports @aristocratos' framing in #291 that this is largely definitional.

One identity worth recording, since it confirms approach #2 is well-formed: `active + inactive + speculative == internal + external`, exactly, on every sample I took. So subtracting `purgeable + external` does cleanly reduce that sum to anonymous-only.

**This PR deliberately does not close the gap to Activity Monitor.** At 11.24 vs 13.33 GiB it is still ~2.1 GiB short, and ~1.1 GiB short of approach #2 — that difference being precisely the anonymous `inactive` pages. #291 settled that macOS drops `inactive_count` to line up with htop, and reopening that is out of scope here. This changes exactly one thing: compressed RAM stops being reported as available.

If you would rather have the fuller treatment, or the selectable methods @jhmaster2000 offered to write, this can be closed in favour of that. Two things I ran into that whoever implements it may want to weigh:

- Approach #1's `missing_pages` is a residual — it is defined as whatever fails to balance and is then added to `used` (0.15 GiB here). It will track Activity Monitor by construction, including through any future change in Apple's accounting, which makes it hard to tell a real shift from an artefact.
- Approach #1 counts `hw.memsize - hw.memsize_usable` as used (0.80 GiB here, most of the gap between the two approaches). btop draws `Total:` from `hw.memsize`, so that is memory no process can obtain being shown as in use.

Neither is a blocker, and both are inherent to matching Activity Monitor exactly — worth a deliberate decision rather than a default.

## Changes

- `used` includes the compressor; `available` saturates at 0 (page counts are sampled separately from `hw.memsize`, so `used` can briefly exceed it)
- new `compressed` row in `mem_names`, gated on `Mem::has_compressed`
- `item_height` derives from the rows actually drawn instead of a hardcoded `? 6 : 4`

Other platforms are unaffected: `has_compressed` defaults false, only the macOS collector sets it, and the row is skipped when drawing, so their four-row layout is unchanged. The map key is added to the shared initialiser so `.at("compressed")` stays valid in every collector's percent loop.

The new row borrows the `used` theme gradient, the way the swap rows borrow theirs via `name.substr(5)`. Gradients come from `<name>_start/_mid/_end` colours, so a dedicated one would mean touching every theme file.

## Testing

Apple Silicon only — M1 Pro, 16 GB, macOS 26.5.2 (25F84), built with clang++ 21. **Not tested on Intel**, and @jhmaster2000 raised the same caveat about whether this generalises there. Note #845 was originally filed against an Intel MacBook.

Verified against `vm_stat` captured at the same instant as a screen capture of the running binary; `used`, `compressed`, `available`, `cached` and `free` all agree within rounding:

| | btop after | vm_stat |
|---|---|---|
| Used | 11.50 GiB (72%) | 11.52 |
| Compressed | 4.32 GiB | 4.33 |
| Available | 4.48 GiB | 4.48 |
| Cached | 2.43 GiB | 2.43 |

Also checked the box renders correctly with `swap_disk` both on and off, since that path changes the row count.
