### PR TITLE
[AI generated] Fix Linux GPU builds with older glibc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,9 @@ endif
 
 ifeq ($(GPU_SUPPORT),true)
 	override ADDFLAGS += -DGPU_SUPPORT
+	ifeq ($(PLATFORM_LC),linux)
+		override LDFLAGS += -ldl
+	endif
 endif
 
 #? Compiler and Linker

--- a/src/linux/intel_gpu_top/intel_gpu_top.c
+++ b/src/linux/intel_gpu_top/intel_gpu_top.c
@@ -21,6 +21,10 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <assert.h>
 #include <ctype.h>
 #include <dirent.h>


### PR DESCRIPTION
Fixes #1565.

The bundled `intel_gpu_top` C source calls `asprintf`, but C compilers do not implicitly expose that GNU declaration. Linux GPU builds therefore fail with GCC 14/15 unless `_GNU_SOURCE` is enabled. The same builds also need an explicit `libdl` link when targeting glibc older than 2.34.

This defines `_GNU_SOURCE` before the system headers in the Linux-only C source and links `libdl` for Linux Makefile builds with GPU support. The CMake build already uses `CMAKE_DL_LIBS`.

Tested with conda-forge's GCC 14 Linux toolchain:

```console
pixi exec --spec gxx_linux-64=14 --spec gcc_linux-64=14 --spec make make THREADS=4 ARCH=x86_64 GPU_SUPPORT=true VERBOSE=true
```

The GPU-enabled Make build completed and `btop --version` reported `GPU_SUPPORT=true`.

```console
pixi exec --spec gxx_linux-64=14 --spec gcc_linux-64=14 --spec cmake --spec ninja cmake -S . -B build -G Ninja -DBTOP_GPU=ON -DBTOP_LTO=OFF -DCMAKE_BUILD_TYPE=Release
pixi exec --spec gxx_linux-64=14 --spec gcc_linux-64=14 --spec cmake --spec ninja cmake --build build --parallel 4
pixi exec --spec gxx_linux-64=14 --spec gcc_linux-64=14 --spec cmake --spec ninja ctest --test-dir build --output-on-failure
```

The CMake build completed and all 3 tests passed.

AI disclosure: this small patch was prepared with AI assistance and manually reviewed and tested.
